### PR TITLE
fix: Use null-aware marker instead of `if`

### DIFF
--- a/lib/view/page/server/detail/view.dart
+++ b/lib/view/page/server/detail/view.dart
@@ -103,7 +103,7 @@ class _ServerDetailPageState extends ConsumerState<ServerDetailPage> with Single
   Widget _buildMainPage(ServerState si) {
     final buildFuncs = !_moveServerFuncs;
     final logo = _buildLogo(si);
-    final children = <Widget>[if (logo != null) logo, if (buildFuncs) ServerFuncBtns(spi: si.spi)];
+    final children = <Widget>[?logo, if (buildFuncs) ServerFuncBtns(spi: si.spi)];
     for (final card in _cardsOrder) {
       final child = _cardBuildMap[card]?.call(si);
       if (child != null) {

--- a/lib/view/page/server/discovery/discovery.dart
+++ b/lib/view/page/server/discovery/discovery.dart
@@ -162,7 +162,7 @@ class _SshDiscoveryPageState extends ConsumerState<SshDiscoveryPage> {
         layoutBuilder: (currentChild, previousChildren) {
           return Stack(
             alignment: Alignment.centerRight,
-            children: <Widget>[...previousChildren, if (currentChild != null) currentChild],
+            children: <Widget>[...previousChildren, ?currentChild],
           );
         },
         child: selectedResults.isNotEmpty

--- a/lib/view/page/setting/entries/app.dart
+++ b/lib/view/page/setting/entries/app.dart
@@ -11,8 +11,8 @@ extension _App on _AppSettingsPageState {
       _buildCheckUpdate(),
       _buildHomeTabs(),
       PlatformPublicSettings.buildBioAuth,
-      if (androidSettings != null) androidSettings,
-      if (specific != null) specific,
+      ?androidSettings,
+      ?specific,
       _buildAppMore(),
     ];
 


### PR DESCRIPTION
Fix lint report: `Use the null-aware marker '?' rather than a null check via an 'if'`.

This will pass `flutter analyze`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified conditional widget rendering logic in the detail, discovery, and settings pages for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->