### PR TITLE
fix: imported servers from ssh config are the same

### DIFF
--- a/lib/core/utils/ssh_config.dart
+++ b/lib/core/utils/ssh_config.dart
@@ -63,6 +63,7 @@ abstract final class SSHConfig {
     void addServer() {
       if (currentHost != null && currentHost != '*' && hostname != null) {
         final spi = Spi(
+          id: ShortId.generate(),
           name: currentHost,
           ip: hostname,
           port: port,

--- a/lib/data/res/store.dart
+++ b/lib/data/res/store.dart
@@ -1,4 +1,5 @@
 import 'package:fl_lib/fl_lib.dart';
+import 'package:get_it/get_it.dart';
 import 'package:server_box/data/store/container.dart';
 import 'package:server_box/data/store/history.dart';
 import 'package:server_box/data/store/private_key.dart';
@@ -6,25 +7,34 @@ import 'package:server_box/data/store/server.dart';
 import 'package:server_box/data/store/setting.dart';
 import 'package:server_box/data/store/snippet.dart';
 
+final GetIt getIt = GetIt.instance;
+
 abstract final class Stores {
-  static final setting = SettingStore.instance;
-  static final server = ServerStore.instance;
-  static final container = ContainerStore.instance;
-  static final key = PrivateKeyStore.instance;
-  static final snippet = SnippetStore.instance;
-  static final history = HistoryStore.instance;
+  static SettingStore get setting => getIt<SettingStore>();
+  static ServerStore get server => getIt<ServerStore>();
+  static ContainerStore get container => getIt<ContainerStore>();
+  static PrivateKeyStore get key => getIt<PrivateKeyStore>();
+  static SnippetStore get snippet => getIt<SnippetStore>();
+  static HistoryStore get history => getIt<HistoryStore>();
 
   /// All stores that need backup
-  static final List<HiveStore> _allBackup = [
-    SettingStore.instance,
-    ServerStore.instance,
-    ContainerStore.instance,
-    PrivateKeyStore.instance,
-    SnippetStore.instance,
-    HistoryStore.instance,
-  ];
+  static List<HiveStore> get _allBackup => [
+        setting,
+        server,
+        container,
+        key,
+        snippet,
+        history,
+      ];
 
   static Future<void> init() async {
+    getIt.registerLazySingleton<SettingStore>(() => SettingStore.instance);
+    getIt.registerLazySingleton<ServerStore>(() => ServerStore.instance);
+    getIt.registerLazySingleton<ContainerStore>(() => ContainerStore.instance);
+    getIt.registerLazySingleton<PrivateKeyStore>(() => PrivateKeyStore.instance);
+    getIt.registerLazySingleton<SnippetStore>(() => SnippetStore.instance);
+    getIt.registerLazySingleton<HistoryStore>(() => HistoryStore.instance);
+    
     await Future.wait(_allBackup.map((store) => store.init()));
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -682,6 +682,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  get_it:
+    dependency: "direct main"
+    description:
+      name: get_it
+      sha256: a4292e7cf67193f8e7c1258203104eb2a51ec8b3a04baa14695f4064c144297b
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.2.0"
   glob:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -65,6 +65,7 @@ dependencies:
       url: https://github.com/lppcg/fl_lib
       ref: v1.0.345
   flutter_gbk2utf8: ^1.0.1
+  get_it: ^8.2.0
 
 dependency_overrides:
   # webdav_client_plus:
@@ -77,7 +78,7 @@ dependency_overrides:
   #   path: ../fl_lib
   # fl_build:
   #   path: ../fl_build
-  gtk:
+  gtk: # TODO: remove it after fixed in upstream
     git:
       url: https://github.com/lollipopkit/gtk.dart
       ref: v0.0.36


### PR DESCRIPTION
Fixes #881

## Summary by Sourcery

Replace direct singleton stores with GetIt-based dependency injection, register lazy singletons at startup, add get_it dependency, and assign unique IDs to SSH-config imported servers to prevent duplicates.

Bug Fixes:
- Generate a unique ShortId for each server imported from SSH config to avoid duplicate entries.

Enhancements:
- Use GetIt to manage and retrieve store instances via getters and lazy singleton registration.
- Convert the backup store list into a getter that relies on the GetIt-managed store instances.

Build:
- Add get_it 8.2.0 as a project dependency.