### PR TITLE
Add disk collection toggles to server edit settings

### DIFF
--- a/lib/data/res/github_id.dart
+++ b/lib/data/res/github_id.dart
@@ -171,6 +171,7 @@ abstract final class GithubIds {
     'tetsuya-ops',
     'maxpeyn10',
     'agczsz',
+    'kuilei0926'
   };
 }
 

--- a/lib/view/page/server/edit/actions.dart
+++ b/lib/view/page/server/edit/actions.dart
@@ -105,13 +105,19 @@ extension _Actions on _ServerEditPageState {
     }
   }
 
-  void _setCmdTypeDisabled(String display, bool disabled) {
+  void _setCmdTypeDisabled(
+    String display,
+    bool disabled, {
+    bool notify = true,
+  }) {
     if (disabled) {
       _disabledCmdTypes.value.add(display);
     } else {
       _disabledCmdTypes.value.remove(display);
     }
-    _disabledCmdTypes.notify();
+    if (notify) {
+      _disabledCmdTypes.notify();
+    }
   }
 
   bool _isCmdGroupDisabled(Iterable<ShellCmdType> cmdTypes) {
@@ -121,8 +127,9 @@ extension _Actions on _ServerEditPageState {
 
   void _setCmdGroupDisabled(Iterable<ShellCmdType> cmdTypes, bool disabled) {
     for (final cmdType in cmdTypes) {
-      _setCmdTypeDisabled(cmdType.displayName, disabled);
+      _setCmdTypeDisabled(cmdType.displayName, disabled, notify: false);
     }
+    _disabledCmdTypes.notify();
   }
 
   String _cmdTypeTitle(ShellCmdType cmdType) {
@@ -363,7 +370,7 @@ extension _Utils on _ServerEditPageState {
         child: _disabledCmdTypes.listenVal((disabled) {
           return ListView.builder(
             itemCount: allCmdTypes.length,
-            itemExtent: 50,
+            itemExtent: 72,
             itemBuilder: (context, index) {
               final cmdType = allCmdTypes.elementAtOrNull(index);
               if (cmdType == null) return UIs.placeholder;

--- a/lib/view/page/server/edit/actions.dart
+++ b/lib/view/page/server/edit/actions.dart
@@ -4,6 +4,17 @@ part of 'edit.dart';
 final _hostReg = RegExp(r'^[a-zA-Z0-9\.\-_:%;]+$');
 
 extension _Actions on _ServerEditPageState {
+  Iterable<ShellCmdType> get _diskInfoCmdTypes => const [
+    StatusCmdType.disk,
+    BSDStatusCmdType.disk,
+    WindowsStatusCmdType.disk,
+  ];
+
+  Iterable<ShellCmdType> get _diskHealthCmdTypes => const [
+    StatusCmdType.diskSmart,
+    WindowsStatusCmdType.diskSmart,
+  ];
+
   Future<void> _refreshStoredSudoPasswordState() async {
     String? storedValue;
     try {
@@ -51,10 +62,7 @@ extension _Actions on _ServerEditPageState {
               },
               child: Text(libL10n.clear),
             ),
-          TextButton(
-            onPressed: context.pop,
-            child: Text(libL10n.cancel),
-          ),
+          TextButton(onPressed: context.pop, child: Text(libL10n.cancel)),
           TextButton(
             onPressed: () async => await _saveSudoPassword(controller.text),
             child: Text(libL10n.save),
@@ -104,6 +112,28 @@ extension _Actions on _ServerEditPageState {
       _disabledCmdTypes.value.remove(display);
     }
     _disabledCmdTypes.notify();
+  }
+
+  bool _isCmdGroupDisabled(Iterable<ShellCmdType> cmdTypes) {
+    final disabled = _disabledCmdTypes.value;
+    return cmdTypes.every((cmdType) => disabled.contains(cmdType.displayName));
+  }
+
+  void _setCmdGroupDisabled(Iterable<ShellCmdType> cmdTypes, bool disabled) {
+    for (final cmdType in cmdTypes) {
+      _setCmdTypeDisabled(cmdType.displayName, disabled);
+    }
+  }
+
+  String _cmdTypeTitle(ShellCmdType cmdType) {
+    return switch (cmdType) {
+      StatusCmdType.disk ||
+      BSDStatusCmdType.disk ||
+      WindowsStatusCmdType.disk => libL10n.disk,
+      StatusCmdType.diskSmart ||
+      WindowsStatusCmdType.diskSmart => l10n.diskHealth,
+      _ => cmdType.name,
+    };
   }
 
   String _validationErrorMessage(SpiValidationError error) {
@@ -340,7 +370,11 @@ extension _Utils on _ServerEditPageState {
               final display = cmdType.displayName;
               return ListTile(
                 leading: Icon(cmdType.sysType.icon, size: 20),
-                title: Text(cmdType.name, style: const TextStyle(fontSize: 16)),
+                title: Text(
+                  _cmdTypeTitle(cmdType),
+                  style: const TextStyle(fontSize: 16),
+                ),
+                subtitle: Text(cmdType.displayName, style: UIs.text12Grey),
                 trailing: Checkbox(
                   value: disabled.contains(display),
                   onChanged: (value) {

--- a/lib/view/page/server/edit/widget.dart
+++ b/lib/view/page/server/edit/widget.dart
@@ -148,6 +148,7 @@ extension _Widgets on _ServerEditPageState {
         _buildEnvs(),
         _buildPVEs(),
         _buildCustomCmds(),
+        _buildStorageCollection(),
         _buildDisabledCmdTypes(),
         _buildCustomDev(),
         _buildWOLs(),
@@ -338,6 +339,58 @@ extension _Widgets on _ServerEditPageState {
           trailing: const Icon(Icons.open_in_new, size: 17),
           onTap: libL10n.customCmdDocUrl.launchUrl,
         ).cardx,
+      ],
+    );
+  }
+
+  Widget _buildStorageCollection() {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        CenterGreyTitle(libL10n.disk),
+        _disabledCmdTypes.listenVal((_) {
+          final diskInfoEnabled = !_isCmdGroupDisabled(_diskInfoCmdTypes);
+          final diskHealthEnabled = !_isCmdGroupDisabled(_diskHealthCmdTypes);
+          return Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                leading: const Icon(Icons.storage),
+                title: Text(libL10n.disk),
+                subtitle: Text(
+                  _diskInfoCmdTypes.map((e) => e.displayName).join(', '),
+                  style: UIs.textGrey,
+                ),
+                trailing: Switch(
+                  value: diskInfoEnabled,
+                  onChanged: (value) {
+                    _setCmdGroupDisabled(_diskInfoCmdTypes, !value);
+                  },
+                ),
+                onTap: () {
+                  _setCmdGroupDisabled(_diskInfoCmdTypes, diskInfoEnabled);
+                },
+              ).cardx,
+              ListTile(
+                leading: const Icon(MingCute.heartbeat_line),
+                title: Text(l10n.diskHealth),
+                subtitle: Text(
+                  _diskHealthCmdTypes.map((e) => e.displayName).join(', '),
+                  style: UIs.textGrey,
+                ),
+                trailing: Switch(
+                  value: diskHealthEnabled,
+                  onChanged: (value) {
+                    _setCmdGroupDisabled(_diskHealthCmdTypes, !value);
+                  },
+                ),
+                onTap: () {
+                  _setCmdGroupDisabled(_diskHealthCmdTypes, diskHealthEnabled);
+                },
+              ).cardx,
+            ],
+          );
+        }),
       ],
     );
   }


### PR DESCRIPTION
Resolve #1075 and add its issuer to participants list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a storage section with toggles for disk info and disk health controls.

* **Improvements**
  * Command-type dialogs now show localized group titles, clearer subtitles, and improved list spacing.
  * Participant list expanded with an additional GitHub ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->