### PR TITLE
fix: clean up proguard-rules to remove depends on google libraries

### DIFF
--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,7 +1,1 @@
--keep class io.flutter.app.** { *; }
--keep class io.flutter.plugin.**  { *; }
--keep class io.flutter.util.**  { *; }
--keep class io.flutter.view.**  { *; }
--keep class io.flutter.**  { *; }
--keep class io.flutter.plugins.**  { *; }
 -keep class com.jcraft.**  { *; }


### PR DESCRIPTION
https://github.com/lollipopkit/flutter_server_box/issues/381#issuecomment-2161258327