### PR TITLE
Update analysis checkout action version to avoid build warnning message

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable' # or: 'beta', 'dev' or 'master'


### PR DESCRIPTION
Modify checkout actions to run on Node 20 instead of Node 16.
[https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/](url)