### PR TITLE
fix(storage): Fixed an issue with the SFTP path history

### DIFF
--- a/lib/view/page/storage/sftp.dart
+++ b/lib/view/page/storage/sftp.dart
@@ -99,11 +99,15 @@ class _SftpPageState extends ConsumerState<SftpPage> with AfterLayoutMixin {
     if (Stores.setting.sftpOpenLastPath.fetch()) {
       final history = Stores.history.sftpLastPath.fetch(widget.args.spi.id);
       if (history != null) {
+        SftpClient? sftp;
         try {
-          final sftp = await _client.sftp();
-          await sftp.listdir(history);
-          initPath = history;
+          final normalizedHistory = _normalizeSftpPath(history);
+          sftp = await _client.sftp();
+          await sftp.listdir(normalizedHistory);
+          initPath = normalizedHistory;
         } catch (_) {
+        } finally {
+          sftp?.close();
         }
       }
     }
@@ -644,10 +648,7 @@ extension _Actions on _SftpPageState {
 
           // Only update history when success
           if (Stores.setting.sftpOpenLastPath.fetch()) {
-            var normalizedPath = listPath;
-            while (normalizedPath.contains('//')) {
-              normalizedPath = normalizedPath.replaceAll('//', '/');
-            }
+            final normalizedPath = _normalizeSftpPath(listPath);
             Stores.history.sftpLastPath.put(widget.args.spi.id, normalizedPath);
           }
 
@@ -797,6 +798,8 @@ extension _Actions on _SftpPageState {
     );
   }
 }
+
+String _normalizeSftpPath(String path) => path.replaceAll(RegExp(r'/+'), '/');
 
 String? _getDecompressCmd(String filename) {
   for (final ext in _extCmdMap.keys) {


### PR DESCRIPTION
Resolve #1030.

Added path validity checks when processing the SFTP path history

Standardized the format of stored paths and removed extra slashes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validate and verify previously opened SFTP paths before auto-loading to avoid loading deleted or inaccessible locations; failures are now handled gracefully.
  * Normalize and store path history to remove duplicate consecutive slashes for consistent behavior and more reliable path recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->