### PR TITLE
fix: ensure unique IDs for bulk server import to prevent overwriting

### DIFF
--- a/lib/view/page/backup.dart
+++ b/lib/view/page/backup.dart
@@ -618,10 +618,15 @@ extension on _BackupPageState {
       if (sure == true) {
         final (suc, err) = await context.showLoadingDialog(
           fn: () async {
+            final usedIds = <String>{};
             for (var spi in spis) {
               // Ensure each server has a unique ID
-              final spiWithId = spi.id.isEmpty ? spi.copyWith(id: ShortId.generate()) : spi;
+
+              // Only generate a new ID if the imported one is empty or already used in importing stage
+              final isIdUsed = spi.id.isNotEmpty || usedIds.contains(spi.id);
+              final spiWithId = isIdUsed ? spi.copyWith(id: ShortId.generate()) : spi;
               Stores.server.put(spiWithId);
+              usedIds.add(spiWithId.id);
             }
             return true;
           },

--- a/lib/view/page/backup.dart
+++ b/lib/view/page/backup.dart
@@ -619,7 +619,9 @@ extension on _BackupPageState {
         final (suc, err) = await context.showLoadingDialog(
           fn: () async {
             for (var spi in spis) {
-              Stores.server.put(spi);
+              // Ensure each server has a unique ID
+              final spiWithId = spi.id.isEmpty ? spi.copyWith(id: ShortId.generate()) : spi;
+              Stores.server.put(spiWithId);
             }
             return true;
           },


### PR DESCRIPTION
Fixes issue where bulk server import from JSON only showed the last server instead of all servers.

Previously, when importing multiple servers from JSON, all servers with empty ID fields would overwrite each other in storage since they all used the same empty key.

This fix ensures each imported server gets a unique ID if it doesn't already have one, allowing all servers to be properly stored and displayed.

Fixes #862

Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Bug Fixes:
- Assign a generated unique ID to each imported server with an empty ID field to avoid storage collisions and ensure all servers are displayed