### PR TITLE
fix: disable APK signing block to resolve F-Droid build issues

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -92,6 +92,13 @@ android {
             applicationIdSuffix '.debug'
         }
     }
+
+    dependenciesInfo {
+        // Disables dependency metadata when building APKs.
+        includeInApk = false
+        // Disables dependency metadata when building Android App Bundles.
+        includeInBundle = false
+    }
 }
 
 flutter {


### PR DESCRIPTION
Thanks for the patch from @linsui at https://github.com/lollipopkit/flutter_server_box/issues/548#issuecomment-2974238657.

## Summary by Sourcery

Build:
- Disable dependency metadata inclusion in APKs and Android App Bundles to prevent signing block issues.