### PR TITLE
opt.: watch sync mechanism

### DIFF
--- a/ios/WatchApp/PhoneConnMgr.swift
+++ b/ios/WatchApp/PhoneConnMgr.swift
@@ -14,13 +14,20 @@ class PhoneConnMgr: NSObject, WCSessionDelegate, ObservableObject {
         set {
             Store.setCtx(newValue)
             updateUrls(newValue)
+
+            // Notify the view to update, but the [urls] are already published
+            // so the view will automatically update when [urls] changes.
+            // DispatchQueue.main.async {
+            //     self.objectWillChange.send()
+            // }
         }
         get {
             return _ctx
         }
     }
+    var userInfo: [String: Any] = [:]
     @Published var urls: [String] = []
-    
+
     override init() {
         super.init()
         if !WCSession.isSupported() {
@@ -29,24 +36,62 @@ class PhoneConnMgr: NSObject, WCSessionDelegate, ObservableObject {
         session = WCSession.default
         session?.delegate = self
         session?.activate()
-        
-        ctx = Store.getCtx()
+
+        _ctx = Store.getCtx()
+        updateUrls(_ctx)
     }
- 
+
     func updateUrls(_ val: [String: Any]) {
         if let urls = val["urls"] as? [String] {
-            self.urls = urls.filter { !$0.isEmpty }
+            DispatchQueue.main.async {
+                self.urls = urls.filter { !$0.isEmpty }
+            }
         }
     }
-    
-    func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
-        
+
+    func session(
+        _ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState,
+        error: Error?
+    ) {
+        // Request latest data when the session is activated
+        if activationState == .activated {
+            requestLatestData()
+        }
     }
 
-    // implement session:didReceiveApplicationContext:
-    func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String : Any]) {
-        ctx = applicationContext
+    // Receive realtime msgs
+    func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {
+        DispatchQueue.main.async {
+            self.ctx = message
+        }
+    }
+
+    // Receive UserInfo
+    func session(_ session: WCSession, didReceiveUserInfo userInfo: [String: Any]) {
+        DispatchQueue.main.async {
+            self.ctx = userInfo
+        }
+    }
+
+    // Receive Application Context
+    func session(
+        _ session: WCSession, didReceiveApplicationContext applicationContext: [String: Any]
+    ) {
+        DispatchQueue.main.async {
+            self.ctx = applicationContext
+        }
+    }
+
+    private func requestLatestData() {
+        guard let session = session, session.isReachable else { return }
+
+        // Send a message to request the latest data
+        session.sendMessage(["action": "requestData"]) { response in
+            DispatchQueue.main.async {
+                self.ctx = response
+            }
+        } errorHandler: { error in
+            print("Request data failed: \(error)")
+        }
     }
 }
-
-

--- a/lib/view/page/setting/platform/ios.dart
+++ b/lib/view/page/setting/platform/ios.dart
@@ -114,7 +114,20 @@ class _IosSettingsPageState extends State<IosSettingsPage> {
 
     final (_, err) = await context.showLoadingDialog(
       fn: () async {
-        await wc.updateApplicationContext({'urls': result});
+        final data = {'urls': result};
+
+        // Try realtime update (app must be running foreground).
+        try {
+          if (await wc.isReachable) {
+            await wc.sendMessage(data);
+            return;
+          }
+        } catch (e) {
+          Loggers.app.warning('Failed to send message to watch', e);
+        }
+
+        // fallback
+        await wc.updateApplicationContext(data);
       },
     );
     if (err == null) {


### PR DESCRIPTION
Fixes #816

## Summary by Sourcery

Enable a real-time sync mechanism between the iOS app and Apple Watch by adding message-based communication with fallback to application context, and ensure all UI updates happen on the main thread.

New Features:
- Request the latest data from the phone when the watch session activates via a new requestLatestData method.
- Handle real-time updates in PhoneConnMgr through WCSession message, userInfo, and applicationContext callbacks.
- Add Flutter-side logic in the iOS settings page to send a real-time message if the watch is reachable, falling back to updateApplicationContext.

Enhancements:
- Run URL updates and context assignments on the main thread via DispatchQueue.main.async.
- Initialize the stored context directly in init and remove redundant objectWillChange notifications.