### PR TITLE
reslove issue 717 about logo url and add coreelec support

### DIFF
--- a/lib/data/model/app/shell_func.dart
+++ b/lib/data/model/app/shell_func.dart
@@ -209,7 +209,7 @@ enum StatusCmdType {
   echo._('echo ${SystemType.linuxSign}'),
   time._('date +%s'),
   net._('cat /proc/net/dev'),
-  sys._('cat /etc/*-release | grep PRETTY_NAME'),
+  sys._('cat /etc/*-release | grep ^PRETTY_NAME'),
   cpu._('cat /proc/stat | grep cpu'),
   uptime._('uptime'),
   conn._('cat /proc/net/snmp'),

--- a/lib/data/model/pkg/manager.dart
+++ b/lib/data/model/pkg/manager.dart
@@ -105,6 +105,7 @@ enum PkgManager {
         return PkgManager.apt;
       case Dist.opensuse:
         return PkgManager.zypper;
+      case Dist.coreelec:
       case Dist.wrt:
         return PkgManager.opkg;
       case Dist.arch:

--- a/lib/data/model/server/dist.dart
+++ b/lib/data/model/server/dist.dart
@@ -11,6 +11,7 @@ enum Dist {
   alpine,
   rocky,
   deepin,
+  coreelec,
   ;
 }
 

--- a/lib/view/page/server/detail/view.dart
+++ b/lib/view/page/server/detail/view.dart
@@ -161,7 +161,7 @@ class _ServerDetailPageState extends State<ServerDetailPage>
     if (logoUrl == null) return UIs.placeholder;
 
     final dist = si.status.more[StatusCmdType.sys]?.dist;
-    if (dist == null) return UIs.placeholder;
+    if (dist == null && (logoUrl.contains('{DIST}') || logoUrl.contains('{BRIGHT}')) ) return UIs.placeholder;
 
     logoUrl = logoUrl
         .replaceFirst('{DIST}', dist.name)


### PR DESCRIPTION
1. Logo url work with specific url such as https://example.com/coreelec.png
2. Add "coreelec" to distributor enumeration 

clsoe https://github.com/lollipopkit/flutter_server_box/issues/717

## Summary by Sourcery

Resolve issue 717 by fixing logo URL handling and adding support for 'coreelec' in the distributor enumeration.

New Features:
- Add support for 'coreelec' to the distributor enumeration.

Bug Fixes:
- Fix logo URL handling to work with specific URLs containing placeholders like '{DIST}' or '{BRIGHT}'.

Enhancements:
- Modify the system command to correctly parse the 'PRETTY_NAME' from system release files.