### PR TITLE
feat: SFTP interface implements responsive design

### DIFF
--- a/lib/view/page/storage/sftp.dart
+++ b/lib/view/page/storage/sftp.dart
@@ -177,32 +177,56 @@ extension _UI on _SftpPageState {
 
   Widget _buildItem(SftpName file, {VoidCallback? beforeTap}) {
     final isDir = file.attr.isDirectory;
-    final trailing = Text(
-      '${_getTime(file.attr.modifyTime)}\n${file.attr.mode?.str ?? ''}',
-      style: UIs.textGrey,
-      textAlign: TextAlign.right,
-    );
-    return CardX(
-      child: ListTile(
-        leading: Icon(isDir ? Icons.folder_outlined : Icons.insert_drive_file),
-        title: Text(file.filename),
-        trailing: trailing,
-        subtitle: isDir ? null : Text((file.attr.size ?? 0).bytes2Str, style: UIs.textGrey),
-        onTap: () {
-          beforeTap?.call();
-          if (isDir) {
-            _status.path.path = file.filename;
-            _listDir();
-          } else {
-            _onItemPress(file, true);
-          }
-        },
-        onLongPress: () {
-          beforeTap?.call();
-          _onItemPress(file, !isDir);
-        },
-      ),
-    );
+    final double screenWidth = MediaQuery.of(context).size.width;
+    if (screenWidth < 350) {
+      return CardX(
+        child: ListTile(
+          leading: Icon(isDir ? Icons.folder_outlined : Icons.insert_drive_file),
+          title: Text(file.filename),
+          subtitle: isDir ? Text('${_getTime(file.attr.modifyTime)}\n${file.attr.mode?.str ?? ''}', style: UIs.textGrey) :
+            Text('${(file.attr.size ?? 0).bytes2Str}\n${_getTime(file.attr.modifyTime)}\n${file.attr.mode?.str ?? ''}', style: UIs.textGrey),
+          onTap: () {
+            beforeTap?.call();
+            if (isDir) {
+              _status.path.path = file.filename;
+              _listDir();
+            } else {
+              _onItemPress(file, true);
+            }
+          },
+          onLongPress: () {
+            beforeTap?.call();
+            _onItemPress(file, !isDir);
+          },
+        ),
+      );
+    } else {
+      return CardX(
+        child: ListTile(
+          leading: Icon(isDir ? Icons.folder_outlined : Icons.insert_drive_file),
+          title: Text(file.filename),
+          trailing: Text(
+            '${_getTime(file.attr.modifyTime)}\n${file.attr.mode?.str ?? ''}',
+            style: UIs.textGrey,
+            textAlign: TextAlign.right,
+          ),
+          subtitle: isDir ? null : Text((file.attr.size ?? 0).bytes2Str, style: UIs.textGrey),
+          onTap: () {
+            beforeTap?.call();
+            if (isDir) {
+              _status.path.path = file.filename;
+              _listDir();
+            } else {
+              _onItemPress(file, true);
+            }
+          },
+          onLongPress: () {
+            beforeTap?.call();
+            _onItemPress(file, !isDir);
+          },
+        ),
+      );
+    }
   }
 }
 


### PR DESCRIPTION
### feat
检测屏幕逻辑分辨率,当逻辑分辨率小于350时将时间信息放到subtitle而不是trailing,为更加重要的文件名腾出显示空间

https://github.com/user-attachments/assets/59adf147-1aaa-4f98-9941-c7c7d88302f2


相关issue: #972 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Responsive layout for SFTP file metadata display. Narrow screens now show file information in an optimized multiline format, while wider screens preserve the original layout for improved readability across all screen sizes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->