### PR TITLE
feat(sftp): add sudo mode for privileged file operations

### DIFF
--- a/lib/core/utils/sftp_sudo.dart
+++ b/lib/core/utils/sftp_sudo.dart
@@ -147,7 +147,19 @@ final class SftpSudoHelper {
     final output = await _runAndRead(
       'find ${_shellQuote(remotePath)} '
       '-mindepth 1 -maxdepth 1 '
-      '-printf \'%f\\t%m\\t%y\\t%s\\t%T@\\n\'',
+      '-exec sh -c \''
+      'for path do '
+      'name=\${path##*/}; '
+      'perm=\$(stat -c %a "\$path"); '
+      'type=u; '
+      '[ -d "\$path" ] && type=d; '
+      '[ -L "\$path" ] && type=l; '
+      '[ -f "\$path" ] && type=f; '
+      'size=\$(stat -c %s "\$path"); '
+      'mtime=\$(stat -c %Y "\$path"); '
+      'printf "%s\\t%s\\t%s\\t%s\\t%s\\n" "\$name" "\$perm" "\$type" "\$size" "\$mtime"; '
+      'done'
+      '\' sh {} +',
       password: password,
     );
 

--- a/lib/core/utils/sftp_sudo.dart
+++ b/lib/core/utils/sftp_sudo.dart
@@ -1,0 +1,261 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:fl_lib/fl_lib.dart';
+import 'package:flutter/material.dart';
+import 'package:server_box/core/extension/context/locale.dart';
+import 'package:server_box/core/extension/ssh_client.dart';
+import 'package:server_box/data/model/server/server_private_info.dart';
+import 'package:server_box/data/res/store.dart';
+
+final class SftpSudoHelper {
+  final SSHClient client;
+  final Spi spi;
+  final BuildContext context;
+
+  String? _cachedPassword;
+
+  SftpSudoHelper({
+    required this.client,
+    required this.spi,
+    required this.context,
+  });
+
+  bool get enabled => !spi.isRoot;
+
+  bool get _rememberPwd => Stores.setting.rememberPwdInMem.fetch();
+
+  Future<String?> ensurePassword({bool force = false}) async {
+    if (!enabled) return '';
+
+    if (force) {
+      _cachedPassword = null;
+    } else if (_rememberPwd && _cachedPassword != null) {
+      return _cachedPassword;
+    }
+
+    final pwd = await context.showPwdDialog(
+      title: l10n.trySudo,
+      label: spi.user,
+      id: '${spi.id}_sftp_sudo',
+      remember: _rememberPwd,
+    );
+    if (pwd == null || pwd.isEmpty) return null;
+    if (_rememberPwd) {
+      _cachedPassword = pwd;
+    }
+    return pwd;
+  }
+
+  Future<int> getFileSize(String remotePath, {String? password}) async {
+    final output = await _runAndRead(
+      'wc -c < ${_shellQuote(remotePath)}',
+      password: password,
+    );
+    return int.tryParse(output.trim()) ?? 0;
+  }
+
+  Future<void> downloadTextFile(
+    String remotePath,
+    String localPath, {
+    String? password,
+  }) async {
+    final text = await _runAndRead(
+      'cat ${_shellQuote(remotePath)}',
+      password: password,
+    );
+    final file = File(localPath);
+    await file.parent.create(recursive: true);
+    await file.writeAsString(text);
+  }
+
+  Future<void> uploadTextFile(
+    String localPath,
+    String remotePath, {
+    String? password,
+  }) async {
+    final file = File(localPath);
+    final bytes = await file.readAsBytes();
+    final data = base64Encode(bytes);
+    await _runAndRead(
+      "printf '%s' '$data' | base64 -d | tee ${_shellQuote(remotePath)} > /dev/null",
+      password: password,
+    );
+  }
+
+  Future<void> chmod(
+    String perm,
+    String remotePath, {
+    String? password,
+  }) async {
+    await _runAndRead(
+      'chmod $perm ${_shellQuote(remotePath)}',
+      password: password,
+    );
+  }
+
+  Future<void> mkdir(
+    String remotePath, {
+    String? password,
+  }) async {
+    await _runAndRead(
+      'mkdir ${_shellQuote(remotePath)}',
+      password: password,
+    );
+  }
+
+  Future<void> touch(
+    String remotePath, {
+    String? password,
+  }) async {
+    await _runAndRead(
+      'touch ${_shellQuote(remotePath)}',
+      password: password,
+    );
+  }
+
+  Future<void> rename(
+    String oldPath,
+    String newPath, {
+    String? password,
+  }) async {
+    await _runAndRead(
+      'mv ${_shellQuote(oldPath)} ${_shellQuote(newPath)}',
+      password: password,
+    );
+  }
+
+  Future<void> delete(
+    String remotePath, {
+    required bool isDir,
+    required bool recursive,
+    String? password,
+  }) async {
+    final cmd = switch ((isDir, recursive)) {
+      (true, true) => 'rm -r ${_shellQuote(remotePath)}',
+      (true, false) => 'rmdir ${_shellQuote(remotePath)}',
+      (false, _) => 'rm ${_shellQuote(remotePath)}',
+    };
+    await _runAndRead(cmd, password: password);
+  }
+
+  Future<List<SftpName>> listDir(
+    String remotePath, {
+    String? password,
+  }) async {
+    final output = await _runAndRead(
+      'find ${_shellQuote(remotePath)} '
+      '-mindepth 1 -maxdepth 1 '
+      '-printf \'%f\\t%m\\t%y\\t%s\\t%T@\\n\'',
+      password: password,
+    );
+
+    final items = <SftpName>[
+      SftpName(
+        filename: '..',
+        longname: '..',
+        attr: SftpFileAttrs(
+          size: 0,
+          mode: const SftpFileMode.value(0x4000 | 0x1ED),
+          modifyTime: 0,
+        ),
+      ),
+    ];
+
+    for (final rawLine in output.split('\n')) {
+      final line = rawLine.trimRight();
+      if (line.isEmpty) continue;
+      final parts = line.split('\t');
+      if (parts.length < 5) continue;
+
+      final filename = parts[0];
+      final permOct = int.tryParse(parts[1], radix: 8) ?? 0x1A4;
+      final typeChar = parts[2];
+      final size = int.tryParse(parts[3]) ?? 0;
+      final modifyTime = double.tryParse(parts[4])?.toInt() ?? 0;
+      final mode = _buildMode(typeChar, permOct);
+
+      items.add(
+        SftpName(
+          filename: filename,
+          longname: filename,
+          attr: SftpFileAttrs(
+            size: size,
+            mode: mode,
+            modifyTime: modifyTime,
+          ),
+        ),
+      );
+    }
+
+    return items;
+  }
+
+  Future<String> _runAndRead(
+    String innerCommand, {
+    String? password,
+  }) async {
+    final pwd = password ?? await ensurePassword();
+    if (pwd == null) throw const _SftpSudoCancelled();
+
+    final (code, output) = await client.execWithPwd(
+      _buildSudoCommand(innerCommand, pwd),
+      context: context,
+      id: '${spi.id}_sftp_sudo',
+    );
+
+    if (code == 2) {
+      _cachedPassword = null;
+      final retryPwd = await ensurePassword(force: true);
+      if (retryPwd == null) throw const _SftpSudoCancelled();
+
+      final retry = await client.execWithPwd(
+        _buildSudoCommand(innerCommand, retryPwd),
+        context: context,
+        id: '${spi.id}_sftp_sudo',
+      );
+      if (retry.$1 == 2) {
+        _cachedPassword = null;
+        throw Exception('Incorrect sudo password');
+      }
+      if (retry.$1 != 0) {
+        throw Exception(retry.$2.trim().isEmpty ? 'Sudo command failed' : retry.$2.trim());
+      }
+      return retry.$2;
+    }
+
+    if (code != 0) {
+      throw Exception(output.trim().isEmpty ? 'Sudo command failed' : output.trim());
+    }
+    return output;
+  }
+
+  static String _buildSudoCommand(String command, String password) {
+    final pwdBase64 = base64Encode(utf8.encode(password));
+    final wrapped = '($command) 2>&1';
+    final escapedWrapped = wrapped.replaceAll("'", "'\\''");
+    return 'echo "$pwdBase64" | base64 -d | sudo -S -- sh -c \'$escapedWrapped\'';
+  }
+
+  static String _shellQuote(String value) {
+    return "'${value.replaceAll("'", "'\\''")}'";
+  }
+
+  static SftpFileMode _buildMode(String typeChar, int permOct) {
+    final typeFlag = switch (typeChar) {
+      'd' => 0x4000,
+      'l' => 0xA000,
+      'b' => 0x6000,
+      'c' => 0x2000,
+      'p' => 0x1000,
+      's' => 0xC000,
+      _ => 0x8000,
+    };
+    return SftpFileMode.value(typeFlag | permOct);
+  }
+}
+
+final class _SftpSudoCancelled implements Exception {
+  const _SftpSudoCancelled();
+}

--- a/lib/core/utils/sftp_sudo.dart
+++ b/lib/core/utils/sftp_sudo.dart
@@ -9,6 +9,8 @@ import 'package:server_box/core/extension/ssh_client.dart';
 import 'package:server_box/data/model/server/server_private_info.dart';
 import 'package:server_box/data/res/store.dart';
 
+final _octalPermReg = RegExp(r'^[0-7]{3,4}$');
+
 final class SftpSudoHelper {
   final SSHClient client;
   final Spi spi;
@@ -89,6 +91,9 @@ final class SftpSudoHelper {
     String remotePath, {
     String? password,
   }) async {
+    if (!_octalPermReg.hasMatch(perm)) {
+      throw ArgumentError.value(perm, 'perm', 'Permission must be a 3 or 4 digit octal string');
+    }
     await _runAndRead(
       'chmod $perm ${_shellQuote(remotePath)}',
       password: password,
@@ -157,7 +162,7 @@ final class SftpSudoHelper {
       '[ -f "\$path" ] && type=f; '
       'size=\$(stat -c %s "\$path"); '
       'mtime=\$(stat -c %Y "\$path"); '
-      'printf "%s\\t%s\\t%s\\t%s\\t%s\\n" "\$name" "\$perm" "\$type" "\$size" "\$mtime"; '
+      'printf "%s\\0%s\\0%s\\0%s\\0%s\\0" "\$name" "\$perm" "\$type" "\$size" "\$mtime"; '
       'done'
       '\' sh {} +',
       password: password,
@@ -175,17 +180,13 @@ final class SftpSudoHelper {
       ),
     ];
 
-    for (final rawLine in output.split('\n')) {
-      final line = rawLine.trimRight();
-      if (line.isEmpty) continue;
-      final parts = line.split('\t');
-      if (parts.length < 5) continue;
-
-      final filename = parts[0];
-      final permOct = int.tryParse(parts[1], radix: 8) ?? 0x1A4;
-      final typeChar = parts[2];
-      final size = int.tryParse(parts[3]) ?? 0;
-      final modifyTime = double.tryParse(parts[4])?.toInt() ?? 0;
+    final parts = output.split('\u0000').where((e) => e.isNotEmpty).toList();
+    for (var i = 0; i + 4 < parts.length; i += 5) {
+      final filename = parts[i];
+      final permOct = int.tryParse(parts[i + 1], radix: 8) ?? 0x1A4;
+      final typeChar = parts[i + 2];
+      final size = int.tryParse(parts[i + 3]) ?? 0;
+      final modifyTime = double.tryParse(parts[i + 4])?.toInt() ?? 0;
       final mode = _buildMode(typeChar, permOct);
 
       items.add(

--- a/lib/view/page/storage/sftp.dart
+++ b/lib/view/page/storage/sftp.dart
@@ -8,8 +8,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:icons_plus/icons_plus.dart';
 import 'package:server_box/core/extension/context/locale.dart';
 import 'package:server_box/core/extension/sftpfile.dart';
+import 'package:server_box/core/extension/ssh_client.dart';
 import 'package:server_box/core/utils/comparator.dart';
 import 'package:server_box/core/utils/host_key_helper.dart';
+import 'package:server_box/core/utils/sftp_sudo.dart';
 import 'package:server_box/data/model/server/server_private_info.dart';
 import 'package:server_box/data/model/sftp/browser_status.dart';
 import 'package:server_box/data/model/sftp/worker.dart';
@@ -22,6 +24,8 @@ import 'package:server_box/view/page/storage/local.dart';
 import 'package:server_box/view/page/storage/sftp_mission.dart';
 import 'package:server_box/view/widget/omit_start_text.dart';
 import 'package:server_box/view/widget/unix_perm.dart';
+
+final _sftpPermissionDeniedReg = RegExp(r'permission denied', caseSensitive: false);
 
 final class SftpPageArgs {
   final Spi spi;
@@ -45,7 +49,11 @@ class SftpPage extends ConsumerStatefulWidget {
 class _SftpPageState extends ConsumerState<SftpPage> with AfterLayoutMixin {
   late final SftpBrowserStatus _status;
   late final SSHClient _client;
+  late final SftpSudoHelper _sudoHelper;
   final _sortOption = _SortOption().vn;
+  final _sudoMode = false.vn;
+
+  bool get _useSudo => _sudoHelper.enabled && _sudoMode.value;
 
   @override
   void initState() {
@@ -53,12 +61,14 @@ class _SftpPageState extends ConsumerState<SftpPage> with AfterLayoutMixin {
     final serverState = ref.read(serverProvider(widget.args.spi.id));
     _client = serverState.client!;
     _status = SftpBrowserStatus(_client);
+    _sudoHelper = SftpSudoHelper(client: _client, spi: widget.args.spi, context: context);
   }
 
   @override
   void dispose() {
     super.dispose();
     _sortOption.dispose();
+    _sudoMode.dispose();
   }
 
   @override
@@ -67,6 +77,7 @@ class _SftpPageState extends ConsumerState<SftpPage> with AfterLayoutMixin {
       Btn.icon(icon: const Icon(Icons.downloading), onTap: () => SftpMissionPage.route.go(context)),
       _buildSortMenu(),
       _buildSearchBtn(),
+      if (_sudoHelper.enabled) _buildSudoBtn(),
     ];
     if (isDesktop) children.add(_buildRefreshBtn());
 
@@ -168,12 +179,32 @@ extension _UI on _SftpPageState {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            OmitStartText(_status.path.path),
+            _sudoMode.listenVal((enabled) {
+              return Row(
+                children: [
+                  Expanded(child: OmitStartText(_status.path.path)),
+                  if (enabled) ...[
+                    UIs.width7,
+                    Icon(Icons.security, size: 16, color: UIs.primaryColor),
+                  ],
+                ],
+              );
+            }),
             Row(mainAxisAlignment: MainAxisAlignment.spaceAround, children: children),
           ],
         ),
       ),
     );
+  }
+
+  Widget _buildSudoBtn() {
+    return _sudoMode.listenVal((enabled) {
+      return IconButton(
+        tooltip: l10n.trySudo,
+        onPressed: () => _sudoMode.value = !enabled,
+        icon: Icon(Icons.security, color: enabled ? UIs.primaryColor : null),
+      );
+    });
   }
 
   Widget _buildFileView() {
@@ -254,6 +285,120 @@ extension _UI on _SftpPageState {
 }
 
 extension _Actions on _SftpPageState {
+  bool _isPermissionDeniedErr(Object? err) {
+    final msg = '$err'.toLowerCase();
+    return msg.contains('permission denied') ||
+        msg.contains('access denied') ||
+        msg.contains('code 3') ||
+        msg.contains('failure');
+  }
+
+  Future<bool> _askRetryWithSudo() async {
+    if (_useSudo || !_sudoHelper.enabled) return false;
+
+    final retry = await context.showRoundDialog<bool>(
+      title: l10n.trySudo,
+      child: Text('Permission denied.\n${libL10n.askContinue(l10n.trySudo)}'),
+      actions: Btnx.cancelRedOk,
+    );
+    if (retry != true) return false;
+
+    _sudoMode.value = true;
+    return true;
+  }
+
+  Future<void> _runShellCommand(String command) async {
+    final (code, output) = await _client.execWithPwd(
+      command,
+      context: context,
+      id: '${widget.args.spi.id}_sftp_cmd',
+    );
+    if (code != 0) {
+      throw Exception(output.trim().isEmpty ? 'Command failed' : output.trim());
+    }
+  }
+
+  Future<bool> _runWithSudoRetry({
+    required Future<void> Function() normal,
+    required Future<void> Function(String pwd) sudo,
+  }) async {
+    if (_useSudo) {
+      final pwd = await _sudoHelper.ensurePassword();
+      if (pwd == null) return false;
+      final (suc, err) = await context.showLoadingDialog(
+        fn: () async {
+          await sudo(pwd);
+          return true;
+        },
+      );
+      return suc != null && err == null;
+    }
+
+    final (suc, err) = await context.showLoadingDialog(
+      fn: () async {
+        await normal();
+        return true;
+      },
+    );
+    if (suc != null && err == null) return true;
+    if (!_isPermissionDeniedErr(err)) return false;
+
+    final shouldRetry = await _askRetryWithSudo();
+    if (!shouldRetry) return false;
+
+    final pwd = await _sudoHelper.ensurePassword();
+    if (pwd == null) return false;
+    final (sudoSuc, sudoErr) = await context.showLoadingDialog(
+      fn: () async {
+        await sudo(pwd);
+        return true;
+      },
+    );
+    return sudoSuc != null && sudoErr == null;
+  }
+
+  Future<bool> _canWriteRemotePath(String remoteDir) async {
+    final (code, _) = await _client.execWithPwd(
+      'test -w "$remoteDir"',
+      context: context,
+      id: '${widget.args.spi.id}_sftp_write_probe',
+    );
+    return code == 0;
+  }
+
+  Future<bool> _uploadViaSudo({
+    required String localPath,
+    required String remotePath,
+    required String fileName,
+  }) async {
+    final pwd = await _sudoHelper.ensurePassword();
+    if (pwd == null) return false;
+
+    final tmpPath = '/tmp/serverbox-upload-${DateTime.now().microsecondsSinceEpoch}-$fileName';
+    final completer = Completer();
+    final req = SftpReq(widget.args.spi, tmpPath, localPath, SftpReqType.upload);
+    final reqId = ref.read(sftpProvider.notifier).add(req, completer: completer);
+
+    final (uploaded, uploadErr) = await context.showLoadingDialog(
+      fn: () async {
+        await completer.future;
+        final status = ref.read(sftpProvider.notifier).get(reqId);
+        if (status?.error != null) {
+          throw status!.error!;
+        }
+        await _sudoHelper.rename(tmpPath, remotePath, password: pwd);
+        return true;
+      },
+    );
+
+    if (uploaded != null && uploadErr == null) return true;
+
+    try {
+      await _runShellCommand('rm -f "$tmpPath"');
+    } catch (_) {}
+    return false;
+  }
+
   void _onItemPress(SftpName file, bool notDir) {
     final children = [
       ListTile(leading: const Icon(Icons.delete), title: Text(libL10n.delete), onTap: () => _delete(file)),
@@ -282,12 +427,13 @@ extension _Actions on _SftpPageState {
 
           final permStr = newPerm.perm;
           if (ok == true && permStr != perm.perm) {
-            await context.showLoadingDialog(
-              fn: () async {
-                await _client.run('chmod $permStr "${_getRemotePath(file)}"');
-                await _listDir();
-              },
+            final remotePath = _getRemotePath(file);
+            final suc = await _runWithSudoRetry(
+              normal: () => _runShellCommand('chmod $permStr "$remotePath"'),
+              sudo: (pwd) => _sudoHelper.chmod(permStr, remotePath, password: pwd),
             );
+            if (!suc) return;
+            await _listDir();
           }
         },
       ),
@@ -317,46 +463,86 @@ extension _Actions on _SftpPageState {
   Future<void> _edit(SftpName name) async {
     context.pop();
 
+    final remotePath = _getRemotePath(name);
+    final useSudoForEdit = _useSudo;
+
     // #489
     final editor = Stores.setting.sftpEditor.fetch();
     if (editor.isNotEmpty) {
+      final sudoPrefix = useSudoForEdit ? 'sudo ' : '';
       // Use single quote to avoid escape
-      final cmd = "$editor '${_getRemotePath(name)}'";
+      final cmd = "$sudoPrefix$editor '$remotePath'";
       final args = SshPageArgs(spi: widget.args.spi, initCmd: cmd);
       await SSHPage.route.go(context, args);
       await _listDir();
       return;
     }
 
-    final size = name.attr.size;
+    int? size = name.attr.size;
+    if (useSudoForEdit) {
+      final pwd = await _sudoHelper.ensurePassword();
+      if (pwd == null) return;
+      final (ret, err) = await context.showLoadingDialog(
+        fn: () => _sudoHelper.getFileSize(remotePath, password: pwd),
+      );
+      if (ret == null || err != null) return;
+      size = ret;
+    }
+
     if (size == null || size > Miscs.editorMaxSize) {
       context.showSnackBar(l10n.fileTooLarge(name.filename, size ?? 0, Miscs.editorMaxSize));
       return;
     }
 
-    if (!await ensureHostKeyAcceptedForSftp(context, widget.args.spi)) {
-      return;
-    }
-
-    final remotePath = _getRemotePath(name);
     final localPath = _getLocalPath(remotePath);
-    final completer = Completer();
-    final req = SftpReq(widget.args.spi, remotePath, localPath, SftpReqType.download);
-    ref.read(sftpProvider.notifier).add(req, completer: completer);
-    final (suc, err) = await context.showLoadingDialog(fn: () => completer.future);
-    if (suc == null || err != null) return;
+    if (useSudoForEdit) {
+      final pwd = await _sudoHelper.ensurePassword();
+      if (pwd == null) return;
+      final (suc, err) = await context.showLoadingDialog(
+        fn: () async {
+          await _sudoHelper.downloadTextFile(remotePath, localPath, password: pwd);
+          return true;
+        },
+      );
+      if (suc == null || err != null) return;
+    } else {
+      if (!await ensureHostKeyAcceptedForSftp(context, widget.args.spi)) {
+        return;
+      }
+
+      final completer = Completer();
+      final req = SftpReq(widget.args.spi, remotePath, localPath, SftpReqType.download);
+      ref.read(sftpProvider.notifier).add(req, completer: completer);
+      final (suc, err) = await context.showLoadingDialog(fn: () => completer.future);
+      if (suc == null || err != null) return;
+    }
 
     await EditorPage.route.go(
       context,
       args: EditorPageArgs(
         path: localPath,
         onSave: (_) async {
-          if (!await ensureHostKeyAcceptedForSftp(context, req.spi)) {
+          if (useSudoForEdit) {
+            final pwd = await _sudoHelper.ensurePassword();
+            if (pwd == null) return;
+            final (suc, err) = await context.showLoadingDialog(
+              fn: () async {
+                await _sudoHelper.uploadTextFile(localPath, remotePath, password: pwd);
+                return true;
+              },
+            );
+            if (suc == null || err != null) return;
+            if (context.mounted) context.showSnackBar(libL10n.success);
+            await _listDir();
+            return;
+          }
+
+          if (!await ensureHostKeyAcceptedForSftp(context, widget.args.spi)) {
             return;
           }
           ref
               .read(sftpProvider.notifier)
-              .add(SftpReq(req.spi, remotePath, localPath, SftpReqType.upload));
+              .add(SftpReq(widget.args.spi, remotePath, localPath, SftpReqType.upload));
           context.showSnackBar(l10n.added2List);
         },
         closeAfterSave: Stores.setting.closeAfterSave.fetch(),
@@ -438,21 +624,25 @@ extension _Actions on _SftpPageState {
         TextButton(
           onPressed: () async {
             context.pop();
-
-            final (suc, err) = await context.showLoadingDialog(
-              fn: () async {
-                final remotePath = _getRemotePath(file);
+            final remotePath = _getRemotePath(file);
+            final suc = await _runWithSudoRetry(
+              normal: () async {
                 if (useRmr) {
-                  await _client.run('rm -r "$remotePath"');
+                  await _runShellCommand('rm -r "$remotePath"');
                 } else if (file.attr.isDirectory) {
                   await _status.client!.rmdir(remotePath);
                 } else {
                   await _status.client!.remove(remotePath);
                 }
-                return true;
               },
+              sudo: (pwd) => _sudoHelper.delete(
+                remotePath,
+                isDir: file.attr.isDirectory,
+                recursive: useRmr,
+                password: pwd,
+              ),
             );
-            if (suc == null || err != null) return;
+            if (!suc) return;
 
             _listDir();
           },
@@ -473,15 +663,12 @@ extension _Actions on _SftpPageState {
         return;
       }
       context.pop();
-
-      final (suc, err) = await context.showLoadingDialog(
-        fn: () async {
-          final dir = '${_status.path.path}/$text';
-          await _status.client!.mkdir(dir);
-          return true;
-        },
+      final dir = '${_status.path.path}/$text';
+      final suc = await _runWithSudoRetry(
+        normal: () => _status.client!.mkdir(dir),
+        sudo: (pwd) => _sudoHelper.mkdir(dir, password: pwd),
       );
-      if (suc == null || err != null) return;
+      if (!suc) return;
 
       _listDir();
     }
@@ -511,15 +698,12 @@ extension _Actions on _SftpPageState {
         return;
       }
       context.pop();
-
-      final (suc, err) = await context.showLoadingDialog(
-        fn: () async {
-          final path = '${_status.path.path}/$text';
-          await _client.run('touch "$path"');
-          return true;
-        },
+      final path = '${_status.path.path}/$text';
+      final suc = await _runWithSudoRetry(
+        normal: () => _runShellCommand('touch "$path"'),
+        sudo: (pwd) => _sudoHelper.touch(path, password: pwd),
       );
-      if (suc == null || err != null) return;
+      if (!suc) return;
 
       _listDir();
     }
@@ -549,15 +733,16 @@ extension _Actions on _SftpPageState {
         return;
       }
       context.pop();
-
-      final (suc, err) = await context.showLoadingDialog(
-        fn: () async {
-          final newName = textController.text;
-          await _status.client?.rename(file.filename, newName);
-          return true;
-        },
+      final newName = textController.text;
+      final suc = await _runWithSudoRetry(
+        normal: () => _status.client!.rename(file.filename, newName),
+        sudo: (pwd) => _sudoHelper.rename(
+          _getRemotePath(file),
+          _status.path.path.joinPath(newName, separator: '/'),
+          password: pwd,
+        ),
       );
-      if (suc == null || err != null) return;
+      if (!suc) return;
 
       _listDir();
     }
@@ -623,9 +808,8 @@ extension _Actions on _SftpPageState {
   Future<bool?> _listDir() async {
     final (ret, err) = await context.showLoadingDialog(
       fn: () async {
-        _status.client ??= await _client.sftp();
         final listPath = _status.path.path;
-        final fs = await _status.client?.listdir(listPath);
+        final fs = await _listDirWithFallback(listPath);
         if (fs == null) {
           return false;
         }
@@ -662,6 +846,28 @@ extension _Actions on _SftpPageState {
       barrierDismiss: true,
     );
     return ret ?? err == null;
+  }
+
+  Future<List<SftpName>?> _listDirWithFallback(String listPath) async {
+    if (_useSudo) {
+      final pwd = await _sudoHelper.ensurePassword();
+      if (pwd == null) return null;
+      return _sudoHelper.listDir(listPath, password: pwd);
+    }
+
+    try {
+      _status.client ??= await _client.sftp();
+      return await _status.client?.listdir(listPath);
+    } on SftpStatusError catch (e) {
+      final canFallback = _sudoHelper.enabled &&
+          (e.code == 3 || _sftpPermissionDeniedReg.hasMatch(e.message));
+      if (!canFallback) rethrow;
+
+      final pwd = await _sudoHelper.ensurePassword();
+      if (pwd == null) return null;
+      _sudoMode.value = true;
+      return _sudoHelper.listDir(listPath, password: pwd);
+    }
   }
 
   Future<void> _backward() async {
@@ -718,14 +924,32 @@ extension _Actions on _SftpPageState {
 
         final remoteDir = _status.path.path;
         final fileName = path.split(Platform.pathSeparator).lastOrNull;
+        if (fileName == null || fileName.isEmpty) return;
         final remotePath = '$remoteDir/$fileName';
         Loggers.app.info('SFTP upload local: $path, remote: $remotePath');
         if (!await ensureHostKeyAcceptedForSftp(context, widget.args.spi)) {
           return;
         }
-        ref
-            .read(sftpProvider.notifier)
-            .add(SftpReq(widget.args.spi, remotePath, path, SftpReqType.upload));
+
+        if (_useSudo) {
+          await _uploadViaSudo(localPath: path, remotePath: remotePath, fileName: fileName);
+          await _listDir();
+          return;
+        }
+
+        final writable = await _canWriteRemotePath(remoteDir);
+        if (!writable) {
+          final shouldRetry = await _askRetryWithSudo();
+          if (shouldRetry) {
+            final suc = await _uploadViaSudo(localPath: path, remotePath: remotePath, fileName: fileName);
+            if (suc) {
+              await _listDir();
+            }
+          }
+          return;
+        }
+
+        ref.read(sftpProvider.notifier).add(SftpReq(widget.args.spi, remotePath, path, SftpReqType.upload));
       },
       icon: const Icon(Icons.upload_file),
     );

--- a/lib/view/page/storage/sftp.dart
+++ b/lib/view/page/storage/sftp.dart
@@ -285,6 +285,10 @@ extension _UI on _SftpPageState {
 }
 
 extension _Actions on _SftpPageState {
+  String _shellQuote(String value) {
+    return "'${value.replaceAll("'", "'\\''")}'";
+  }
+
   bool _isPermissionDeniedErr(Object? err) {
     final msg = '$err'.toLowerCase();
     return msg.contains('permission denied') ||
@@ -301,10 +305,7 @@ extension _Actions on _SftpPageState {
       child: Text('Permission denied.\n${libL10n.askContinue(l10n.trySudo)}'),
       actions: Btnx.cancelRedOk,
     );
-    if (retry != true) return false;
-
-    _sudoMode.value = true;
-    return true;
+    return retry == true;
   }
 
   Future<void> _runShellCommand(String command) async {
@@ -354,12 +355,15 @@ extension _Actions on _SftpPageState {
         return true;
       },
     );
+    if (sudoSuc != null && sudoErr == null) {
+      _sudoMode.value = true;
+    }
     return sudoSuc != null && sudoErr == null;
   }
 
   Future<bool> _canWriteRemotePath(String remoteDir) async {
     final (code, _) = await _client.execWithPwd(
-      'test -w "$remoteDir"',
+      'test -w ${_shellQuote(remoteDir)}',
       context: context,
       id: '${widget.args.spi.id}_sftp_write_probe',
     );
@@ -391,10 +395,13 @@ extension _Actions on _SftpPageState {
       },
     );
 
-    if (uploaded != null && uploadErr == null) return true;
+    if (uploaded != null && uploadErr == null) {
+      _sudoMode.value = true;
+      return true;
+    }
 
     try {
-      await _runShellCommand('rm -f "$tmpPath"');
+      await _runShellCommand('rm -f ${_shellQuote(tmpPath)}');
     } catch (_) {}
     return false;
   }
@@ -429,7 +436,9 @@ extension _Actions on _SftpPageState {
           if (ok == true && permStr != perm.perm) {
             final remotePath = _getRemotePath(file);
             final suc = await _runWithSudoRetry(
-              normal: () => _runShellCommand('chmod $permStr "$remotePath"'),
+              normal: () => _runShellCommand(
+                'chmod ${_shellQuote(permStr)} ${_shellQuote(remotePath)}',
+              ),
               sudo: (pwd) => _sudoHelper.chmod(permStr, remotePath, password: pwd),
             );
             if (!suc) return;
@@ -628,7 +637,7 @@ extension _Actions on _SftpPageState {
             final suc = await _runWithSudoRetry(
               normal: () async {
                 if (useRmr) {
-                  await _runShellCommand('rm -r "$remotePath"');
+                  await _runShellCommand('rm -r ${_shellQuote(remotePath)}');
                 } else if (file.attr.isDirectory) {
                   await _status.client!.rmdir(remotePath);
                 } else {
@@ -700,7 +709,7 @@ extension _Actions on _SftpPageState {
       context.pop();
       final path = '${_status.path.path}/$text';
       final suc = await _runWithSudoRetry(
-        normal: () => _runShellCommand('touch "$path"'),
+        normal: () => _runShellCommand('touch ${_shellQuote(path)}'),
         sudo: (pwd) => _sudoHelper.touch(path, password: pwd),
       );
       if (!suc) return;
@@ -852,7 +861,9 @@ extension _Actions on _SftpPageState {
     if (_useSudo) {
       final pwd = await _sudoHelper.ensurePassword();
       if (pwd == null) return null;
-      return _sudoHelper.listDir(listPath, password: pwd);
+      final items = await _sudoHelper.listDir(listPath, password: pwd);
+      _sudoMode.value = true;
+      return items;
     }
 
     try {
@@ -865,8 +876,9 @@ extension _Actions on _SftpPageState {
 
       final pwd = await _sudoHelper.ensurePassword();
       if (pwd == null) return null;
+      final items = await _sudoHelper.listDir(listPath, password: pwd);
       _sudoMode.value = true;
-      return _sudoHelper.listDir(listPath, password: pwd);
+      return items;
     }
   }
 


### PR DESCRIPTION
Solve one part mentioned in #277.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sudo-enabled SFTP: perform uploads, downloads, edits, deletes, chmod, mkdir, touch, rename with elevated privileges.
  * UI toggle and visual indicator for sudo mode; password prompt with optional in-memory caching.

* **Improvements**
  * Automatic retry/fallback to sudo on permission errors.
  * Safer upload via temporary remote path and retry prompts when sudo is required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->