### PR TITLE
fix: harden ProxyCommand SSH config parsing and validation

### DIFF
--- a/lib/core/utils/ssh_config.dart
+++ b/lib/core/utils/ssh_config.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:fl_lib/fl_lib.dart';
+import 'package:meta/meta.dart';
 import 'package:server_box/data/model/server/server_private_info.dart';
 
 /// Utility class to parse SSH config files under `~/.ssh/config`
@@ -214,6 +215,11 @@ abstract final class SSHConfig {
     }
 
     return line.trim();
+  }
+
+  @visibleForTesting
+  static String stripInlineCommentForTest(String line) {
+    return _stripInlineComment(line);
   }
 
   /// Check if SSH config file exists, trying multiple possible paths

--- a/lib/core/utils/ssh_config.dart
+++ b/lib/core/utils/ssh_config.dart
@@ -63,6 +63,18 @@ abstract final class SSHConfig {
 
     void addServer() {
       if (currentHost != null && currentHost != '*' && hostname != null) {
+        final normalizedProxyCommand = proxyCommand?.trim();
+        final resolvedProxyCommand =
+            normalizedProxyCommand == null || normalizedProxyCommand.isEmpty
+            ? null
+            : normalizedProxyCommand;
+        final resolvedJumpHost = resolvedProxyCommand != null ? null : jumpHost;
+        if (resolvedProxyCommand != null && jumpHost != null) {
+          Loggers.app.info(
+            'SSH config host $currentHost defines both ProxyJump and '
+            'ProxyCommand; preferring ProxyCommand.',
+          );
+        }
         final spi = Spi(
           id: ShortId.generate(),
           name: currentHost,
@@ -70,10 +82,16 @@ abstract final class SSHConfig {
           port: port,
           user: user ?? 'root', // Default user is 'root'
           keyId: identityFile,
-          jumpId: jumpHost,
-          proxyCommand: proxyCommand,
+          jumpId: resolvedJumpHost,
+          proxyCommand: resolvedProxyCommand,
         );
-        spi.validateOrThrow();
+        final validationError = spi.validate();
+        if (validationError != null) {
+          Loggers.app.warning(
+            'Skipping invalid SSH config host $currentHost: $validationError',
+          );
+          return;
+        }
         servers.add(spi);
       }
     }
@@ -83,8 +101,7 @@ abstract final class SSHConfig {
       if (trimmed.isEmpty || trimmed.startsWith('#')) continue;
 
       // Handle inline comments
-      final commentIndex = trimmed.indexOf('#');
-      final cleanLine = commentIndex != -1 ? trimmed.substring(0, commentIndex).trim() : trimmed;
+      final cleanLine = _stripInlineComment(trimmed);
       if (cleanLine.isEmpty) continue;
 
       final parts = cleanLine.split(RegExp(r'\s+'));
@@ -163,6 +180,40 @@ abstract final class SSHConfig {
       return parts.isNotEmpty ? parts[0] : null;
     }
     return null;
+  }
+
+  static String _stripInlineComment(String line) {
+    var inSingleQuotes = false;
+    var inDoubleQuotes = false;
+    var escaped = false;
+
+    for (var i = 0; i < line.length; i++) {
+      final char = line[i];
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (char == r'\') {
+        escaped = true;
+        continue;
+      }
+      if (char == "'" && !inDoubleQuotes) {
+        inSingleQuotes = !inSingleQuotes;
+        continue;
+      }
+      if (char == '"' && !inSingleQuotes) {
+        inDoubleQuotes = !inDoubleQuotes;
+        continue;
+      }
+      if (char == '#' &&
+          !inSingleQuotes &&
+          !inDoubleQuotes &&
+          (i == 0 || line[i - 1].trim().isEmpty)) {
+        return line.substring(0, i).trim();
+      }
+    }
+
+    return line.trim();
   }
 
   /// Check if SSH config file exists, trying multiple possible paths

--- a/lib/data/model/server/server_private_info.dart
+++ b/lib/data/model/server/server_private_info.dart
@@ -13,6 +13,15 @@ part 'server_private_info.g.dart';
 
 enum SpiValidationError { jumpServerAndProxyCommandConflict }
 
+class SpiValidationException implements Exception {
+  const SpiValidationException(this.error);
+
+  final SpiValidationError error;
+
+  @override
+  String toString() => 'SpiValidationException($error)';
+}
+
 /// In the first version, it's called `ServerPrivateInfo` which was designed to
 /// store the private information of a server.
 ///
@@ -80,12 +89,7 @@ extension Spix on Spi {
   void validateOrThrow() {
     final validationError = validate();
     if (validationError == null) return;
-    switch (validationError) {
-      case SpiValidationError.jumpServerAndProxyCommandConflict:
-        throw ArgumentError(
-          'Jump server and ProxyCommand cannot be used together.',
-        );
-    }
+    throw SpiValidationException(validationError);
   }
 
   /// After upgrading to >= 1155, this field is only recommended to be used

--- a/lib/generated/l10n/l10n_zh.dart
+++ b/lib/generated/l10n/l10n_zh.dart
@@ -505,8 +505,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get pushToken => '消息推送 Token';
 
   @override
-  String get proxyCommandOnlySupportedOnDesktop =>
-      'ProxyCommand 仅支持桌面平台。';
+  String get proxyCommandOnlySupportedOnDesktop => 'ProxyCommand 仅支持桌面平台。';
 
   @override
   String get pveIgnoreCertTip => '不推荐开启，注意安全隐患！如果你使用的 PVE 默认证书，需要开启该选项';

--- a/lib/view/page/server/edit/actions.dart
+++ b/lib/view/page/server/edit/actions.dart
@@ -136,11 +136,8 @@ extension _Actions on _ServerEditPageState {
           : _disabledCmdTypes.value.toList(),
     );
     final validationError = spi.validate();
-    if (validationError ==
-        SpiValidationError.jumpServerAndProxyCommandConflict) {
-      context.showSnackBar(
-        l10n.jumpServerAndProxyCommandCannotBeUsedTogether,
-      );
+    if (validationError != null) {
+      context.showSnackBar(_validationErrorMessage(validationError));
       return;
     }
 

--- a/lib/view/page/server/edit/actions.dart
+++ b/lib/view/page/server/edit/actions.dart
@@ -4,6 +4,13 @@ part of 'edit.dart';
 final _hostReg = RegExp(r'^[a-zA-Z0-9\.\-_:%;]+$');
 
 extension _Actions on _ServerEditPageState {
+  String _validationErrorMessage(SpiValidationError error) {
+    switch (error) {
+      case SpiValidationError.jumpServerAndProxyCommandConflict:
+        return l10n.jumpServerAndProxyCommandCannotBeUsedTogether;
+    }
+  }
+
   bool _isInvalidJumpSelection(String? candidateJumpId) {
     final currentServer = spi;
     return wouldCreateJumpCycle(
@@ -206,8 +213,8 @@ extension _Utils on _ServerEditPageState {
       } else {
         dprint('Error checking SSH config: $e');
         Stores.setting.firstTimeReadSSHCfg.put(false);
-        if (e is ArgumentError) {
-          context.showSnackBar(e.message?.toString() ?? e.toString());
+        if (e is SpiValidationException) {
+          context.showSnackBar(_validationErrorMessage(e.error));
         }
       }
     }

--- a/test/ssh_config_test.dart
+++ b/test/ssh_config_test.dart
@@ -351,5 +351,41 @@ Host internal-server
       expect(dev.port, 22);
       expect(dev.keyId, isNull);
     });
+
+    group('_stripInlineComment', () {
+      test('preserves hash characters inside quotes', () {
+        expect(
+          SSHConfig.stripInlineCommentForTest("ProxyCommand echo '#'"),
+          "ProxyCommand echo '#'",
+        );
+        expect(
+          SSHConfig.stripInlineCommentForTest('ProxyCommand echo "#"'),
+          'ProxyCommand echo "#"',
+        );
+      });
+
+      test('preserves escaped hash characters', () {
+        expect(
+          SSHConfig.stripInlineCommentForTest(r'ProxyCommand echo \#'),
+          r'ProxyCommand echo \#',
+        );
+      });
+
+      test('removes whitespace-prefixed inline comments', () {
+        expect(
+          SSHConfig.stripInlineCommentForTest('value  # comment'),
+          'value',
+        );
+      });
+
+      test('handles combined escapes and quotes', () {
+        expect(
+          SSHConfig.stripInlineCommentForTest(
+            r'''ProxyCommand sh -c "echo \# '#'"  # comment''',
+          ),
+          r'''ProxyCommand sh -c "echo \# '#'"''',
+        );
+      });
+    });
   });
 }

--- a/test/ssh_config_test.dart
+++ b/test/ssh_config_test.dart
@@ -378,6 +378,13 @@ Host internal-server
         );
       });
 
+      test('preserves hash without preceding whitespace', () {
+        expect(
+          SSHConfig.stripInlineCommentForTest('foo#bar'),
+          'foo#bar',
+        );
+      });
+
       test('handles combined escapes and quotes', () {
         expect(
           SSHConfig.stripInlineCommentForTest(


### PR DESCRIPTION
Continue fix of #1117.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved SSH import validation with clearer user-facing messages for proxy configuration conflicts and prioritization of explicit proxy commands over jump hosts.

* **Bug Fixes**
  * SSH parsing now preserves quoted values and trims inline comments only when appropriate.
  * Invalid host entries are skipped with a warning instead of aborting the entire import.

* **Tests**
  * Added tests covering inline-comment, quoting, and escape edge cases in SSH config parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->