### PR TITLE
fix: resolve Docker interface blank issue caused by LateInitializatio…

### DIFF
--- a/lib/data/provider/container.dart
+++ b/lib/data/provider/container.dart
@@ -38,11 +38,6 @@ class ContainerNotifier extends _$ContainerNotifier {
 
   @override
   ContainerState build(SSHClient? client, String userName, String hostId, BuildContext context) {
-    this.client = client;
-    this.userName = userName;
-    this.hostId = hostId;
-    this.context = context;
-    
     final type = Stores.container.getType(hostId);
     final initialState = ContainerState(type: type);
     


### PR DESCRIPTION
…nError

Remove manual field assignment in ContainerNotifier.build() method since the generated Riverpod code already handles field initialization automatically. This prevents the 'Field client has already been initialized' error that was causing the Docker container page to display blank content.

Fixes #883

## Summary by Sourcery

Bug Fixes:
- Remove redundant manual field assignments in ContainerNotifier.build since Riverpod generated code handles initialization automatically, resolving the LateInitializationError.