### PR TITLE
chore: add distributionSha256Sum in gradle

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,3 +3,4 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-all.zip
+distributionSha256Sum=6001aba9b2204d26fa25a5800bb9382cf3ee01ccb78fe77317b2872336eb2f80


### PR DESCRIPTION
F-Droid suggests adding distributionSha256Sum in gradle/wrapper/gradle-wrapper.properties.
https://gitlab.com/fdroid/rfp/-/issues/2780