### PR TITLE
fix: Use persistent shell sessions to avoid duplicate session creation

### DIFF
--- a/lib/data/provider/server/single.dart
+++ b/lib/data/provider/server/single.dart
@@ -22,6 +22,7 @@ import 'package:server_box/data/model/server/try_limiter.dart';
 import 'package:server_box/data/provider/server/all.dart';
 import 'package:server_box/data/res/status.dart';
 import 'package:server_box/data/res/store.dart';
+import 'package:server_box/data/ssh/persistent_shell.dart';
 import 'package:server_box/data/ssh/session_manager.dart';
 
 part 'single.g.dart';
@@ -41,8 +42,14 @@ abstract class ServerState with _$ServerState {
 // Individual server state management
 @Riverpod(keepAlive: true)
 class ServerNotifier extends _$ServerNotifier {
+  PersistentShell? _persistentShell;
+
   @override
   ServerState build(String serverId) {
+    ref.onDispose(() {
+      unawaited(_disposePersistentShell());
+    });
+
     final serverNotifier = ref.read(serversProvider);
     final spi = serverNotifier.servers[serverId];
     if (spi == null) {
@@ -93,6 +100,9 @@ class ServerNotifier extends _$ServerNotifier {
 
   // Update SSH client
   void updateClient(SSHClient? client) {
+    if (!identical(state.client, client)) {
+      unawaited(_disposePersistentShell());
+    }
     state = state.copyWith(client: client);
   }
 
@@ -103,6 +113,7 @@ class ServerNotifier extends _$ServerNotifier {
 
   void _setFailedState(ServerStatus status, {bool closeClient = false}) {
     final client = state.client;
+    unawaited(_disposePersistentShell());
     if (closeClient) {
       client?.close();
     }
@@ -115,6 +126,7 @@ class ServerNotifier extends _$ServerNotifier {
 
   // Close connection
   void closeConnection() {
+    unawaited(_disposePersistentShell());
     state.client?.close();
     state = state.copyWith(client: null, conn: ServerConn.disconnected);
   }
@@ -148,10 +160,15 @@ class ServerNotifier extends _$ServerNotifier {
       return;
     }
 
-    final newStatus = _copyStatus(state.status, err: null, setErr: true); // Clear previous error
+    final newStatus = _copyStatus(
+      state.status,
+      err: null,
+      setErr: true,
+    ); // Clear previous error
     updateStatus(newStatus);
 
-    if (state.conn < ServerConn.connecting || (state.client?.isClosed ?? true)) {
+    if (state.conn < ServerConn.connecting ||
+        (state.client?.isClosed ?? true)) {
       updateConnection(ServerConn.connecting);
 
       // Wake on LAN
@@ -182,13 +199,15 @@ class ServerNotifier extends _$ServerNotifier {
         }
 
         try {
-          await Stores.connectionStats.recordConnection(ConnectionStat(
-            serverId: spi.id,
-            serverName: spi.name,
-            timestamp: time1,
-            result: ConnectionResult.success,
-            durationMs: spentTime,
-          ));
+          await Stores.connectionStats.recordConnection(
+            ConnectionStat(
+              serverId: spi.id,
+              serverName: spi.name,
+              timestamp: time1,
+              result: ConnectionResult.success,
+              durationMs: spentTime,
+            ),
+          );
         } catch (e) {
           Loggers.app.warning('Failed to record connection success', e);
         }
@@ -198,7 +217,8 @@ class ServerNotifier extends _$ServerNotifier {
           id: sessionId,
           spi: spi,
           startTimeMs: time1.millisecondsSinceEpoch,
-          disconnect: () => ref.read(serversProvider.notifier).closeOneServer(spi.id),
+          disconnect: () =>
+              ref.read(serversProvider.notifier).closeOneServer(spi.id),
           status: TermSessionStatus.connecting,
           setAsActive: false,
         );
@@ -212,23 +232,31 @@ class ServerNotifier extends _$ServerNotifier {
         final errStr = e.toString().toLowerCase();
         if (errStr.contains('timed out') || errStr.contains('timeout')) {
           failureResult = ConnectionResult.timeout;
-        } else if (errStr.contains('auth') || errStr.contains('authentication') || errStr.contains('permission denied') || errStr.contains('access denied')) {
+        } else if (errStr.contains('auth') ||
+            errStr.contains('authentication') ||
+            errStr.contains('permission denied') ||
+            errStr.contains('access denied')) {
           failureResult = ConnectionResult.authFailed;
-        } else if (errStr.contains('connection refused') || errStr.contains('no route to host') || errStr.contains('network') || errStr.contains('socket')) {
+        } else if (errStr.contains('connection refused') ||
+            errStr.contains('no route to host') ||
+            errStr.contains('network') ||
+            errStr.contains('socket')) {
           failureResult = ConnectionResult.networkError;
         } else {
           failureResult = ConnectionResult.unknownError;
         }
 
         try {
-          await Stores.connectionStats.recordConnection(ConnectionStat(
-            serverId: spi.id,
-            serverName: spi.name,
-            timestamp: time1,
-            result: failureResult,
-            errorMessage: e.toString(),
-            durationMs: durationMs,
-          ));
+          await Stores.connectionStats.recordConnection(
+            ConnectionStat(
+              serverId: spi.id,
+              serverName: spi.name,
+              timestamp: time1,
+              result: failureResult,
+              errorMessage: e.toString(),
+              durationMs: durationMs,
+            ),
+          );
         } catch (recErr) {
           Loggers.app.warning('Failed to record connection failure', recErr);
         }
@@ -256,12 +284,17 @@ class ServerNotifier extends _$ServerNotifier {
 
       try {
         // Detect system type
-        final detectedSystemType = await SystemDetector.detect(state.client!, spi);
+        final detectedSystemType = await SystemDetector.detect(
+          state.client!,
+          spi,
+        );
         final newStatus = _copyStatus(state.status, system: detectedSystemType);
         updateStatus(newStatus);
 
-        Loggers.app.info('Writing script for ${spi.name} (${detectedSystemType.name})');
-        
+        Loggers.app.info(
+          'Writing script for ${spi.name} (${detectedSystemType.name})',
+        );
+
         final (stdoutResult, writeScriptResult) = await state.client!.execSafe(
           (session) async {
             final scriptRaw = ShellFuncManager.allScript(
@@ -280,15 +313,22 @@ class ServerNotifier extends _$ServerNotifier {
           systemType: detectedSystemType,
           context: 'WriteScript<${spi.name}>',
         );
-        
+
         if (stdoutResult.isNotEmpty) {
-          Loggers.app.info('Script write stdout for ${spi.name}: $stdoutResult');
+          Loggers.app.info(
+            'Script write stdout for ${spi.name}: $stdoutResult',
+          );
         }
-        
+
         if (writeScriptResult.isNotEmpty) {
-          Loggers.app.warning('Script write stderr for ${spi.name}: $writeScriptResult');
+          Loggers.app.warning(
+            'Script write stderr for ${spi.name}: $writeScriptResult',
+          );
           if (detectedSystemType != SystemType.windows) {
-            ShellFuncManager.switchScriptDir(spi.id, systemType: detectedSystemType);
+            ShellFuncManager.switchScriptDir(
+              spi.id,
+              systemType: detectedSystemType,
+            );
             throw writeScriptResult;
           }
         } else {
@@ -302,7 +342,10 @@ class ServerNotifier extends _$ServerNotifier {
         _setFailedState(newStatus, closeClient: true);
 
         final sessionId = 'ssh_${spi.id}';
-        TermSessionManager.updateStatus(sessionId, TermSessionStatus.disconnected);
+        TermSessionManager.updateStatus(
+          sessionId,
+          TermSessionStatus.disconnected,
+        );
         return;
       } on SSHAuthFailError catch (e) {
         TryLimiter.inc(sid);
@@ -312,7 +355,10 @@ class ServerNotifier extends _$ServerNotifier {
         _setFailedState(newStatus, closeClient: true);
 
         final sessionId = 'ssh_${spi.id}';
-        TermSessionManager.updateStatus(sessionId, TermSessionStatus.disconnected);
+        TermSessionManager.updateStatus(
+          sessionId,
+          TermSessionStatus.disconnected,
+        );
         return;
       } catch (e) {
         final err = SSHErr(type: SSHErrType.writeScript, message: e.toString());
@@ -321,7 +367,10 @@ class ServerNotifier extends _$ServerNotifier {
         _setFailedState(newStatus, closeClient: true);
 
         final sessionId = 'ssh_${spi.id}';
-        TermSessionManager.updateStatus(sessionId, TermSessionStatus.disconnected);
+        TermSessionManager.updateStatus(
+          sessionId,
+          TermSessionStatus.disconnected,
+        );
         return;
       }
     }
@@ -337,36 +386,54 @@ class ServerNotifier extends _$ServerNotifier {
     String? raw;
 
     try {
-      final statusCmd = ShellFunc.status.exec(spi.id, systemType: state.status.system, customDir: spi.custom?.scriptDir);
+      final statusCmd = ShellFunc.status.exec(
+        spi.id,
+        systemType: state.status.system,
+        customDir: spi.custom?.scriptDir,
+      );
       // Loggers.app.info('Running status command for ${spi.name} (${state.status.system.name}): $statusCmd');
-      final execResult = await state.client?.run(statusCmd);
-      if (execResult != null) {
-        raw = SSHDecoder.decode(
-          execResult,
-          isWindows: state.status.system == SystemType.windows,
-          context: 'GetStatus<${spi.name}>',
-        );
-        // Loggers.app.info('Status response length for ${spi.name}: ${raw.length} bytes');
+      if (state.status.system == SystemType.windows) {
+        final execResult = await state.client?.run(statusCmd);
+        if (execResult != null) {
+          raw = SSHDecoder.decode(
+            execResult,
+            isWindows: true,
+            context: 'GetStatus<${spi.name}>',
+          );
+        } else {
+          raw = '';
+          Loggers.app.warning('No status result from ${spi.name}');
+        }
       } else {
-        raw = '';
-        Loggers.app.warning('No status result from ${spi.name}');
+        final shell = await _getPersistentShell();
+        final result = await shell.run(statusCmd);
+        raw = result.output;
       }
 
       if (raw.isEmpty) {
         TryLimiter.inc(sid);
         final newStatus = _copyStatus(
           state.status,
-          err: SSHErr(type: SSHErrType.segements, message: 'Empty response from server'),
+          err: SSHErr(
+            type: SSHErrType.segements,
+            message: 'Empty response from server',
+          ),
           setErr: true,
         );
         _setFailedState(newStatus);
 
         final sessionId = 'ssh_${spi.id}';
-        TermSessionManager.updateStatus(sessionId, TermSessionStatus.disconnected);
+        TermSessionManager.updateStatus(
+          sessionId,
+          TermSessionStatus.disconnected,
+        );
         return;
       }
 
-      segments = raw.split(ScriptConstants.separator).map((e) => e.trim()).toList();
+      segments = raw
+          .split(ScriptConstants.separator)
+          .map((e) => e.trim())
+          .toList();
       if (segments.isEmpty) {
         if (Stores.setting.keepStatusWhenErr.fetch()) {
           // Keep previous server status when error occurs
@@ -377,13 +444,19 @@ class ServerNotifier extends _$ServerNotifier {
         TryLimiter.inc(sid);
         final newStatus = _copyStatus(
           state.status,
-          err: SSHErr(type: SSHErrType.segements, message: 'Separate segments failed, raw:\n$raw'),
+          err: SSHErr(
+            type: SSHErrType.segements,
+            message: 'Separate segments failed, raw:\n$raw',
+          ),
           setErr: true,
         );
         _setFailedState(newStatus);
 
         final sessionId = 'ssh_${spi.id}';
-        TermSessionManager.updateStatus(sessionId, TermSessionStatus.disconnected);
+        TermSessionManager.updateStatus(
+          sessionId,
+          TermSessionStatus.disconnected,
+        );
         return;
       }
     } catch (e) {
@@ -397,7 +470,10 @@ class ServerNotifier extends _$ServerNotifier {
       Loggers.app.warning('Get status from ${spi.name} failed', e);
 
       final sessionId = 'ssh_${spi.id}';
-      TermSessionManager.updateStatus(sessionId, TermSessionStatus.disconnected);
+      TermSessionManager.updateStatus(
+        sessionId,
+        TermSessionStatus.disconnected,
+      );
       return;
     }
 
@@ -412,20 +488,30 @@ class ServerNotifier extends _$ServerNotifier {
         customCmds: spi.custom?.cmds ?? {},
         tempDivisor: spi.custom?.tempIsCelsius == true ? 1.0 : 1000.0,
       );
-      final newStatus = await Computer.shared.start(getStatus, req, taskName: 'StatusUpdateReq<${spi.id}>');
+      final newStatus = await Computer.shared.start(
+        getStatus,
+        req,
+        taskName: 'StatusUpdateReq<${spi.id}>',
+      );
       updateStatus(newStatus);
     } catch (e, trace) {
       TryLimiter.inc(sid);
       final newStatus = _copyStatus(
         state.status,
-        err: SSHErr(type: SSHErrType.getStatus, message: 'Parse failed: $e\n\n$raw'),
+        err: SSHErr(
+          type: SSHErrType.getStatus,
+          message: 'Parse failed: $e\n\n$raw',
+        ),
         setErr: true,
       );
       _setFailedState(newStatus);
       Loggers.app.warning('Server status', e, trace);
 
       final sessionId = 'ssh_${spi.id}';
-      TermSessionManager.updateStatus(sessionId, TermSessionStatus.disconnected);
+      TermSessionManager.updateStatus(
+        sessionId,
+        TermSessionStatus.disconnected,
+      );
       return;
     }
 
@@ -433,6 +519,28 @@ class ServerNotifier extends _$ServerNotifier {
     updateConnection(ServerConn.finished);
     // Reset retry count only after successful preparation
     TryLimiter.reset(sid);
+  }
+
+  Future<PersistentShell> _getPersistentShell() async {
+    final client = state.client;
+    if (client == null) {
+      throw StateError('SSH client is not connected');
+    }
+
+    final shell = _persistentShell;
+    if (shell != null) {
+      return shell;
+    }
+
+    final newShell = PersistentShell(client);
+    _persistentShell = newShell;
+    return newShell;
+  }
+
+  Future<void> _disposePersistentShell() async {
+    final shell = _persistentShell;
+    _persistentShell = null;
+    await shell?.close();
   }
 }
 

--- a/lib/data/provider/server/single.dart
+++ b/lib/data/provider/server/single.dart
@@ -406,7 +406,11 @@ class ServerNotifier extends _$ServerNotifier {
         }
       } else {
         final shell = await _getPersistentShell();
-        final result = await shell.run(statusCmd);
+        final statusTimeoutSeconds = Stores.setting.timeout.fetch();
+        final statusTimeout = Duration(
+          seconds: statusTimeoutSeconds <= 0 ? 5 : statusTimeoutSeconds,
+        );
+        final result = await shell.run(statusCmd, timeout: statusTimeout);
         raw = result.output;
       }
 

--- a/lib/data/res/github_id.dart
+++ b/lib/data/res/github_id.dart
@@ -167,7 +167,8 @@ abstract final class GithubIds {
     'uniquePWD',
     'ChirmyRam',
     'Utaoki-henji',
-    'smtdev'
+    'smtdev',
+    'tetsuya-ops'
   };
 }
 

--- a/lib/data/ssh/persistent_shell.dart
+++ b/lib/data/ssh/persistent_shell.dart
@@ -103,7 +103,10 @@ final class PersistentShell {
       } catch (error, stackTrace) {
         _pending = null;
         _pendingCommandId = null;
-        completer.completeError(error, stackTrace);
+        await _disposeSession();
+        return _StartedCommand(
+          Future<PersistentShellCommandResult>.error(error, stackTrace),
+        );
       }
 
       return _StartedCommand(completer.future);
@@ -115,27 +118,9 @@ final class PersistentShell {
   Future<void> close() async {
     _closed = true;
     await _withStateLock(() async {
-      final session = _session;
-      _session = null;
-
-      await _stdoutSub?.cancel();
-      await _stderrSub?.cancel();
-      _stdoutSub = null;
-      _stderrSub = null;
-
-      if (session != null) {
-        try {
-          session.close();
-        } catch (error, stackTrace) {
-          Loggers.app.warning(
-            'Failed to close persistent shell',
-            error,
-            stackTrace,
-          );
-        }
-      }
-
-      _failPending(StateError('Persistent shell closed'));
+      await _disposeSession(
+        pendingError: StateError('Persistent shell closed'),
+      );
     });
   }
 
@@ -228,26 +213,59 @@ printf '\\n$_donePrefix$commandId:%s\\n' "\$__server_box_exit"
   }
 
   void _handleStreamDone() {
-    _session = null;
-    _stdoutSub = null;
-    _stderrSub = null;
-    _failPending(StateError('Persistent shell session ended unexpectedly'));
+    unawaited(
+      _disposeSession(
+        pendingError: StateError('Persistent shell session ended unexpectedly'),
+      ),
+    );
   }
 
   void _handleStreamError(Object error, StackTrace stackTrace) {
     Loggers.app.warning('Persistent shell stream error', error, stackTrace);
-    _session = null;
-    _failPending(error, stackTrace);
+    unawaited(
+      _disposeSession(pendingError: error, pendingStackTrace: stackTrace),
+    );
   }
 
-  void _failPending(Object error, [StackTrace? stackTrace]) {
+  Future<void> _disposeSession({
+    Object? pendingError,
+    StackTrace? pendingStackTrace,
+  }) async {
+    final session = _session;
+    final stdoutSub = _stdoutSub;
+    final stderrSub = _stderrSub;
     final pending = _pending;
+
+    _session = null;
+    _stdoutSub = null;
+    _stderrSub = null;
     _pending = null;
     _pendingCommandId = null;
+
     if (pending != null && !pending.isCompleted) {
-      pending.completeError(error, stackTrace ?? StackTrace.current);
+      if (pendingError != null) {
+        pending.completeError(
+          pendingError,
+          pendingStackTrace ?? StackTrace.current,
+        );
+      }
     }
     _buffer.clear();
+
+    await stdoutSub?.cancel();
+    await stderrSub?.cancel();
+
+    if (session != null) {
+      try {
+        session.close();
+      } catch (error, stackTrace) {
+        Loggers.app.warning(
+          'Failed to close persistent shell',
+          error,
+          stackTrace,
+        );
+      }
+    }
   }
 
   static PersistentShellCommandResult? tryParseCompletedOutput(

--- a/lib/data/ssh/persistent_shell.dart
+++ b/lib/data/ssh/persistent_shell.dart
@@ -1,0 +1,230 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:fl_lib/fl_lib.dart';
+
+final class PersistentShellCommandResult {
+  final String output;
+  final int? exitCode;
+
+  const PersistentShellCommandResult({
+    required this.output,
+    required this.exitCode,
+  });
+}
+
+abstract interface class PersistentShellSession {
+  StreamSink<Uint8List> get stdin;
+  Stream<Uint8List> get stdout;
+  Stream<Uint8List> get stderr;
+
+  void close();
+}
+
+final class SshPersistentShellSession implements PersistentShellSession {
+  final SSHSession _session;
+
+  SshPersistentShellSession(this._session);
+
+  @override
+  StreamSink<Uint8List> get stdin => _session.stdin;
+
+  @override
+  Stream<Uint8List> get stdout => _session.stdout;
+
+  @override
+  Stream<Uint8List> get stderr => _session.stderr;
+
+  @override
+  void close() {
+    _session.close();
+  }
+}
+
+final class PersistentShell {
+  PersistentShell(
+    SSHClient? client, {
+    Future<PersistentShellSession> Function()? sessionFactory,
+  }) : _client = client,
+       _sessionFactory = sessionFactory,
+       assert(
+         client != null || sessionFactory != null,
+         'Either client or sessionFactory must be provided',
+       );
+
+  final SSHClient? _client;
+  final Future<PersistentShellSession> Function()? _sessionFactory;
+
+  PersistentShellSession? _session;
+  StreamSubscription<String>? _stdoutSub;
+  StreamSubscription<String>? _stderrSub;
+  Completer<PersistentShellCommandResult>? _pending;
+  final StringBuffer _buffer = StringBuffer();
+  int _commandId = 0;
+  bool _closed = false;
+
+  static const _donePrefix = '__SERVER_BOX_DONE__';
+
+  Future<PersistentShellCommandResult> run(String command) async {
+    if (_closed) {
+      throw StateError('Persistent shell already closed');
+    }
+    if (_pending != null) {
+      throw StateError(
+        'Another command is already running in the persistent shell',
+      );
+    }
+
+    await _ensureSession();
+
+    final completer = Completer<PersistentShellCommandResult>();
+    _pending = completer;
+    _buffer.clear();
+    final commandId = (++_commandId).toString();
+    final wrappedCommand = _wrapCommand(command, commandId);
+
+    try {
+      _session!.stdin.add(Uint8List.fromList(utf8.encode(wrappedCommand)));
+    } catch (error, stackTrace) {
+      _pending = null;
+      completer.completeError(error, stackTrace);
+    }
+
+    return completer.future;
+  }
+
+  Future<void> close() async {
+    _closed = true;
+    final session = _session;
+    _session = null;
+
+    await _stdoutSub?.cancel();
+    await _stderrSub?.cancel();
+    _stdoutSub = null;
+    _stderrSub = null;
+
+    if (session != null) {
+      try {
+        session.close();
+      } catch (error, stackTrace) {
+        Loggers.app.warning(
+          'Failed to close persistent shell',
+          error,
+          stackTrace,
+        );
+      }
+    }
+
+    _failPending(StateError('Persistent shell closed'));
+  }
+
+  Future<void> _ensureSession() async {
+    if (_session != null) {
+      return;
+    }
+
+    final session =
+        await _sessionFactory?.call() ??
+        SshPersistentShellSession(await _client!.execute('sh'));
+    _session = session;
+
+    _stdoutSub = session.stdout
+        .cast<List<int>>()
+        .transform(const Utf8Decoder())
+        .listen(
+          _handleStdout,
+          onError: _handleStreamError,
+          onDone: _handleStreamDone,
+        );
+
+    _stderrSub = session.stderr
+        .cast<List<int>>()
+        .transform(const Utf8Decoder())
+        .listen(
+          _handleStderr,
+          onError: _handleStreamError,
+          onDone: _handleStreamDone,
+        );
+  }
+
+  String _wrapCommand(String command, String commandId) {
+    return '''
+(
+$command
+) 2>&1
+__server_box_exit=\$?
+printf '\\n$_donePrefix$commandId:%s\\n' "\$__server_box_exit"
+''';
+  }
+
+  void _handleStdout(String data) {
+    final pending = _pending;
+    if (pending == null) {
+      return;
+    }
+
+    _buffer.write(data);
+    final parsed = tryParseCompletedOutput(_buffer.toString());
+    if (parsed == null) {
+      return;
+    }
+
+    _pending = null;
+    pending.complete(
+      PersistentShellCommandResult(
+        output: parsed.output,
+        exitCode: parsed.exitCode,
+      ),
+    );
+    _buffer.clear();
+  }
+
+  void _handleStderr(String data) {
+    final pending = _pending;
+    if (pending == null) {
+      return;
+    }
+
+    _buffer.write(data);
+  }
+
+  void _handleStreamDone() {
+    _session = null;
+    _stdoutSub = null;
+    _stderrSub = null;
+    _failPending(StateError('Persistent shell session ended unexpectedly'));
+  }
+
+  void _handleStreamError(Object error, StackTrace stackTrace) {
+    Loggers.app.warning('Persistent shell stream error', error, stackTrace);
+    _session = null;
+    _failPending(error, stackTrace);
+  }
+
+  void _failPending(Object error, [StackTrace? stackTrace]) {
+    final pending = _pending;
+    _pending = null;
+    if (pending != null && !pending.isCompleted) {
+      pending.completeError(error, stackTrace ?? StackTrace.current);
+    }
+    _buffer.clear();
+  }
+
+  static PersistentShellCommandResult? tryParseCompletedOutput(String raw) {
+    final match = RegExp(
+      '(?:^|\\n)${RegExp.escape(_donePrefix)}(\\d+):(\\d+)(?:\\r?\\n|\$)',
+    ).firstMatch(raw);
+    if (match == null) {
+      return null;
+    }
+
+    final output = raw.substring(0, match.start);
+    final exitCode = int.tryParse(match.group(2)!);
+    return PersistentShellCommandResult(
+      output: output.trimRight(),
+      exitCode: exitCode,
+    );
+  }
+}

--- a/lib/data/ssh/persistent_shell.dart
+++ b/lib/data/ssh/persistent_shell.dart
@@ -69,7 +69,10 @@ final class PersistentShell {
 
   static const _donePrefix = '__SERVER_BOX_DONE__';
 
-  Future<PersistentShellCommandResult> run(String command) async {
+  Future<PersistentShellCommandResult> run(
+    String command, {
+    Duration? timeout,
+  }) async {
     final started = await _withStateLock(() async {
       if (_closed) {
         throw StateError('Persistent shell already closed');
@@ -106,13 +109,31 @@ final class PersistentShell {
         await _disposeSession();
         return _StartedCommand(
           Future<PersistentShellCommandResult>.error(error, stackTrace),
+          commandId,
         );
       }
 
-      return _StartedCommand(completer.future);
+      return _StartedCommand(completer.future, commandId);
     });
 
-    return started.future;
+    if (timeout == null) {
+      return started.future;
+    }
+
+    try {
+      return await started.future.timeout(timeout);
+    } on TimeoutException {
+      final error = TimeoutException(
+        'Persistent shell command timed out',
+        timeout,
+      );
+      await _withStateLock(() async {
+        if (_pendingCommandId == started.commandId) {
+          await _disposeSession(pendingError: error);
+        }
+      });
+      throw error;
+    }
   }
 
   Future<void> close() async {
@@ -142,7 +163,7 @@ final class PersistentShell {
 
     _stdoutSub = session.stdout
         .cast<List<int>>()
-        .transform(const Utf8Decoder())
+        .transform(const Utf8Decoder(allowMalformed: true))
         .listen(
           _handleStdout,
           onError: _handleStreamError,
@@ -151,7 +172,7 @@ final class PersistentShell {
 
     _stderrSub = session.stderr
         .cast<List<int>>()
-        .transform(const Utf8Decoder())
+        .transform(const Utf8Decoder(allowMalformed: true))
         .listen(
           _handleStderr,
           onError: _handleStreamError,
@@ -243,12 +264,10 @@ printf '\\n$_donePrefix$commandId:%s\\n' "\$__server_box_exit"
     _pendingCommandId = null;
 
     if (pending != null && !pending.isCompleted) {
-      if (pendingError != null) {
-        pending.completeError(
-          pendingError,
-          pendingStackTrace ?? StackTrace.current,
-        );
-      }
+      pending.completeError(
+        pendingError ?? StateError('Persistent shell session disposed'),
+        pendingStackTrace ?? StackTrace.current,
+      );
     }
     _buffer.clear();
 
@@ -325,6 +344,7 @@ final class _ParsedCompletedOutput {
 
 final class _StartedCommand {
   final Future<PersistentShellCommandResult> future;
+  final String commandId;
 
-  const _StartedCommand(this.future);
+  const _StartedCommand(this.future, this.commandId);
 }

--- a/lib/data/ssh/persistent_shell.dart
+++ b/lib/data/ssh/persistent_shell.dart
@@ -64,70 +64,95 @@ final class PersistentShell {
   final StringBuffer _buffer = StringBuffer();
   int _commandId = 0;
   bool _closed = false;
+  Future<void> _stateLock = Future<void>.value();
+  String? _pendingCommandId;
 
   static const _donePrefix = '__SERVER_BOX_DONE__';
 
   Future<PersistentShellCommandResult> run(String command) async {
-    if (_closed) {
-      throw StateError('Persistent shell already closed');
-    }
-    if (_pending != null) {
-      throw StateError(
-        'Another command is already running in the persistent shell',
-      );
-    }
+    final started = await _withStateLock(() async {
+      if (_closed) {
+        throw StateError('Persistent shell already closed');
+      }
+      if (_pending != null) {
+        throw StateError(
+          'Another command is already running in the persistent shell',
+        );
+      }
 
-    await _ensureSession();
+      final session = await _ensureSessionLocked();
 
-    final completer = Completer<PersistentShellCommandResult>();
-    _pending = completer;
-    _buffer.clear();
-    final commandId = (++_commandId).toString();
-    final wrappedCommand = _wrapCommand(command, commandId);
+      if (_closed) {
+        throw StateError('Persistent shell already closed');
+      }
+      if (_pending != null) {
+        throw StateError(
+          'Another command is already running in the persistent shell',
+        );
+      }
 
-    try {
-      _session!.stdin.add(Uint8List.fromList(utf8.encode(wrappedCommand)));
-    } catch (error, stackTrace) {
-      _pending = null;
-      completer.completeError(error, stackTrace);
-    }
+      final completer = Completer<PersistentShellCommandResult>();
+      _pending = completer;
+      _buffer.clear();
+      final commandId = (++_commandId).toString();
+      _pendingCommandId = commandId;
+      final wrappedCommand = _wrapCommand(command, commandId);
 
-    return completer.future;
+      try {
+        session.stdin.add(Uint8List.fromList(utf8.encode(wrappedCommand)));
+      } catch (error, stackTrace) {
+        _pending = null;
+        _pendingCommandId = null;
+        completer.completeError(error, stackTrace);
+      }
+
+      return _StartedCommand(completer.future);
+    });
+
+    return started.future;
   }
 
   Future<void> close() async {
     _closed = true;
-    final session = _session;
-    _session = null;
+    await _withStateLock(() async {
+      final session = _session;
+      _session = null;
 
-    await _stdoutSub?.cancel();
-    await _stderrSub?.cancel();
-    _stdoutSub = null;
-    _stderrSub = null;
+      await _stdoutSub?.cancel();
+      await _stderrSub?.cancel();
+      _stdoutSub = null;
+      _stderrSub = null;
 
-    if (session != null) {
-      try {
-        session.close();
-      } catch (error, stackTrace) {
-        Loggers.app.warning(
-          'Failed to close persistent shell',
-          error,
-          stackTrace,
-        );
+      if (session != null) {
+        try {
+          session.close();
+        } catch (error, stackTrace) {
+          Loggers.app.warning(
+            'Failed to close persistent shell',
+            error,
+            stackTrace,
+          );
+        }
       }
-    }
 
-    _failPending(StateError('Persistent shell closed'));
+      _failPending(StateError('Persistent shell closed'));
+    });
   }
 
-  Future<void> _ensureSession() async {
+  Future<PersistentShellSession> _ensureSessionLocked() async {
     if (_session != null) {
-      return;
+      return _session!;
     }
 
     final session =
         await _sessionFactory?.call() ??
         SshPersistentShellSession(await _client!.execute('sh'));
+
+    if (_closed) {
+      session.close();
+      throw StateError('Persistent shell already closed');
+    }
+
     _session = session;
 
     _stdoutSub = session.stdout
@@ -147,6 +172,8 @@ final class PersistentShell {
           onError: _handleStreamError,
           onDone: _handleStreamDone,
         );
+
+    return session;
   }
 
   String _wrapCommand(String command, String commandId) {
@@ -161,24 +188,34 @@ printf '\\n$_donePrefix$commandId:%s\\n' "\$__server_box_exit"
 
   void _handleStdout(String data) {
     final pending = _pending;
-    if (pending == null) {
+    final pendingCommandId = _pendingCommandId;
+    if (pending == null || pendingCommandId == null) {
       return;
     }
 
     _buffer.write(data);
-    final parsed = tryParseCompletedOutput(_buffer.toString());
+    final raw = _buffer.toString();
+    final parsed = _parseCompletedOutput(
+      raw,
+      expectedCommandId: pendingCommandId,
+    );
     if (parsed == null) {
       return;
     }
 
     _pending = null;
+    _pendingCommandId = null;
     pending.complete(
       PersistentShellCommandResult(
-        output: parsed.output,
-        exitCode: parsed.exitCode,
+        output: parsed.result.output,
+        exitCode: parsed.result.exitCode,
       ),
     );
     _buffer.clear();
+    final remaining = raw.substring(parsed.consumedLength);
+    if (remaining.isNotEmpty) {
+      _buffer.write(remaining);
+    }
   }
 
   void _handleStderr(String data) {
@@ -206,25 +243,70 @@ printf '\\n$_donePrefix$commandId:%s\\n' "\$__server_box_exit"
   void _failPending(Object error, [StackTrace? stackTrace]) {
     final pending = _pending;
     _pending = null;
+    _pendingCommandId = null;
     if (pending != null && !pending.isCompleted) {
       pending.completeError(error, stackTrace ?? StackTrace.current);
     }
     _buffer.clear();
   }
 
-  static PersistentShellCommandResult? tryParseCompletedOutput(String raw) {
+  static PersistentShellCommandResult? tryParseCompletedOutput(
+    String raw, {
+    required String expectedCommandId,
+  }) {
+    return _parseCompletedOutput(
+      raw,
+      expectedCommandId: expectedCommandId,
+    )?.result;
+  }
+
+  static _ParsedCompletedOutput? _parseCompletedOutput(
+    String raw, {
+    required String expectedCommandId,
+  }) {
     final match = RegExp(
-      '(?:^|\\n)${RegExp.escape(_donePrefix)}(\\d+):(\\d+)(?:\\r?\\n|\$)',
+      '(?:^|\\n)${RegExp.escape(_donePrefix)}${RegExp.escape(expectedCommandId)}:(\\d+)(?:\\r?\\n|\$)',
     ).firstMatch(raw);
     if (match == null) {
       return null;
     }
 
     final output = raw.substring(0, match.start);
-    final exitCode = int.tryParse(match.group(2)!);
-    return PersistentShellCommandResult(
-      output: output.trimRight(),
-      exitCode: exitCode,
+    final exitCode = int.tryParse(match.group(1)!);
+    return _ParsedCompletedOutput(
+      result: PersistentShellCommandResult(
+        output: output.trimRight(),
+        exitCode: exitCode,
+      ),
+      consumedLength: match.end,
     );
   }
+
+  Future<T> _withStateLock<T>(Future<T> Function() fn) async {
+    final previous = _stateLock;
+    final release = Completer<void>();
+    _stateLock = release.future;
+    await previous;
+    try {
+      return await fn();
+    } finally {
+      release.complete();
+    }
+  }
+}
+
+final class _ParsedCompletedOutput {
+  final PersistentShellCommandResult result;
+  final int consumedLength;
+
+  const _ParsedCompletedOutput({
+    required this.result,
+    required this.consumedLength,
+  });
+}
+
+final class _StartedCommand {
+  final Future<PersistentShellCommandResult> future;
+
+  const _StartedCommand(this.future);
 }

--- a/test/persistent_shell_test.dart
+++ b/test/persistent_shell_test.dart
@@ -86,6 +86,32 @@ void main() {
     expect(result.output, 'stdout line\nstderr line');
   });
 
+  test(
+    'PersistentShell tolerates malformed UTF-8 from stdout and stderr',
+    () async {
+      final factory = _FakeSessionFactory();
+      final shell = PersistentShell(null, sessionFactory: factory.call);
+
+      final future = shell.run('echo malformed');
+      await Future<void>.delayed(Duration.zero);
+      factory.session.stdoutController.add(
+        Uint8List.fromList([0x66, 0x6f, 0x80, 0x6f, 0x0a]),
+      );
+      factory.session.stderrController.add(
+        Uint8List.fromList([0x62, 0x61, 0xff, 0x64, 0x0a]),
+      );
+      factory.session.stdoutController.add(
+        Uint8List.fromList(utf8.encode('__SERVER_BOX_DONE__1:0\n')),
+      );
+
+      final result = await future;
+
+      expect(result.output, contains('fo'));
+      expect(result.output, contains('\uFFFD'));
+      expect(result.output, contains('ba'));
+    },
+  );
+
   test('PersistentShell rejects commands after close', () async {
     final shell = PersistentShell(
       null,
@@ -159,6 +185,21 @@ void main() {
       final result = await nextRun;
       expect(factory.createCount, 2);
       expect(result.output, 'recovered');
+    },
+  );
+
+  test(
+    'PersistentShell times out a hanging command and disposes the session',
+    () async {
+      final factory = _FakeSessionFactory();
+      final shell = PersistentShell(null, sessionFactory: factory.call);
+
+      await expectLater(
+        shell.run('echo hanging', timeout: const Duration(milliseconds: 20)),
+        throwsA(isA<TimeoutException>()),
+      );
+
+      expect(factory.session.isClosed, isTrue);
     },
   );
 

--- a/test/persistent_shell_test.dart
+++ b/test/persistent_shell_test.dart
@@ -117,7 +117,50 @@ void main() {
     await factory.session.stdoutController.close();
     await factory.session.stderrController.close();
     await expectation;
+    expect(factory.session.isClosed, isTrue);
   });
+
+  test(
+    'PersistentShell disposes a broken session when stdin.add throws',
+    () async {
+      var createIndex = 0;
+      final brokenSession = _FakePersistentShellSession()..throwOnAdd = true;
+      final factory = _FakeSessionFactory(
+        createSession: () {
+          createIndex += 1;
+          return createIndex == 1
+              ? brokenSession
+              : _FakePersistentShellSession();
+        },
+      );
+      final shell = PersistentShell(null, sessionFactory: factory.call);
+
+      final brokenFuture = shell.run('echo broken');
+      await expectLater(
+        brokenFuture,
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('stdin add failed'),
+          ),
+        ),
+      );
+
+      expect(brokenSession.isClosed, isTrue);
+
+      final nextRun = shell.run('echo recovered');
+      await Future<void>.delayed(Duration.zero);
+      final recoveredSession = factory.sessions[1];
+      recoveredSession.stdoutController.add(
+        Uint8List.fromList(utf8.encode('recovered\n__SERVER_BOX_DONE__2:0\n')),
+      );
+
+      final result = await nextRun;
+      expect(factory.createCount, 2);
+      expect(result.output, 'recovered');
+    },
+  );
 
   test(
     'PersistentShell does not allow a concurrent run to overwrite pending state during async session creation',
@@ -194,15 +237,24 @@ void main() {
 
 final class _FakeSessionFactory {
   final Future<void> Function()? beforeCreate;
+  final PersistentShellSession Function()? createSession;
   int createCount = 0;
-  final session = _FakePersistentShellSession();
+  late final _defaultSession = _FakePersistentShellSession();
+  final sessions = <_FakePersistentShellSession>[];
 
-  _FakeSessionFactory({this.beforeCreate});
+  _FakePersistentShellSession get session =>
+      sessions.isNotEmpty ? sessions.first : _defaultSession;
+
+  _FakeSessionFactory({this.beforeCreate, this.createSession});
 
   Future<PersistentShellSession> call() async {
     await beforeCreate?.call();
     createCount += 1;
-    return session;
+    final created =
+        (createSession?.call() ?? _defaultSession)
+            as _FakePersistentShellSession;
+    sessions.add(created);
+    return created;
   }
 }
 
@@ -211,9 +263,13 @@ final class _FakePersistentShellSession implements PersistentShellSession {
   final stderrController = StreamController<Uint8List>();
   final writes = <String>[];
   bool isClosed = false;
+  bool throwOnAdd = false;
 
   @override
   StreamSink<Uint8List> get stdin => _FakeSink((data) {
+    if (throwOnAdd) {
+      throw StateError('stdin add failed');
+    }
     writes.add(utf8.decode(data));
   });
 

--- a/test/persistent_shell_test.dart
+++ b/test/persistent_shell_test.dart
@@ -1,0 +1,162 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:server_box/data/ssh/persistent_shell.dart';
+
+void main() {
+  test('PersistentShell parses completed output marker', () {
+    const raw = 'cpu:10%\nmem:20%\n__SERVER_BOX_DONE__7:0\n';
+
+    final result = PersistentShell.tryParseCompletedOutput(raw);
+
+    expect(result, isNotNull);
+    expect(result!.output, 'cpu:10%\nmem:20%');
+    expect(result.exitCode, 0);
+  });
+
+  test('PersistentShell waits for full completion marker', () {
+    const raw = 'cpu:10%\n__SERVER_BOX_DONE__7:';
+
+    final result = PersistentShell.tryParseCompletedOutput(raw);
+
+    expect(result, isNull);
+  });
+
+  test('PersistentShell reuses one session across multiple commands', () async {
+    final factory = _FakeSessionFactory();
+    final shell = PersistentShell(null, sessionFactory: factory.call);
+
+    final firstFuture = shell.run('echo first');
+    await Future<void>.delayed(Duration.zero);
+    factory.session.stdoutController.add(
+      Uint8List.fromList(utf8.encode('first\n__SERVER_BOX_DONE__1:0\n')),
+    );
+    final first = await firstFuture;
+
+    final secondFuture = shell.run('echo second');
+    await Future<void>.delayed(Duration.zero);
+    factory.session.stdoutController.add(
+      Uint8List.fromList(utf8.encode('second\n__SERVER_BOX_DONE__2:0\n')),
+    );
+    final second = await secondFuture;
+
+    expect(factory.createCount, 1);
+    expect(first.output, 'first');
+    expect(second.output, 'second');
+    expect(factory.session.writes, hasLength(2));
+  });
+
+  test('PersistentShell combines stderr with stdout output', () async {
+    final factory = _FakeSessionFactory();
+    final shell = PersistentShell(null, sessionFactory: factory.call);
+
+    final future = shell.run('echo mixed');
+    await Future<void>.delayed(Duration.zero);
+    factory.session.stdoutController.add(
+      Uint8List.fromList(utf8.encode('stdout line\n')),
+    );
+    factory.session.stderrController.add(
+      Uint8List.fromList(utf8.encode('stderr line\n')),
+    );
+    factory.session.stdoutController.add(
+      Uint8List.fromList(utf8.encode('__SERVER_BOX_DONE__1:0\n')),
+    );
+
+    final result = await future;
+
+    expect(result.output, 'stdout line\nstderr line');
+  });
+
+  test('PersistentShell rejects commands after close', () async {
+    final shell = PersistentShell(
+      null,
+      sessionFactory: _FakeSessionFactory().call,
+    );
+
+    await shell.close();
+
+    expect(() => shell.run('echo should fail'), throwsA(isA<StateError>()));
+  });
+
+  test('PersistentShell fails pending command when session ends', () async {
+    final factory = _FakeSessionFactory();
+    final shell = PersistentShell(null, sessionFactory: factory.call);
+
+    final future = shell.run('echo hanging');
+    final expectation = expectLater(
+      future,
+      throwsA(
+        isA<StateError>().having(
+          (e) => e.message,
+          'message',
+          contains('ended unexpectedly'),
+        ),
+      ),
+    );
+
+    await Future<void>.delayed(Duration.zero);
+    await factory.session.stdoutController.close();
+    await factory.session.stderrController.close();
+    await expectation;
+  });
+}
+
+final class _FakeSessionFactory {
+  int createCount = 0;
+  final session = _FakePersistentShellSession();
+
+  Future<PersistentShellSession> call() async {
+    createCount += 1;
+    return session;
+  }
+}
+
+final class _FakePersistentShellSession implements PersistentShellSession {
+  final stdoutController = StreamController<Uint8List>();
+  final stderrController = StreamController<Uint8List>();
+  final writes = <String>[];
+  bool isClosed = false;
+
+  @override
+  StreamSink<Uint8List> get stdin => _FakeSink((data) {
+    writes.add(utf8.decode(data));
+  });
+
+  @override
+  Stream<Uint8List> get stdout => stdoutController.stream;
+
+  @override
+  Stream<Uint8List> get stderr => stderrController.stream;
+
+  @override
+  void close() {
+    isClosed = true;
+  }
+}
+
+final class _FakeSink implements StreamSink<Uint8List> {
+  final void Function(Uint8List data) _onAdd;
+
+  _FakeSink(this._onAdd);
+
+  @override
+  void add(Uint8List data) => _onAdd(data);
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {}
+
+  @override
+  Future<void> addStream(Stream<Uint8List> stream) async {
+    await for (final chunk in stream) {
+      add(chunk);
+    }
+  }
+
+  @override
+  Future<void> close() async {}
+
+  @override
+  Future<void> get done async {}
+}

--- a/test/persistent_shell_test.dart
+++ b/test/persistent_shell_test.dart
@@ -9,7 +9,10 @@ void main() {
   test('PersistentShell parses completed output marker', () {
     const raw = 'cpu:10%\nmem:20%\n__SERVER_BOX_DONE__7:0\n';
 
-    final result = PersistentShell.tryParseCompletedOutput(raw);
+    final result = PersistentShell.tryParseCompletedOutput(
+      raw,
+      expectedCommandId: '7',
+    );
 
     expect(result, isNotNull);
     expect(result!.output, 'cpu:10%\nmem:20%');
@@ -19,7 +22,21 @@ void main() {
   test('PersistentShell waits for full completion marker', () {
     const raw = 'cpu:10%\n__SERVER_BOX_DONE__7:';
 
-    final result = PersistentShell.tryParseCompletedOutput(raw);
+    final result = PersistentShell.tryParseCompletedOutput(
+      raw,
+      expectedCommandId: '7',
+    );
+
+    expect(result, isNull);
+  });
+
+  test('PersistentShell ignores markers for another command id', () {
+    const raw = 'cpu:10%\n__SERVER_BOX_DONE__999:0\n';
+
+    final result = PersistentShell.tryParseCompletedOutput(
+      raw,
+      expectedCommandId: '7',
+    );
 
     expect(result, isNull);
   });
@@ -101,13 +118,89 @@ void main() {
     await factory.session.stderrController.close();
     await expectation;
   });
+
+  test(
+    'PersistentShell does not allow a concurrent run to overwrite pending state during async session creation',
+    () async {
+      final gate = Completer<void>();
+      final factory = _FakeSessionFactory(beforeCreate: () => gate.future);
+      final shell = PersistentShell(null, sessionFactory: factory.call);
+
+      final firstFuture = shell.run('echo first');
+      final secondFuture = shell.run('echo second');
+      final secondExpectation = expectLater(
+        secondFuture,
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('Another command is already running'),
+          ),
+        ),
+      );
+
+      gate.complete();
+      await Future<void>.delayed(Duration.zero);
+
+      factory.session.stdoutController.add(
+        Uint8List.fromList(utf8.encode('first\n__SERVER_BOX_DONE__1:0\n')),
+      );
+
+      final first = await firstFuture;
+
+      expect(first.output, 'first');
+      expect(factory.createCount, 1);
+      await secondExpectation;
+    },
+  );
+
+  test(
+    'PersistentShell rejects a run closed during async session creation',
+    () async {
+      final entered = Completer<void>();
+      final gate = Completer<void>();
+      final factory = _FakeSessionFactory(
+        beforeCreate: () {
+          if (!entered.isCompleted) {
+            entered.complete();
+          }
+          return gate.future;
+        },
+      );
+      final shell = PersistentShell(null, sessionFactory: factory.call);
+
+      final runFuture = shell.run('echo delayed');
+      await entered.future;
+      final runExpectation = expectLater(
+        runFuture,
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('already closed'),
+          ),
+        ),
+      );
+      final closeFuture = shell.close();
+
+      gate.complete();
+      await closeFuture;
+
+      expect(factory.session.isClosed, isTrue);
+      await runExpectation;
+    },
+  );
 }
 
 final class _FakeSessionFactory {
+  final Future<void> Function()? beforeCreate;
   int createCount = 0;
   final session = _FakePersistentShellSession();
 
+  _FakeSessionFactory({this.beforeCreate});
+
   Future<PersistentShellSession> call() async {
+    await beforeCreate?.call();
     createCount += 1;
     return session;
   }


### PR DESCRIPTION
Resolve #602. Also add the issuer of this issue to participants list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent SSH shell abstraction for sequential command execution and improved session reuse.

* **Bug Fixes**
  * More reliable status refreshes on non-Windows hosts and safer teardown when connections change to avoid stale or failed sessions.

* **Tests**
  * Added comprehensive tests for parsing, session reuse, concurrency, error recovery, and timeouts.

* **Chores**
  * Updated contributor list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->