### PR TITLE
fix: code editor page popping

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -526,8 +526,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "v1.0.288"
-      resolved-ref: de2141ab5a2005a103ee098cc467fe6bda780cbc
+      ref: "v1.0.289"
+      resolved-ref: b272de58cdb0ee8d488337e7a0d00c57ee8f8a36
       url: "https://github.com/lppcg/fl_lib"
     source: git
     version: "0.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,7 +63,7 @@ dependencies:
   fl_lib:
     git:
       url: https://github.com/lppcg/fl_lib
-      ref: v1.0.288
+      ref: v1.0.289
 
 dependency_overrides:
   # webdav_client_plus:


### PR DESCRIPTION
Fixes #713

## Summary by Sourcery

Update the fl_lib dependency to pick up a patch that fixes the code editor page popping issue.

Bug Fixes:
- Fix code editor page popping.

Chores:
- Bump fl_lib git ref from v1.0.288 to v1.0.289 in pubspec.yaml and update lockfile.