### PR TITLE
feat(local file page): Display server names for server folders

### DIFF
--- a/lib/view/page/storage/local.dart
+++ b/lib/view/page/storage/local.dart
@@ -143,7 +143,7 @@ class _LocalFilePageState extends ConsumerState<LocalFilePage> with AutomaticKee
     final isServerFolder = isDir && file.parent.path == Paths.file;
     String? serverName;
     if (isServerFolder) {
-      final servers = ref.watch(serversProvider).servers;
+      final servers = ref.read(serversProvider).servers;
       final server = servers[fileName];
       if (server != null) {
         serverName = server.name;


### PR DESCRIPTION
On the File page, server folders were displayed using only their generated IDs (e.g., `ptQHjje00`), which are not user-friendly and difficult to identify.

<img width="1007" height="557" alt="QQ_1767860939004" src="https://github.com/user-attachments/assets/4fa63c32-e544-4aac-b35e-f4763eed1c90" />

This PR adds a feature that displays server folders with their configured names, with the ID shown as a subtitle:

- **Title**: Server name (e.g., "My Server")
- **Subtitle**: Server ID (e.g., `pxk9kk100`) in grey text

<img width="1006" height="556" alt="QQ_1767861126624" src="https://github.com/user-attachments/assets/310efc2a-db0c-4b95-b0fb-f662c106340f" />

Folders of deleted servers (first one in the pic), non-servers will display their names as usual.

This only applies to folders directly under the root directory, avoiding false positives for nested folders with matching names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server-backed folders now display their server name as the title with the folder name shown as a subtitle for reference
  * Enhanced storage item display logic to properly distinguish between server-backed and local items

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->