### PR TITLE
Windows点进服务器详情页时若断连无法退出断联页面

### DIFF
--- a/lib/view/page/server/detail/view.dart
+++ b/lib/view/page/server/detail/view.dart
@@ -82,6 +82,7 @@ class _ServerDetailPageState extends State<ServerDetailPage>
       final s = widget.spi.server;
       if (s == null) {
         return Scaffold(
+          appBar: const CustomAppBar(),
           body: Center(
             child: Text(l10n.noClient),
           ),


### PR DESCRIPTION
Fixes #435