### PR TITLE
opt.: systemd page

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,7 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    if: github.event.pull_request.user.login == 'lollipopkit'
     
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,12 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      github.actor == 'lollipopkit' && (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/lib/core/extension/ssh_client.dart
+++ b/lib/core/extension/ssh_client.dart
@@ -132,8 +132,9 @@ extension SSHClientX on SSHClient {
         if (data.contains('[sudo] password for ')) {
           isRequestingPwd = true;
           final user = Miscs.pwdRequestWithUserReg.firstMatch(data)?.group(1);
-          if (context == null) return;
-          final pwd = context.mounted ? await context.showPwdDialog(title: user, id: id) : null;
+          final ctx = context ?? WidgetsBinding.instance.focusManager.primaryFocus?.context;
+          if (ctx == null) return;
+          final pwd = ctx.mounted ? await ctx.showPwdDialog(title: user, id: id) : null;
           if (pwd == null || pwd.isEmpty) {
             session.stdin.close();
           } else {

--- a/lib/data/model/server/systemd.dart
+++ b/lib/data/model/server/systemd.dart
@@ -1,5 +1,6 @@
 import 'package:fl_lib/fl_lib.dart';
 import 'package:flutter/material.dart';
+import 'package:server_box/core/extension/context/locale.dart';
 
 enum SystemdUnitFunc {
   start,
@@ -55,9 +56,9 @@ enum SystemdScopeFilter {
   user;
 
   String get displayName => switch (this) {
-    all => 'All',
-    system => 'System',
-    user => 'User',
+    all => libL10n.all,
+    system => l10n.system,
+    user => libL10n.user,
   };
 }
 

--- a/lib/data/model/server/systemd.dart
+++ b/lib/data/model/server/systemd.dart
@@ -49,6 +49,18 @@ enum SystemdUnitScope {
   }
 }
 
+enum SystemdScopeFilter {
+  all,
+  system,
+  user;
+
+  String get displayName => switch (this) {
+    all => 'All',
+    system => 'System',
+    user => 'User',
+  };
+}
+
 enum SystemdUnitState {
   active,
   inactive,

--- a/lib/data/provider/server.dart
+++ b/lib/data/provider/server.dart
@@ -440,7 +440,7 @@ class ServerProvider extends Provider {
 
     try {
       raw = await sv.client?.run(ShellFunc.status.exec(spi.id, systemType: sv.status.system)).string;
-      dprint('Get status from ${spi.name}:\n$raw');
+      //dprint('Get status from ${spi.name}:\n$raw');
       segments = raw?.split(ScriptConstants.separator).map((e) => e.trim()).toList();
       if (raw == null || raw.isEmpty || segments == null || segments.isEmpty) {
         if (Stores.setting.keepStatusWhenErr.fetch()) {

--- a/lib/data/provider/systemd.dart
+++ b/lib/data/provider/systemd.dart
@@ -80,8 +80,11 @@ done
     final units = result.split(ScriptConstants.separator);
 
     final parsedUnits = <SystemdUnit>[];
-    for (final unit in units.skipWhile((e) => e.trim().isEmpty)) {
-      final parts = unit.split('\n').skipWhile((e) => e.trim().isEmpty);
+    for (final unit in units.where((e) => e.trim().isNotEmpty)) {
+      final parts = unit
+          .split('\n')
+          .where((e) => e.trim().isNotEmpty)
+          .toList();
       if (parts.isEmpty) continue;
       var name = '';
       var type = '';
@@ -89,13 +92,18 @@ done
       String? description;
       for (final part in parts) {
         if (part.startsWith('Id=')) {
-          final val = _getIniVal(part).split('.');
-          name = val.first;
-          type = val.last;
+          final val = _getIniVal(part);
+          if (val == null) continue;
+          // Id=sshd.service
+          final vals = val.split('.');
+          name = vals.first;
+          type = vals.last;
           continue;
         }
         if (part.startsWith('ActiveState=')) {
-          state = _getIniVal(part);
+          final val = _getIniVal(part);
+          if (val == null) continue;
+          state = val;
           continue;
         }
         if (part.startsWith('Description=')) {
@@ -154,8 +162,8 @@ done
     ''';
 }
 
-String _getIniVal(String line) {
+String? _getIniVal(String line) {
   final idx = line.indexOf('=');
-  if (idx < 0) return line;
+  if (idx < 0) return null;
   return line.substring(idx + 1).trim();
 }

--- a/lib/data/provider/systemd.dart
+++ b/lib/data/provider/systemd.dart
@@ -16,10 +16,23 @@ final class SystemdProvider {
 
   final isBusy = false.vn;
   final units = <SystemdUnit>[].vn;
+  final scopeFilter = SystemdScopeFilter.all.vn;
 
   void dispose() {
     isBusy.dispose();
     units.dispose();
+    scopeFilter.dispose();
+  }
+
+  List<SystemdUnit> get filteredUnits {
+    switch (scopeFilter.value) {
+      case SystemdScopeFilter.all:
+        return units.value;
+      case SystemdScopeFilter.system:
+        return units.value.where((unit) => unit.scope == SystemdUnitScope.system).toList();
+      case SystemdScopeFilter.user:
+        return units.value.where((unit) => unit.scope == SystemdUnitScope.user).toList();
+    }
   }
 
   Future<void> getUnits() async {

--- a/lib/view/page/server/tab/content.dart
+++ b/lib/view/page/server/tab/content.dart
@@ -20,7 +20,10 @@ extension on _ServerPageState {
   Widget _buildTopRightWidget(Server s) {
     final (child, onTap) = switch (s.conn) {
       ServerConn.connecting || ServerConn.loading || ServerConn.connected => (
-        SizedLoading(_ServerPageState._kCardHeightMin, strokeWidth: 3, padding: 5),
+        SizedBox.square(
+          dimension: _ServerPageState._kCardHeightMin,
+          child: SizedLoading(_ServerPageState._kCardHeightMin, strokeWidth: 3, padding: 3),
+        ),
         null,
       ),
       ServerConn.failed => (

--- a/lib/view/page/systemd.dart
+++ b/lib/view/page/systemd.dart
@@ -46,6 +46,7 @@ final class _SystemdPageState extends State<SystemdPage> {
               duration: Durations.medium1,
               curve: Curves.fastEaseInToSlowEaseOut,
               height: isBusy ? SizedLoading.medium.size : 0,
+              width: isBusy ? SizedLoading.medium.size : 0,
               child: isBusy ? SizedLoading.medium : const SizedBox.shrink(),
             ),
           ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -497,8 +497,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "v1.0.327"
-      resolved-ref: "5075a679b814b10742f967066858ba4df92ea4ae"
+      ref: "v1.0.329"
+      resolved-ref: "1620fb055986dfcf7587d7a16eb994a39c0d5772"
       url: "https://github.com/lppcg/fl_lib"
     source: git
     version: "0.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,7 +63,7 @@ dependencies:
   fl_lib:
     git:
       url: https://github.com/lppcg/fl_lib
-      ref: v1.0.327
+      ref: v1.0.329
 
 dependency_overrides:
   # webdav_client_plus:


### PR DESCRIPTION
## Summary by Sourcery

Add scope filter functionality to the systemd page, refactor unit fetching and parsing logic in the provider, improve UI loading indicators and SSH prompt context handling, tighten GitHub workflow triggers, and bump fl_lib dependency.

New Features:
- Introduce scope filter chips on the systemd page to select All, System, or User units
- Expose a filteredUnits getter in SystemdProvider to apply the selected scope filter

Enhancements:
- Refactor SystemdProvider to unify system and user unit parsing, skip empty segments, and switch warning logs to dprint
- Improve the loading spinner layout by wrapping it in a square SizedBox and update animated container dimensions
- Enhance SSHClient extension to resolve context from focus manager when prompting for a password

CI:
- Restrict Claude GitHub actions to runs triggered by a specific actor

Chores:
- Bump fl_lib dependency reference from v1.0.327 to v1.0.329