### PR TITLE
feat(ssh): add snippet button and limit home actions to the add page

### DIFF
--- a/lib/view/page/ssh/page/page.dart
+++ b/lib/view/page/ssh/page/page.dart
@@ -431,7 +431,13 @@ class SSHPageState extends ConsumerState<SSHPage>
       );
       if (selected == null) return;
 
-      await selected.runInTerm(_terminal, widget.args.spi);
+      try {
+        await selected.runInTerm(_terminal, widget.args.spi);
+      } catch (e, s) {
+        if (!mounted) return;
+        context.showErrDialog(e, s, '${libL10n.snippet}: ${selected.name}');
+        return;
+      }
       if (!mounted) return;
       widget.args.focusNode?.requestFocus();
       _termKey.currentState?.requestKeyboard();

--- a/lib/view/page/ssh/page/page.dart
+++ b/lib/view/page/ssh/page/page.dart
@@ -116,11 +116,14 @@ class SSHPageState extends ConsumerState<SSHPage>
   bool _disconnectDialogOpen = false;
   bool _reportedDisconnected = false;
   VoidCallback? _visibilityListener;
+  bool _isPickingSnippet = false;
 
   /// Used for (de)activate the wake lock and forground service
   static var _sshConnCount = 0;
   late final String _sessionId = ShortId.generate();
   late final int _sessionStartMs = DateTime.now().millisecondsSinceEpoch;
+
+  Future<void> pickSnippetFromToolbar() => _pickSnippet();
 
   @override
   void dispose() {
@@ -390,14 +393,51 @@ class SSHPageState extends ConsumerState<SSHPage>
   }
 
   List<Widget> _buildAppBarActions() {
-    if (widget.args.spi.isRoot) return const [];
-    return [
+    final actions = <Widget>[
       IconButton(
-        onPressed: _insertSudoPassword,
-        tooltip: l10n.trySudo,
-        icon: const Icon(Icons.password),
+        onPressed: _pickSnippet,
+        tooltip: libL10n.snippet,
+        icon: const Icon(Icons.code),
       ),
     ];
+    if (!widget.args.spi.isRoot) {
+      actions.add(
+        IconButton(
+          onPressed: _insertSudoPassword,
+          tooltip: l10n.trySudo,
+          icon: const Icon(Icons.password),
+        ),
+      );
+    }
+    return actions;
+  }
+
+  Future<void> _pickSnippet() async {
+    if (_isPickingSnippet) return;
+    _isPickingSnippet = true;
+
+    try {
+      final snippets = ref.read(snippetProvider.select((p) => p.snippets));
+      if (snippets.isEmpty) {
+        if (!mounted) return;
+        context.showSnackBar(libL10n.empty);
+        return;
+      }
+
+      final selected = await context.showPickSingleDialog<Snippet>(
+        title: libL10n.snippet,
+        items: snippets,
+        display: (snippet) => snippet.name,
+      );
+      if (selected == null) return;
+
+      await selected.runInTerm(_terminal, widget.args.spi);
+      if (!mounted) return;
+      widget.args.focusNode?.requestFocus();
+      _termKey.currentState?.requestKeyboard();
+    } finally {
+      _isPickingSnippet = false;
+    }
   }
 
   Widget _buildVirtualKey(

--- a/lib/view/page/ssh/tab.dart
+++ b/lib/view/page/ssh/tab.dart
@@ -25,7 +25,12 @@ class SSHTabPage extends ConsumerStatefulWidget {
 typedef _TabMap =
     Map<
       String,
-      ({Widget page, FocusNode? focus, ValueNotifier<bool>? visible})
+      ({
+        Widget page,
+        FocusNode? focus,
+        ValueNotifier<bool>? visible,
+        GlobalKey<SSHPageState>? sshPageKey,
+      })
     >;
 
 class _SSHTabPageState extends ConsumerState<SSHTabPage>
@@ -39,6 +44,7 @@ class _SSHTabPageState extends ConsumerState<SSHTabPage>
       ),
       focus: null,
       visible: null,
+      sshPageKey: null,
     ),
   };
   final _pageCtrl = PageController();
@@ -72,6 +78,7 @@ class _SSHTabPageState extends ConsumerState<SSHTabPage>
             map: _tabMap,
             onTap: _onTapTab,
             onClose: _onTapClose,
+            snippetBtn: buildSnippetBtn(context),
             sortBtn: buildSortBtn(context),
             searchBtn: buildSearchBtn(context),
             historyBtn: buildHistoryBtn(context),
@@ -128,19 +135,36 @@ extension on _SSHTabPageState {
   }
 
   void _disposeTabEntry(
-    ({Widget page, FocusNode? focus, ValueNotifier<bool>? visible}) entry,
+    ({
+      Widget page,
+      FocusNode? focus,
+      ValueNotifier<bool>? visible,
+      GlobalKey<SSHPageState>? sshPageKey,
+    })
+    entry,
   ) {
     entry.focus?.dispose();
     entry.visible?.dispose();
   }
 
-  ({Widget page, FocusNode? focus, ValueNotifier<bool>? visible})?
+  ({
+    Widget page,
+    FocusNode? focus,
+    ValueNotifier<bool>? visible,
+    GlobalKey<SSHPageState>? sshPageKey,
+  })?
   _detachTabEntry(String name) {
     return _tabMap.remove(name);
   }
 
   void _disposeTabEntryAfterFrame(
-    ({Widget page, FocusNode? focus, ValueNotifier<bool>? visible})? entry,
+    ({
+      Widget page,
+      FocusNode? focus,
+      ValueNotifier<bool>? visible,
+      GlobalKey<SSHPageState>? sshPageKey,
+    })?
+    entry,
   ) {
     if (entry == null) return;
     WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -211,7 +235,7 @@ extension on _SSHTabPageState {
       }
       return spi.name;
     }();
-    final key = Key(name);
+    final key = GlobalKey<SSHPageState>(debugLabel: name);
     final focusNode = FocusNode();
     final visibleVN = ValueNotifier(false);
     final args = SshPageArgs(
@@ -230,6 +254,7 @@ extension on _SSHTabPageState {
       ),
       focus: focusNode,
       visible: visibleVN,
+      sshPageKey: key,
     );
     _tabRN.notify();
     Stores.history.sshServerHistory.add(spi.id);
@@ -384,6 +409,18 @@ extension on _SSHTabPageState {
     );
   }
 
+  Widget buildSnippetBtn(BuildContext context) {
+    return Btn.icon(
+      icon: const Icon(Icons.code, size: 18),
+      onTap: () {
+        final idx = _fabVN.value;
+        if (idx == 0) return;
+        final entry = _tabMap.values.elementAtOrNull(idx);
+        entry?.sshPageKey?.currentState?.pickSnippetFromToolbar();
+      },
+    );
+  }
+
   void showHistoryDialog(BuildContext context) {
     final history = Stores.history.sshServerHistory.all.cast<String>();
     if (history.isEmpty) {
@@ -443,6 +480,7 @@ final class _TabBar extends StatelessWidget implements PreferredSizeWidget {
     required this.map,
     required this.onTap,
     required this.onClose,
+    required this.snippetBtn,
     required this.sortBtn,
     required this.searchBtn,
     required this.historyBtn,
@@ -452,11 +490,13 @@ final class _TabBar extends StatelessWidget implements PreferredSizeWidget {
   final _TabMap map;
   final void Function(int idx) onTap;
   final void Function(String name) onClose;
+  final Widget snippetBtn;
   final Widget sortBtn;
   final Widget searchBtn;
   final Widget historyBtn;
 
   List<String> get names => map.keys.toList();
+  List<String> get connectionNames => names.skip(1).toList();
 
   @override
   Size get preferredSize => const Size.fromHeight(48);
@@ -466,23 +506,11 @@ final class _TabBar extends StatelessWidget implements PreferredSizeWidget {
     return ListenBuilder(
       listenable: idxVN,
       builder: () {
+        final showHomeActions = idxVN.value == 0;
+        final showSnippetAction = idxVN.value != 0;
         return Row(
           children: [
-            Expanded(
-              child: ListView.separated(
-                scrollDirection: Axis.horizontal,
-                padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 5),
-                itemCount: names.length,
-                itemBuilder: (_, idx) => _buildItem(idx),
-                separatorBuilder: (_, _) => Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 17),
-                  child: Container(
-                    color: Theme.of(context).dividerColor.withAlpha(61),
-                    width: 3,
-                  ),
-                ),
-              ),
-            ),
+            _buildAddItem(context),
             Padding(
               padding: const EdgeInsets.symmetric(vertical: 17),
               child: Container(
@@ -490,19 +518,61 @@ final class _TabBar extends StatelessWidget implements PreferredSizeWidget {
                 width: 3,
               ),
             ),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 7),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  sortBtn,
-                  const SizedBox(width: 7),
-                  searchBtn,
-                  const SizedBox(width: 7),
-                  historyBtn,
-                ],
+            Expanded(
+              child: ClipRect(
+                child: ListView.separated(
+                  scrollDirection: Axis.horizontal,
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 7,
+                    vertical: 5,
+                  ),
+                  itemCount: connectionNames.length,
+                  itemBuilder: (_, idx) => _buildItem(idx + 1),
+                  separatorBuilder: (_, _) => Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 17),
+                    child: Container(
+                      color: Theme.of(context).dividerColor.withAlpha(61),
+                      width: 3,
+                    ),
+                  ),
+                ),
               ),
             ),
+            if (showSnippetAction) ...[
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 17),
+                child: Container(
+                  color: Theme.of(context).dividerColor.withAlpha(61),
+                  width: 3,
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 7),
+                child: snippetBtn,
+              ),
+            ],
+            if (showHomeActions) ...[
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 17),
+                child: Container(
+                  color: Theme.of(context).dividerColor.withAlpha(61),
+                  width: 3,
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 7),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    sortBtn,
+                    const SizedBox(width: 7),
+                    searchBtn,
+                    const SizedBox(width: 7),
+                    historyBtn,
+                  ],
+                ),
+              ),
+            ],
           ],
         );
       },
@@ -512,50 +582,59 @@ final class _TabBar extends StatelessWidget implements PreferredSizeWidget {
   static const kWideWidth = 90.0;
   static const kNarrowWidth = 60.0;
 
+  Widget _buildAddItem(BuildContext context) {
+    final color = idxVN.value == 0 ? null : Colors.grey;
+    return Material(
+      color: Colors.transparent,
+      borderRadius: BorderRadius.circular(13),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(13),
+        onTap: () => onTap(0),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+          child: Icon(MingCute.add_circle_fill, size: 17, color: color),
+        ),
+      ),
+    );
+  }
+
   Widget _buildItem(int idx) {
     final name = names[idx];
     final selected = idxVN.value == idx;
     final color = selected ? null : Colors.grey;
 
-    final Widget child;
-    if (idx == 0) {
-      child = Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 13),
-        child: Icon(MingCute.add_circle_fill, size: 17, color: color),
+    final text = Text(
+      name,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+      style: TextStyle(color: color),
+      softWrap: false,
+      textAlign: TextAlign.right,
+      textWidthBasis: TextWidthBasis.parent,
+    );
+    final Widget btn;
+    if (selected) {
+      btn = Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: [
+          Btn.icon(
+            icon: Icon(MingCute.close_circle_fill, color: color, size: 17),
+            onTap: () => onClose(name),
+            padding: null,
+          ),
+          SizedBox(width: kNarrowWidth - 15, child: text),
+        ],
       );
     } else {
-      final text = Text(
-        name,
-        maxLines: 1,
-        overflow: TextOverflow.ellipsis,
-        style: TextStyle(color: color),
-        softWrap: false,
-        textAlign: TextAlign.right,
-        textWidthBasis: TextWidthBasis.parent,
-      );
-      final Widget btn;
-      if (selected) {
-        btn = Row(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          children: [
-            Btn.icon(
-              icon: Icon(MingCute.close_circle_fill, color: color, size: 17),
-              onTap: () => onClose(name),
-              padding: null,
-            ),
-            SizedBox(width: kNarrowWidth - 15, child: text),
-          ],
-        );
-      } else {
-        btn = Center(child: text);
-      }
-      child = AnimatedContainer(
-        width: selected ? kWideWidth : kNarrowWidth,
-        duration: Durations.medium3,
-        curve: Curves.fastEaseInToSlowEaseOut,
-        child: OverflowBox(maxWidth: selected ? kWideWidth : null, child: btn),
-      );
+      btn = Center(child: text);
     }
+    final child = AnimatedContainer(
+      width: selected ? kWideWidth : kNarrowWidth,
+      duration: Durations.medium3,
+      curve: Curves.fastEaseInToSlowEaseOut,
+      child: OverflowBox(maxWidth: selected ? kWideWidth : null, child: btn),
+    );
 
     return InkWell(
       borderRadius: BorderRadius.circular(13),


### PR DESCRIPTION
## Summary
- add a snippet action button for SSH tabs
- allow running snippets from the current SSH tab through the toolbar
- show the top-right home actions only on the add-connection page instead of every SSH tab

## Test plan
- [x] Run the app on macOS
- [x] Open the SSH tabs page
- [x] Verify the snippet button is available on SSH connection tabs
- [x] Verify the home actions only appear on the add page

<img width="1055" height="744" alt="image" src="https://github.com/user-attachments/assets/bf539f8f-4bf5-4174-8b76-61bafd83a55e" />
<img width="1055" height="744" alt="image" src="https://github.com/user-attachments/assets/3fc80951-a11a-4713-a6cf-67dcdc4885c1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add snippet browsing and one-tap execution from the SSH toolbar/app bar.
  * Snippet action visible in the app bar; session actions reorganized for clarity.
  * Tab bar updated to surface the snippet control and maintain a cleaner tab layout.
* **Bug Fixes**
  * Prevent concurrent snippet picks to avoid duplicate actions.
  * Restore terminal focus and keyboard reliably after running a snippet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->