### PR TITLE
feat (Private Key Editing): Added private key format normalization

### DIFF
--- a/lib/view/page/private_key/edit.dart
+++ b/lib/view/page/private_key/edit.dart
@@ -13,8 +13,8 @@ import 'package:server_box/data/res/misc.dart';
 
 const _format = 'text/plain';
 final _whitespaceRegex = RegExp(r'\s+');
-final _pemBeginRegex = RegExp(r'^-----BEGIN [A-Z0-9 ]+-----$');
-final _pemEndRegex = RegExp(r'^-----END [A-Z0-9 ]+-----$');
+final _pemBeginRegex = RegExp(r'^-----BEGIN ([A-Z0-9 ]+)-----$');
+final _pemEndRegex = RegExp(r'^-----END ([A-Z0-9 ]+)-----$');
 
 final class PrivateKeyEditPageArgs {
   final PrivateKeyInfo? pki;
@@ -131,7 +131,16 @@ class _PrivateKeyEditPageState extends ConsumerState<PrivateKeyEditPage> {
     final footer = lines.last;
 
     // Validate PEM boundaries before mutating input
-    if (!_pemBeginRegex.hasMatch(header) || !_pemEndRegex.hasMatch(footer)) {
+    final headerMatch = _pemBeginRegex.firstMatch(header);
+    final footerMatch = _pemEndRegex.firstMatch(footer);
+    if (headerMatch == null || footerMatch == null) {
+      return key;
+    }
+
+    // Ensure header and footer labels match
+    final headerLabel = headerMatch.group(1);
+    final footerLabel = footerMatch.group(1);
+    if (headerLabel != footerLabel) {
       return key;
     }
 


### PR DESCRIPTION
Resolve #910.

Added the _normalizePrivateKey method to normalize private key formats:
- Removes whitespace characters from Base64 content
- Ensures the standard format of 64 characters per line
- Ensures that the private key ends with a newline character

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Private key input is now PEM-aware on save: excess whitespace is removed, the Base64 body is reformatted into consistent 64-character lines, header/footer and any embedded metadata header lines are preserved, and a trailing newline is ensured. Validation prevents accidental alteration of non-PEM content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->