### PR TITLE
opt.:try add high refresh rate support

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_displaymode/flutter_displaymode.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:logging/logging.dart';
 import 'package:provider/provider.dart';
@@ -93,6 +94,8 @@ Future<void> _initApp() async {
     }
     // SharedPreferences is only used on Android for saving home widgets settings.
     SharedPreferences.setPrefix('');
+    // try switch to highest refresh rate
+    await FlutterDisplayMode.setHighRefreshRate();
   }
   if (isIOS || isMacOS) {
     if (Stores.setting.icloudSync.fetch()) ICloud.sync();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -335,6 +335,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_displaymode:
+    dependency: "direct main"
+    description:
+      name: flutter_displaymode
+      sha256: "42c5e9abd13d28ed74f701b60529d7f8416947e58256e6659c5550db719c57ef"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
   flutter_highlight:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,6 +65,7 @@ dependencies:
       ref: main
       url: https://github.com/lollipopkit/webdav_client
   window_manager: ^0.3.7
+  flutter_displaymode: ^0.6.0
 
 dev_dependencies:
   flutter_native_splash: ^2.1.6


### PR DESCRIPTION
On some Android devices, high refresh rates are not available. 
![1703777408442](https://github.com/lollipopkit/flutter_server_box/assets/73320008/8a3d3f51-6106-48e6-9a9c-9558c147db0e)


I was able to enable high refresh rate globally on my OnePlus 7 Pro by adding this [flutter_displaymode](https://pub.dev/packages/flutter_displaymode) module.

![1703776612394](https://github.com/lollipopkit/flutter_server_box/assets/73320008/4d45dd8f-47ab-42a6-a862-0d06bd223309)
