### PR TITLE
opt.: bak pwd is optional

### DIFF
--- a/lib/core/sync.dart
+++ b/lib/core/sync.dart
@@ -14,11 +14,7 @@ final class BakSyncer extends SyncIface {
   @override
   Future<void> saveToFile() async {
     final pwd = await SecureStoreProps.bakPwd.read();
-    if (pwd == null || pwd.isEmpty) {
-      // Enforce password for non-clipboard backups
-      throw Exception('Backup password not set');
-    }
-    await BackupV2.backup(null, pwd);
+    await BackupV2.backup(null, pwd?.isEmpty == true ? null : pwd);
   }
 
   @override

--- a/lib/data/provider/server.freezed.dart
+++ b/lib/data/provider/server.freezed.dart
@@ -14,8 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$ServersState {
 
- Map<String, Spi> get servers;// Only store server configuration information
- List<String> get serverOrder; Set<String> get tags; Set<String> get manualDisconnectedIds; Timer? get autoRefreshTimer;
+ Map<String, Spi> get servers; List<String> get serverOrder; Set<String> get tags; Set<String> get manualDisconnectedIds; Timer? get autoRefreshTimer;
 /// Create a copy of ServersState
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -221,9 +220,7 @@ class _ServersState implements ServersState {
   return EqualUnmodifiableMapView(_servers);
 }
 
-// Only store server configuration information
  final  List<String> _serverOrder;
-// Only store server configuration information
 @override@JsonKey() List<String> get serverOrder {
   if (_serverOrder is EqualUnmodifiableListView) return _serverOrder;
   // ignore: implicit_dynamic_type

--- a/lib/data/res/github_id.dart
+++ b/lib/data/res/github_id.dart
@@ -124,6 +124,7 @@ abstract final class GithubIds {
     'CreeperKong',
     'zxf945',
     'cnen2018',
+    'xiaomeng9597',
   };
 }
 


### PR DESCRIPTION
Fixes #860

## Summary by Sourcery

Allow backup operations to proceed without requiring a preset password, simplify password handling across code paths, and unify the treatment of empty passwords as unencrypted backups.

Bug Fixes:
- Remove exception in BakSyncer that enforced a mandatory backup password

Enhancements:
- Treat empty saved password as optional and pass null to BackupV2 to disable encryption
- Remove specialized clipboard-password flow and consolidate password retrieval from secure storage
- Allow BackupPageState to remain alive via wantKeepAlive override

Chores:
- Combine multiline getters in server.freezed.dart to a single line
- Add new GitHub contributor ID 'xiaomeng9597'