### PR TITLE
fix: watchOS app cfg

### DIFF
--- a/lib/intro.dart
+++ b/lib/intro.dart
@@ -121,7 +121,7 @@ final class _IntroPage extends StatelessWidget {
         IntroPage.title(text: l10n.backupPassword, big: true),
         SizedBox(height: padTop * 0.5),
         Text(
-          '${l10n.backupTip}\n\n${l10n.backupPasswordTip}',
+          l10n.backupTip,
           style: const TextStyle(fontSize: 16),
           textAlign: TextAlign.center,
         ),
@@ -148,10 +148,7 @@ final class _IntroPage extends StatelessWidget {
                   ),
                 ],
               ),
-              actions: [
-                TextButton(onPressed: () => ctx.pop(false), child: Text(libL10n.cancel)),
-                TextButton(onPressed: () => ctx.pop(true), child: Text(libL10n.ok)),
-              ],
+              actions: Btnx.cancelOk,
             );
             if (result == true) {
               final pwd = controller.text.trim();

--- a/lib/view/page/setting/platform/ios.dart
+++ b/lib/view/page/setting/platform/ios.dart
@@ -108,14 +108,13 @@ class _IosSettingsPageState extends State<IosSettingsPage> {
   }
 
   void _onTapWatchApp(Map<String, dynamic> map) async {
-    final urls = Map<String, String>.from(map['urls'] as Map? ?? {});
-    final result = await KvEditor.route.go(context, KvEditorArgs(data: urls));
+    final cfgs = List<String>.from(map['urls'] as List? ?? []);
+    final result = await JsonListEditor.route.go(context, JsonListEditorArgs(data: cfgs));
     if (result == null) return;
 
     final (_, err) = await context.showLoadingDialog(
       fn: () async {
         final data = {'urls': result};
-
         // Try realtime update (app must be running foreground).
         try {
           if (await wc.isReachable) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -464,10 +464,10 @@ packages:
     dependency: "direct main"
     description:
       name: file_picker
-      sha256: ef7d2a085c1b1d69d17b6842d0734aad90156de08df6bd3c12496d0bd6ddf8e2
+      sha256: e7e16c9d15c36330b94ca0e2ad8cb61f93cd5282d0158c09805aed13b5452f22
       url: "https://pub.dev"
     source: hosted
-    version: "10.3.1"
+    version: "10.3.2"
   fixnum:
     dependency: transitive
     description:
@@ -489,10 +489,10 @@ packages:
     dependency: "direct main"
     description:
       name: fl_chart
-      sha256: "577aeac8ca414c25333334d7c4bb246775234c0e44b38b10a82b559dd4d764e7"
+      sha256: d3f82f4a38e33ba23d05a08ff304d7d8b22d2a59a5503f20bd802966e915db89
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   fl_lib:
     dependency: "direct main"
     description:
@@ -580,10 +580,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: "6382ce712ff69b0f719640ce957559dde459e55ecd433c767e06d139ddf16cab"
+      sha256: b0694b7fb1689b0e6cc193b3f1fcac6423c4f93c74fb20b806c6b6f196db0c31
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.29"
+    version: "2.0.30"
   flutter_riverpod:
     dependency: "direct main"
     description:
@@ -735,10 +735,10 @@ packages:
     dependency: "direct main"
     description:
       name: hive_ce_flutter
-      sha256: a0989670652eab097b47544f1e5a4456e861b1b01b050098ea0b80a5fabe9909
+      sha256: f5bd57fda84402bca7557fedb8c629c96c8ea10fab4a542968d7b60864ca02cc
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   hive_ce_generator:
     dependency: "direct dev"
     description:
@@ -1079,10 +1079,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: d0d310befe2c8ab9e7f393288ccbb11b60c019c6b5afc21973eeee4dda2b35e9
+      sha256: "993381400e94d18469750e5b9dcb8206f15bc09f9da86b9e44a9b0092a0066db"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.17"
+    version: "2.2.18"
   path_provider_foundation:
     dependency: transitive
     description:
@@ -1232,10 +1232,10 @@ packages:
     dependency: transitive
     description:
       name: qr_code_dart_scan
-      sha256: b23879821242bc2c1b2d3a035d96d453a5554c86894a69e10726b559206bcafb
+      sha256: "1b317b47f475f6995c19e0f41d790902a8cd158b23c435d936763d86ba44309c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.2"
+    version: "0.11.3"
   quiver:
     dependency: transitive
     description:
@@ -1376,10 +1376,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "5bcf0772a761b04f8c6bf814721713de6f3e5d9d89caf8d3fe031b02a342379e"
+      sha256: a2608114b1ffdcbc9c120eb71a0e207c71da56202852d4aab8a5e30a82269e74
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.11"
+    version: "2.4.12"
   shared_preferences_foundation:
     dependency: transitive
     description:
@@ -1758,10 +1758,10 @@ packages:
     dependency: transitive
     description:
       name: watcher
-      sha256: "0b7fd4a0bbc4b92641dbf20adfd7e3fd1398fe17102d94b674234563e110088a"
+      sha256: "5bf046f41320ac97a469d506261797f35254fa61c641741ef32dacda98b7d39c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   web:
     dependency: transitive
     description:


### PR DESCRIPTION
Fixes #741

## Summary by Sourcery

Apply UI and configuration editor improvements: simplify the intro dialog display and actions, and switch the watchOS app settings editor on iOS to use a JSON list instead of a key-value map.

Enhancements:
- Streamline the intro page dialog by removing redundant backup password text and using Btnx.cancelOk actions
- Update the watchOS app configuration editor on iOS from KvEditor with a map to JsonListEditor with a list of URLs