### PR TITLE
fix: cant sort servers order

### DIFF
--- a/lib/data/provider/pve.g.dart
+++ b/lib/data/provider/pve.g.dart
@@ -58,7 +58,7 @@ final class PveNotifierProvider
   }
 }
 
-String _$pveNotifierHash() => r'b5da7240db1b9ee7d61f238cebca45821b7a3445';
+String _$pveNotifierHash() => r'ba5f2d6cb47c33735f7cc09b771b4a86501b86c6';
 
 final class PveNotifierFamily extends $Family
     with $ClassFamilyOverride<PveNotifier, PveState, PveState, PveState, Spi> {

--- a/lib/data/provider/server/all.dart
+++ b/lib/data/provider/server/all.dart
@@ -239,6 +239,50 @@ class ServersNotifier extends _$ServersNotifier {
     bakSync.sync(milliDelay: 1000);
   }
 
+  void updateServerOrder(List<String> order) {
+    final seen = <String>{};
+    final newOrder = <String>[];
+
+    for (final id in order) {
+      if (!state.servers.containsKey(id)) {
+        continue;
+      }
+      if (!seen.add(id)) {
+        continue;
+      }
+      newOrder.add(id);
+    }
+
+    for (final id in state.servers.keys) {
+      if (seen.add(id)) {
+        newOrder.add(id);
+      }
+    }
+
+    if (_isSameOrder(newOrder, state.serverOrder)) {
+      return;
+    }
+
+    state = state.copyWith(serverOrder: newOrder);
+    Stores.setting.serverOrder.put(newOrder);
+    bakSync.sync(milliDelay: 1000);
+  }
+
+  bool _isSameOrder(List<String> a, List<String> b) {
+    if (identical(a, b)) {
+      return true;
+    }
+    if (a.length != b.length) {
+      return false;
+    }
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   Future<void> updateServer(Spi old, Spi newSpi) async {
     if (old != newSpi) {
       Stores.server.update(old, newSpi);

--- a/lib/data/provider/server/all.g.dart
+++ b/lib/data/provider/server/all.g.dart
@@ -41,7 +41,7 @@ final class ServersNotifierProvider
   }
 }
 
-String _$serversNotifierHash() => r'2b29ad3027a203c7a20bfd0142d384a503cbbcaa';
+String _$serversNotifierHash() => r'3292bdce7d602ff64687b05ff81d120e71761ec2';
 
 abstract class _$ServersNotifier extends $Notifier<ServersState> {
   ServersState build();

--- a/lib/data/provider/server/single.g.dart
+++ b/lib/data/provider/server/single.g.dart
@@ -58,7 +58,7 @@ final class ServerNotifierProvider
   }
 }
 
-String _$serverNotifierHash() => r'd9724fbe6d132f2e2ea4dfa5af73aeab168e1c57';
+String _$serverNotifierHash() => r'185c6b4546c3bc526f5b2ca79d16aed665818863';
 
 final class ServerNotifierFamily extends $Family
     with

--- a/lib/data/provider/systemd.g.dart
+++ b/lib/data/provider/systemd.g.dart
@@ -58,7 +58,7 @@ final class SystemdNotifierProvider
   }
 }
 
-String _$systemdNotifierHash() => r'98466bd176518545be49cae52f8dbe12af3a88a6';
+String _$systemdNotifierHash() => r'030d556efc3d897419cd3462d37cb705813e24c7';
 
 final class SystemdNotifierFamily extends $Family
     with


### PR DESCRIPTION
Fixes: #927

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Reorder servers in Settings and persist the custom order across sessions.

- Bug Fixes
  - Corrected item movement logic in the reorder list for accurate placement.
  - Kept the on-screen order in sync with external updates to prevent desynchronization.

- Refactor
  - Streamlined item rendering to derive display from the current order.
  - Simplified drag proxy behavior during reordering.

- Style
  - Minor UI tweaks to spacing and avatars for a cleaner list appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->