### PR TITLE
opt.: m3 layout breakpoints

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -82,9 +82,9 @@ class MyApp extends StatelessWidget {
       builder: (context, child) => ResponsiveBreakpoints.builder(
         child: child ?? UIs.placeholder,
         breakpoints: const [
-          Breakpoint(start: 0, end: 450, name: MOBILE),
-          Breakpoint(start: 451, end: 800, name: TABLET),
-          Breakpoint(start: 801, end: 1920, name: DESKTOP),
+          Breakpoint(start: 0, end: 600, name: MOBILE),
+          Breakpoint(start: 600, end: 1199, name: TABLET),
+          Breakpoint(start: 1199, end: 3840, name: DESKTOP),
         ],
       ),
       locale: locale,


### PR DESCRIPTION
Fixes #834

## Summary by Sourcery

Update responsive layout breakpoints to new thresholds for mobile, tablet, and desktop views

Bug Fixes:
- Fix issue #834 by adjusting layout breakpoints

Enhancements:
- Revise mobile breakpoint from 0–450 to 0–600
- Revise tablet breakpoint from 451–800 to 600–1199
- Revise desktop breakpoint from 801–1920 to 1199–3840