### PR TITLE
fix: Android app reload on hardware keyboard change

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -23,7 +23,7 @@
             android:exported="true"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme"
-            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
+            android:configChanges="orientation|keyboardHidden|keyboard|hardKeyboardHidden|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
             android:windowSoftInputMode="adjustResize">
             <!-- Specifies an Android theme to apply to this Activity as soon as


### PR DESCRIPTION
## Summary
- prevent activity restart when connecting/disconnecting hardware keyboards

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6844dbb4477c832cbfdce4a5c9676ccf

## Summary by Sourcery

Enhancements:
- Add 'hardKeyboardHidden' to Android activity's configChanges in AndroidManifest to handle hardware keyboard changes without restarting the app.