### PR TITLE
fix(sftp): Fix SFTP file download failures on Windows

### DIFF
--- a/lib/data/model/sftp/req.dart
+++ b/lib/data/model/sftp/req.dart
@@ -36,7 +36,7 @@ class SftpReqStatus {
   late SftpWorker worker;
   final Completer? completer;
 
-  String get fileName => req.localPath.split('/').last;
+  String get fileName => req.localPath.split(Pfs.seperator).last;
 
   // status of the download
   double? progress;

--- a/lib/data/model/sftp/worker.dart
+++ b/lib/data/model/sftp/worker.dart
@@ -70,7 +70,7 @@ Future<void> _download(SftpReq req, SendPort mainSendPort, SendErrorFunction sen
     mainSendPort.send(SftpWorkerStatus.sshConnectted);
 
     /// Create the directory if not exists
-    final dirPath = req.localPath.substring(0, req.localPath.lastIndexOf('/'));
+    final dirPath = req.localPath.substring(0, req.localPath.lastIndexOf(Pfs.seperator));
     await Directory(dirPath).create(recursive: true);
 
     /// Use [FileMode.write] to overwrite the file

--- a/lib/view/page/storage/local.dart
+++ b/lib/view/page/storage/local.dart
@@ -123,7 +123,7 @@ class _LocalFilePageState extends ConsumerState<LocalFilePage> with AutomaticKee
 
             final item = items![index];
             final file = item.$1;
-            final fileName = file.path.split('/').last;
+            final fileName = file.path.split(Pfs.seperator).last;
             final stat = item.$2;
             final isDir = stat.type == FileSystemEntityType.directory;
 
@@ -216,7 +216,7 @@ extension _Actions on _LocalFilePageState {
   }
 
   Future<void> _showFileActionDialog(FileSystemEntity file) async {
-    final fileName = file.path.split('/').lastOrNull ?? '';
+    final fileName = file.path.split(Pfs.seperator).lastOrNull ?? '';
     if (isPickFile) {
       context.showRoundDialog(
         title: libL10n.file,
@@ -308,7 +308,7 @@ extension _Actions on _LocalFilePageState {
   }
 
   void _showDeleteDialog(FileSystemEntity file) {
-    final fileName = file.path.split('/').last;
+    final fileName = file.path.split(Pfs.seperator).last;
     context.showRoundDialog(
       title: libL10n.delete,
       child: Text(libL10n.askContinue('${libL10n.delete} $fileName')),

--- a/lib/view/page/storage/sftp.dart
+++ b/lib/view/page/storage/sftp.dart
@@ -585,7 +585,11 @@ extension _Actions on _SftpPageState {
 
   /// Local file dir + server id + remote path
   String _getLocalPath(String remotePath) {
-    return Paths.file.joinPath(widget.args.spi.oldId).joinPath(remotePath);
+    var normalizedPath = remotePath.replaceAll('/', Pfs.seperator);
+    if (normalizedPath.startsWith(Pfs.seperator)) {
+      normalizedPath = normalizedPath.substring(1);
+    }
+    return Paths.file.joinPath(widget.args.spi.id).joinPath(normalizedPath);
   }
 
   /// Only return true if the path is changed


### PR DESCRIPTION
Fix multiple path handling issues that caused SFTP file download failures on Windows:

1. **Invalid folder names**: Replaced `spi.oldId` (format: `user@ip:port`) with `spi.id` (format: `ptPQHje00`) for folder naming, as the former contains characters illegal on Windows (`@` and `:`)
2. **Path separator mismatch**: Fixed inconsistent use of path separators by normalizing all path operations to use platform-specific separators (`Pfs.seperator`)
3. **RangeError**: Fixed substring operations that used hardcoded `/` separator while `localPath` used platform-specific separators
4. **Triple separators**: Fixed path joining logic that resulted in malformed paths with triple separators (`\\\`)

This bug has been reported in #992.

## Changes

### Modified Files

- `lib/view/page/storage/sftp.dart`
  - Changed `spi.oldId` to `spi.id` for folder naming
  - Added logic to strip leading separator from `normalizedPath` before joining paths

- `lib/data/model/sftp/worker.dart`
  - Changed hardcoded `/` to `Pfs.seperator` in `lastIndexOf` operation

- `lib/data/model/sftp/req.dart`
  - Changed hardcoded `/` to `Pfs.seperator` in `split` operation


This change only affects internal path handling logic and should not impact the public API.

The application already generates server IDs using `ShortId.generate()` (e.g., `ptPQHje00`), which are valid folder names on all platforms. The `spi.oldId` (format: `user@ip:port`) is still available for display purposes but should not be used for file system operations on Windows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file path handling to use platform-appropriate path separators across file and directory operations, ensuring proper functionality across different operating systems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->