### PR TITLE
Added Function keys (F1-F12) to SSH virtual keyboard options

### DIFF
--- a/lib/data/model/ssh/virtual_key.dart
+++ b/lib/data/model/ssh/virtual_key.dart
@@ -75,7 +75,30 @@ enum VirtKey {
   colon,
   @HiveField(31)
   semicolon,
-  ;
+  @HiveField(32)
+  f1,
+  @HiveField(33)
+  f2,
+  @HiveField(34)
+  f3,
+  @HiveField(35)
+  f4,
+  @HiveField(36)
+  f5,
+  @HiveField(37)
+  f6,
+  @HiveField(38)
+  f7,
+  @HiveField(39)
+  f8,
+  @HiveField(40)
+  f9,
+  @HiveField(41)
+  f10,
+  @HiveField(42)
+  f11,
+  @HiveField(43)
+  f12;
 }
 
 extension VirtKeyX on VirtKey {
@@ -146,6 +169,18 @@ extension VirtKeyX on VirtKey {
         VirtKey.right => TerminalKey.arrowRight,
         VirtKey.pgup => TerminalKey.pageUp,
         VirtKey.pgdn => TerminalKey.pageDown,
+        VirtKey.f1 => TerminalKey.f1,
+        VirtKey.f2 => TerminalKey.f2,
+        VirtKey.f3 => TerminalKey.f3,
+        VirtKey.f4 => TerminalKey.f4,
+        VirtKey.f5 => TerminalKey.f5,
+        VirtKey.f6 => TerminalKey.f6,
+        VirtKey.f7 => TerminalKey.f7,
+        VirtKey.f8 => TerminalKey.f8,
+        VirtKey.f9 => TerminalKey.f9,
+        VirtKey.f10 => TerminalKey.f10,
+        VirtKey.f11 => TerminalKey.f11,
+        VirtKey.f12 => TerminalKey.f12,
         _ => null,
       };
 

--- a/lib/data/model/ssh/virtual_key.g.dart
+++ b/lib/data/model/ssh/virtual_key.g.dart
@@ -77,6 +77,30 @@ class VirtKeyAdapter extends TypeAdapter<VirtKey> {
         return VirtKey.colon;
       case 31:
         return VirtKey.semicolon;
+      case 32:
+        return VirtKey.f1;
+      case 33:
+        return VirtKey.f2;
+      case 34:
+        return VirtKey.f3;
+      case 35:
+        return VirtKey.f4;
+      case 36:
+        return VirtKey.f5;
+      case 37:
+        return VirtKey.f6;
+      case 38:
+        return VirtKey.f7;
+      case 39:
+        return VirtKey.f8;
+      case 40:
+        return VirtKey.f9;
+      case 41:
+        return VirtKey.f10;
+      case 42:
+        return VirtKey.f11;
+      case 43:
+        return VirtKey.f12;
       default:
         return VirtKey.esc;
     }
@@ -180,6 +204,42 @@ class VirtKeyAdapter extends TypeAdapter<VirtKey> {
         break;
       case VirtKey.semicolon:
         writer.writeByte(31);
+        break;
+      case VirtKey.f1:
+        writer.writeByte(32);
+        break;
+      case VirtKey.f2:
+        writer.writeByte(33);
+        break;
+      case VirtKey.f3:
+        writer.writeByte(34);
+        break;
+      case VirtKey.f4:
+        writer.writeByte(35);
+        break;
+      case VirtKey.f5:
+        writer.writeByte(36);
+        break;
+      case VirtKey.f6:
+        writer.writeByte(37);
+        break;
+      case VirtKey.f7:
+        writer.writeByte(38);
+        break;
+      case VirtKey.f8:
+        writer.writeByte(39);
+        break;
+      case VirtKey.f9:
+        writer.writeByte(40);
+        break;
+      case VirtKey.f10:
+        writer.writeByte(41);
+        break;
+      case VirtKey.f11:
+        writer.writeByte(42);
+        break;
+      case VirtKey.f12:
+        writer.writeByte(43);
         break;
     }
   }


### PR DESCRIPTION
closes #640 
This implements the Fn keys as requested by me in Issue #640. Tested on iOS and Android.