### PR TITLE
fix: sync will refresh the entire app

### DIFF
--- a/lib/data/provider/private_key.dart
+++ b/lib/data/provider/private_key.dart
@@ -9,17 +9,25 @@ part 'private_key.g.dart';
 
 @freezed
 abstract class PrivateKeyState with _$PrivateKeyState {
-  const factory PrivateKeyState({
-    @Default(<PrivateKeyInfo>[]) List<PrivateKeyInfo> keys,
-  }) = _PrivateKeyState;
+  const factory PrivateKeyState({@Default(<PrivateKeyInfo>[]) List<PrivateKeyInfo> keys}) = _PrivateKeyState;
 }
 
 @Riverpod(keepAlive: true)
 class PrivateKeyNotifier extends _$PrivateKeyNotifier {
   @override
   PrivateKeyState build() {
+    return _load();
+  }
+
+  void reload() {
+    final newState = _load();
+    if (newState == state) return;
+    state = newState;
+  }
+
+  PrivateKeyState _load() {
     final keys = Stores.key.fetch();
-    return PrivateKeyState(keys: keys);
+    return stateOrNull?.copyWith(keys: keys) ?? PrivateKeyState(keys: keys);
   }
 
   void add(PrivateKeyInfo info) {

--- a/lib/data/provider/server/all.dart
+++ b/lib/data/provider/server/all.dart
@@ -1,4 +1,3 @@
-
 import 'dart:async';
 
 import 'package:fl_lib/fl_lib.dart';
@@ -30,12 +29,17 @@ abstract class ServersState with _$ServersState {
 class ServersNotifier extends _$ServersNotifier {
   @override
   ServersState build() {
-    // Initialize with empty state, load data asynchronously
-    Future.microtask(() => _load());
-    return const ServersState();
+    return _load();
   }
 
-  Future<void> _load() async {
+  Future<void> reload() async {
+    final newState = _load();
+    if (newState == state) return;
+    state = newState;
+    await refresh();
+  }
+
+  ServersState _load() {
     final spis = Stores.server.fetch();
     final newServers = <String, Spi>{};
     final newServerOrder = <String>[];
@@ -59,7 +63,8 @@ class ServersNotifier extends _$ServersNotifier {
 
     final newTags = _calculateTags(newServers);
 
-    state = state.copyWith(servers: newServers, serverOrder: newServerOrder, tags: newTags);
+    return stateOrNull?.copyWith(servers: newServers, serverOrder: newServerOrder, tags: newTags) ??
+        ServersState(servers: newServers, serverOrder: newServerOrder, tags: newTags);
   }
 
   Set<String> _calculateTags(Map<String, Spi> servers) {

--- a/lib/view/page/home.dart
+++ b/lib/view/page/home.dart
@@ -22,7 +22,7 @@ class HomePage extends ConsumerStatefulWidget {
 }
 
 class _HomePageState extends ConsumerState<HomePage>
-    with AutomaticKeepAliveClientMixin, AfterLayoutMixin, WidgetsBindingObserver {
+    with AutomaticKeepAliveClientMixin, AfterLayoutMixin, WidgetsBindingObserver, GlobalRef {
   late final PageController _pageController;
 
   final _selectIndex = ValueNotifier(0);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -497,8 +497,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "v1.0.344"
-      resolved-ref: "9c7dd603b125fa3ca7a65d466c8fb41383997bd3"
+      ref: "v1.0.345"
+      resolved-ref: "1b797643ef7603dd825caf96a6c57b88dbd23c34"
       url: "https://github.com/lppcg/fl_lib"
     source: git
     version: "0.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,7 +63,7 @@ dependencies:
   fl_lib:
     git:
       url: https://github.com/lppcg/fl_lib
-      ref: v1.0.344
+      ref: v1.0.345
   flutter_gbk2utf8: ^1.0.1
 
 dependency_overrides:


### PR DESCRIPTION
Fixes #876

## Summary by Sourcery

Prevent full application refresh during data sync by refactoring providers to load synchronously, add conditional reload methods, and update backup merge logic to trigger only the necessary notifiers.

Bug Fixes:
- Stop synchronise operations from refreshing the entire app by removing global reload triggers and using targeted provider reloads.

Enhancements:
- Extract synchronous `_load` functions and have `build` return initial state directly in snippet, server, and private_key notifiers.
- Add `reload` methods and use `stateOrNull.copyWith` to update notifier state only when underlying data changes.
- Refactor backup merge to detect per-store changes and invoke individual notifier reloads instead of a global app refresh.
- Mix in `GlobalRef` into HomePageState to enable UI-driven provider reload calls.

Build:
- Bump fl_lib dependency reference to v1.0.345.