### PR TITLE
fix: replace String.fromCharCodes with utf8.decode for proper Chinese character handling in JSON import

### DIFF
--- a/lib/view/page/backup.dart
+++ b/lib/view/page/backup.dart
@@ -360,7 +360,7 @@ final class _BackupPageState extends ConsumerState<BackupPage> with AutomaticKee
       onTap: () async {
         final data = await context.showImportDialog(title: l10n.snippet, modelDef: Snippet.example.toJson());
         if (data == null) return;
-        final str = String.fromCharCodes(data);
+        final str = utf8.decode(data);
         final (list, _) = await context.showLoadingDialog(
           fn: () => Computer.shared.start((s) {
             return json.decode(s) as List;
@@ -588,7 +588,7 @@ extension on _BackupPageState {
   void _onBulkImportServers(BuildContext context) async {
     final data = await context.showImportDialog(title: l10n.server, modelDef: Spix.example.toJson());
     if (data == null) return;
-    final text = String.fromCharCodes(data);
+    final text = utf8.decode(data);
 
     try {
       final (spis, err) = await context.showLoadingDialog(

--- a/lib/view/page/backup.dart
+++ b/lib/view/page/backup.dart
@@ -360,7 +360,13 @@ final class _BackupPageState extends ConsumerState<BackupPage> with AutomaticKee
       onTap: () async {
         final data = await context.showImportDialog(title: l10n.snippet, modelDef: Snippet.example.toJson());
         if (data == null) return;
-        final str = utf8.decode(data);
+        String str;
+        try {
+          str = utf8.decode(data);
+        } on FormatException catch (e, s) {
+          context.showErrDialog(e, s, libL10n.error);
+          return;
+        }
         final (list, _) = await context.showLoadingDialog(
           fn: () => Computer.shared.start((s) {
             return json.decode(s) as List;
@@ -588,7 +594,13 @@ extension on _BackupPageState {
   void _onBulkImportServers(BuildContext context) async {
     final data = await context.showImportDialog(title: l10n.server, modelDef: Spix.example.toJson());
     if (data == null) return;
-    final text = utf8.decode(data);
+    String text;
+    try {
+      text = utf8.decode(data);
+    } on FormatException catch (e, s) {
+      context.showErrDialog(e, s, libL10n.error);
+      return;
+    }
 
     try {
       final (spis, err) = await context.showLoadingDialog(


### PR DESCRIPTION
Fixes FormatException when importing server data with Chinese names by using proper UTF-8 decoding instead of raw character code conversion.

Fixes #861

Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Use proper UTF-8 decoding when importing JSON data to fix FormatException errors with Chinese characters

Bug Fixes:
- Replace String.fromCharCodes with utf8.decode in snippet import flow
- Replace String.fromCharCodes with utf8.decode in bulk server import flow