### PR TITLE
ref: tweak snippet and SSH page layouts

### DIFF
--- a/lib/view/page/snippet/list.dart
+++ b/lib/view/page/snippet/list.dart
@@ -12,14 +12,18 @@ class SnippetListPage extends ConsumerStatefulWidget {
   @override
   ConsumerState<SnippetListPage> createState() => _SnippetListPageState();
 
-  static const route = AppRouteNoArg(page: SnippetListPage.new, path: '/snippets');
+  static const route = AppRouteNoArg(
+    page: SnippetListPage.new,
+    path: '/snippets',
+  );
 }
 
-class _SnippetListPageState extends ConsumerState<SnippetListPage> with AutomaticKeepAliveClientMixin {
+class _SnippetListPageState extends ConsumerState<SnippetListPage>
+    with AutomaticKeepAliveClientMixin {
   final _tag = ''.vn;
   final _splitViewCtrl = SplitViewController();
 
-  static const _desiredItemHeight = 77.0;
+  static const _desiredItemHeight = 85.0;
 
   @override
   void dispose() {
@@ -38,20 +42,20 @@ class _SnippetListPageState extends ConsumerState<SnippetListPage> with Automati
     // final isMobile = ResponsiveBreakpoints.of(context).isMobile;
     final snippetState = ref.watch(snippetProvider);
     final snippets = snippetState.snippets;
-    
+
     return _tag.listenVal((tag) {
       final child = _buildScaffold(snippets, tag);
       // if (isMobile) {
       return child;
       // }
 
-        // return SplitView(
-        //   controller: _splitViewCtrl,
-        //   leftWeight: 1,
-        //   rightWeight: 1.3,
-        //   initialRight: Center(child: Text(libL10n.empty)),
-        //   leftBuilder: (_, __) => child,
-        // );
+      // return SplitView(
+      //   controller: _splitViewCtrl,
+      //   leftWeight: 1,
+      //   rightWeight: 1.3,
+      //   initialRight: Center(child: Text(libL10n.empty)),
+      //   leftBuilder: (_, __) => child,
+      // );
     });
   }
 
@@ -101,26 +105,48 @@ class _SnippetListPageState extends ConsumerState<SnippetListPage> with Automati
   }
 
   Widget _buildSnippetItem(Snippet snippet) {
-    return ListTile(
-      contentPadding: const EdgeInsets.only(left: 23, right: 17),
-      title: Text(snippet.name, overflow: TextOverflow.ellipsis, maxLines: 1),
-      subtitle: Text(
-        snippet.note ?? snippet.script,
-        overflow: TextOverflow.ellipsis,
-        maxLines: 3,
-        style: UIs.textGrey,
-      ),
-      trailing: const Icon(Icons.keyboard_arrow_right),
+    return InkWell(
       onTap: () {
-        // final isMobile = ResponsiveBreakpoints.of(context).isMobile;
-        // if (isMobile) {
-        SnippetEditPage.route.go(context, args: SnippetEditPageArgs(snippet: snippet));
-        // } else {
-        //   _splitViewCtrl.replace(SnippetEditPage(
-        //     args: SnippetEditPageArgs(snippet: snippet),
-        //   ));
-        // }
+        SnippetEditPage.route.go(
+          context,
+          args: SnippetEditPageArgs(snippet: snippet),
+        );
       },
+      child: SizedBox(
+        height: _desiredItemHeight,
+        child: Stack(
+          children: [
+            Positioned.fill(
+              child: Padding(
+                padding: const EdgeInsets.only(left: 23, right: 45),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      snippet.name,
+                      overflow: TextOverflow.ellipsis,
+                      maxLines: 1,
+                    ),
+                    Text(
+                      snippet.note ?? snippet.script,
+                      overflow: TextOverflow.ellipsis,
+                      maxLines: 2,
+                      style: UIs.textGrey,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const Positioned(
+              top: 0,
+              right: 17,
+              bottom: 0,
+              child: Center(child: Icon(Icons.keyboard_arrow_right)),
+            ),
+          ],
+        ),
+      ),
     ).cardx;
   }
 

--- a/lib/view/page/snippet/list.dart
+++ b/lib/view/page/snippet/list.dart
@@ -21,7 +21,6 @@ class SnippetListPage extends ConsumerStatefulWidget {
 class _SnippetListPageState extends ConsumerState<SnippetListPage>
     with AutomaticKeepAliveClientMixin {
   final _tag = ''.vn;
-  final _splitViewCtrl = SplitViewController();
 
   static const _desiredItemHeight = 85.0;
 
@@ -29,7 +28,6 @@ class _SnippetListPageState extends ConsumerState<SnippetListPage>
   void dispose() {
     super.dispose();
     _tag.dispose();
-    _splitViewCtrl.dispose();
   }
 
   @override
@@ -39,23 +37,11 @@ class _SnippetListPageState extends ConsumerState<SnippetListPage>
   }
 
   Widget _buildBody() {
-    // final isMobile = ResponsiveBreakpoints.of(context).isMobile;
     final snippetState = ref.watch(snippetProvider);
     final snippets = snippetState.snippets;
 
     return _tag.listenVal((tag) {
-      final child = _buildScaffold(snippets, tag);
-      // if (isMobile) {
-      return child;
-      // }
-
-      // return SplitView(
-      //   controller: _splitViewCtrl,
-      //   leftWeight: 1,
-      //   rightWeight: 1.3,
-      //   initialRight: Center(child: Text(libL10n.empty)),
-      //   leftBuilder: (_, __) => child,
-      // );
+      return _buildScaffold(snippets, tag);
     });
   }
 
@@ -73,11 +59,7 @@ class _SnippetListPageState extends ConsumerState<SnippetListPage>
         heroTag: 'snippetAdd',
         child: const Icon(Icons.add),
         onPressed: () {
-          // if (ResponsiveBreakpoints.of(context).isMobile) {
           SnippetEditPage.route.go(context);
-          // } else {
-          //   _splitViewCtrl.replace(const SnippetEditPage());
-          // }
         },
       ),
     );

--- a/lib/view/page/ssh/tab.dart
+++ b/lib/view/page/ssh/tab.dart
@@ -406,12 +406,7 @@ extension on _SSHTabPageState {
   Widget buildHistoryBtn(BuildContext context) {
     return Btn.icon(
       icon: const Icon(Icons.history, size: 18),
-      onTap: () {
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (!context.mounted) return;
-          showHistoryDialog(context);
-        });
-      },
+      onTap: () => showHistoryDialog(context),
     );
   }
 
@@ -744,7 +739,7 @@ class _AddPageState extends ConsumerState<_AddPage> {
                 canUseTwoColumns ? 2 : 1,
               )
             : 1;
-        final mainCount = itemCount ~/ crossCount + 1;
+        final mainCount = (itemCount + crossCount - 1) ~/ crossCount;
         final desktopItemWidth = isDesktopWide
             ? max(
                 0.0,
@@ -808,9 +803,7 @@ class _AddPageState extends ConsumerState<_AddPage> {
                   return SizedBox(width: desktopItemWidth, child: child);
                 }
 
-                return Expanded(
-                  child: Padding(padding: EdgeInsets.zero, child: child),
-                );
+                return Expanded(child: child);
               }),
             ),
           ),

--- a/lib/view/page/ssh/tab.dart
+++ b/lib/view/page/ssh/tab.dart
@@ -5,6 +5,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:icons_plus/icons_plus.dart';
+import 'package:responsive_framework/responsive_framework.dart';
 import 'package:server_box/core/extension/context/locale.dart';
 import 'package:server_box/core/route.dart';
 import 'package:server_box/data/model/server/server_private_info.dart';
@@ -405,7 +406,12 @@ extension on _SSHTabPageState {
   Widget buildHistoryBtn(BuildContext context) {
     return Btn.icon(
       icon: const Icon(Icons.history, size: 18),
-      onTap: () => showHistoryDialog(context),
+      onTap: () {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!context.mounted) return;
+          showHistoryDialog(context);
+        });
+      },
     );
   }
 
@@ -436,6 +442,7 @@ extension on _SSHTabPageState {
     context.showRoundDialog(
       title: l10n.serverHistory,
       child: SizedBox(
+        width: 420,
         height: 300,
         child: ListView.builder(
           itemCount: history.length,
@@ -443,6 +450,7 @@ extension on _SSHTabPageState {
             final id = history[idx];
             final spi = serverState.servers[id];
             return ListTile(
+              contentPadding: EdgeInsets.zero,
               title: Text(spi?.name ?? id),
               subtitle: spi != null
                   ? Text('${spi.user}@${spi.ip}:${spi.port}')
@@ -472,6 +480,7 @@ extension on _SSHTabPageState {
       ],
     );
   }
+
 }
 
 final class _TabBar extends StatelessWidget implements PreferredSizeWidget {
@@ -527,7 +536,7 @@ final class _TabBar extends StatelessWidget implements PreferredSizeWidget {
                     vertical: 5,
                   ),
                   itemCount: connectionNames.length,
-                  itemBuilder: (_, idx) => _buildItem(idx + 1),
+                  itemBuilder: (_, idx) => _buildItem(context, idx + 1),
                   separatorBuilder: (_, _) => Padding(
                     padding: const EdgeInsets.symmetric(vertical: 17),
                     child: Container(
@@ -579,9 +588,6 @@ final class _TabBar extends StatelessWidget implements PreferredSizeWidget {
     );
   }
 
-  static const kWideWidth = 90.0;
-  static const kNarrowWidth = 60.0;
-
   Widget _buildAddItem(BuildContext context) {
     final color = idxVN.value == 0 ? null : Colors.grey;
     return Material(
@@ -599,7 +605,10 @@ final class _TabBar extends StatelessWidget implements PreferredSizeWidget {
     );
   }
 
-  Widget _buildItem(int idx) {
+  Widget _buildItem(BuildContext context, int idx) {
+    final isMobile = ResponsiveBreakpoints.of(context).isMobile;
+    final wideWidth = isMobile ? 90.0 : 130.0;
+    final narrowWidth = isMobile ? 60.0 : 90.0;
     final name = names[idx];
     final selected = idxVN.value == idx;
     final color = selected ? null : Colors.grey;
@@ -623,24 +632,32 @@ final class _TabBar extends StatelessWidget implements PreferredSizeWidget {
             onTap: () => onClose(name),
             padding: null,
           ),
-          SizedBox(width: kNarrowWidth - 15, child: text),
+          Expanded(child: text),
         ],
       );
     } else {
       btn = Center(child: text);
     }
     final child = AnimatedContainer(
-      width: selected ? kWideWidth : kNarrowWidth,
+      width: selected ? wideWidth : narrowWidth,
       duration: Durations.medium3,
       curve: Curves.fastEaseInToSlowEaseOut,
-      child: OverflowBox(maxWidth: selected ? kWideWidth : null, child: btn),
+      child: btn,
     );
 
-    return InkWell(
-      borderRadius: BorderRadius.circular(13),
-      onTap: () => onTap(idx),
-      child: child,
-    ).paddingSymmetric(horizontal: 7);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 7),
+      child: Material(
+        color: Colors.transparent,
+        borderRadius: BorderRadius.circular(13),
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          borderRadius: BorderRadius.circular(13),
+          onTap: () => onTap(idx),
+          child: child,
+        ),
+      ),
+    );
   }
 }
 
@@ -681,7 +698,7 @@ class _AddPageState extends ConsumerState<_AddPage> {
   @override
   Widget build(BuildContext context) {
     const viewPadding = 7.0;
-    final viewWidth = context.windowSize.width - 2 * viewPadding;
+    final isMobile = ResponsiveBreakpoints.of(context).isMobile;
 
     final serverState = ref.watch(serversProvider);
     final sortBy = Stores.setting.sshPageSortBy.fetch();
@@ -708,61 +725,97 @@ class _AddPageState extends ConsumerState<_AddPage> {
 
     final itemCount = order.length;
     const itemPadding = 1.0;
-    const itemWidth = 150.0;
-    const itemHeight = 50.0;
-
-    final visualCrossCount = viewWidth / itemWidth;
-    final crossCount = max(
-      viewWidth ~/ (visualCrossCount * itemPadding + itemWidth),
-      1,
-    );
-    final mainCount = itemCount ~/ crossCount + 1;
+    final isDesktopWide = !isMobile;
+    const desktopMinItemWidth = 280.0;
+    const desktopMaxItemWidth = 320.0;
 
     if (order.isEmpty) {
       return Center(child: Text(libL10n.empty, textAlign: TextAlign.center));
     }
 
-    return ListView(
-      padding: const EdgeInsets.all(viewPadding),
-      children: List.generate(
-        mainCount,
-        (rowIndex) => Row(
-          children: List.generate(crossCount, (columnIndex) {
-            final idx = rowIndex * crossCount + columnIndex;
-            final id = order.elementAtOrNull(idx);
-            final spi = serverState.servers[id];
-            if (spi == null) return _placeholder;
+    return LayoutBuilder(
+      builder: (_, cons) {
+        final availableWidth = max(cons.maxWidth - 2 * viewPadding, 0.0);
+        final canUseTwoColumns =
+            availableWidth >= 2 * (desktopMinItemWidth + itemPadding);
+        final crossCount = isDesktopWide
+            ? max(
+                availableWidth ~/ (desktopMinItemWidth + itemPadding),
+                canUseTwoColumns ? 2 : 1,
+              )
+            : 1;
+        final mainCount = itemCount ~/ crossCount + 1;
+        final desktopItemWidth = isDesktopWide
+            ? max(
+                0.0,
+                min(
+                  desktopMaxItemWidth,
+                  (availableWidth - crossCount * itemPadding * 2) / crossCount,
+                ),
+              )
+            : null;
 
-            return Expanded(
-              child: Padding(
-                padding: const EdgeInsets.all(itemPadding),
-                child: InkWell(
-                  onTap: () => widget.onTapInitCard(spi),
-                  onLongPress: () => widget.onLongPressInitCard(spi),
-                  child: Container(
-                    height: itemHeight,
-                    alignment: Alignment.centerLeft,
-                    padding: const EdgeInsets.only(left: 17, right: 7),
-                    child: Row(
-                      children: [
-                        Expanded(
-                          child: Text(
-                            spi.name,
-                            style: UIs.text18,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
+        return ListView(
+          padding: const EdgeInsets.all(viewPadding),
+          children: List.generate(
+            mainCount,
+            (rowIndex) => Row(
+              mainAxisAlignment: isDesktopWide
+                  ? MainAxisAlignment.center
+                  : MainAxisAlignment.start,
+              children: List.generate(crossCount, (columnIndex) {
+                final idx = rowIndex * crossCount + columnIndex;
+                final id = order.elementAtOrNull(idx);
+                final spi = serverState.servers[id];
+                if (spi == null) {
+                  return isDesktopWide
+                      ? SizedBox(width: desktopItemWidth)
+                      : _placeholder;
+                }
+
+                final child = Padding(
+                  padding: const EdgeInsets.all(itemPadding),
+                  child: InkWell(
+                    onTap: () => widget.onTapInitCard(spi),
+                    onLongPress: () => widget.onLongPressInitCard(spi),
+                    child: Container(
+                      alignment: Alignment.centerLeft,
+                      constraints: BoxConstraints(
+                        minHeight: isDesktopWide ? 58.0 : 50.0,
+                      ),
+                      padding: const EdgeInsets.only(left: 17, right: 7),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          Expanded(
+                            child: Text(
+                              spi.name,
+                              style: UIs.text18,
+                              maxLines: isDesktopWide ? null : 2,
+                              overflow: isDesktopWide
+                                  ? null
+                                  : TextOverflow.ellipsis,
+                            ),
                           ),
-                        ),
-                        const Icon(Icons.chevron_right),
-                      ],
+                          const Icon(Icons.chevron_right),
+                        ],
+                      ),
                     ),
-                  ),
-                ).cardx,
-              ),
-            );
-          }),
-        ),
-      ),
+                  ).cardx,
+                );
+
+                if (isDesktopWide) {
+                  return SizedBox(width: desktopItemWidth, child: child);
+                }
+
+                return Expanded(
+                  child: Padding(padding: EdgeInsets.zero, child: child),
+                );
+              }),
+            ),
+          ),
+        );
+      },
     );
   }
 }


### PR DESCRIPTION
## Summary
- refine SSH page tab and layout behavior for a cleaner desktop presentation
- adjust snippet list item layout and vertically center the trailing arrow within the full card
- keep these UI/layout tweaks isolated from local-only run environment changes

## Test plan
- [x] Run `flutter run -d macos`
- [x] Open the SSH page and verify the updated tab/layout behavior
- [x] Open the snippet list page and verify the trailing arrow is vertically centered in each card

<img width="932" height="1660" alt="cd89e885da9e18e7d486bc11c85ae016" src="https://github.com/user-attachments/assets/769a7988-81c2-420d-a412-80560969fd82" />
<img width="932" height="1660" alt="107a400757d19c25a8bb3c5cbfc8d046" src="https://github.com/user-attachments/assets/414a5307-f6c1-450e-8091-cf67a1acf64b" />
<img width="2194" height="1554" alt="a7c0eb70e64aa4712c76b39335f0b2c5" src="https://github.com/user-attachments/assets/c2921653-221b-4609-8ce2-400cf7e4f9bf" />
<img width="2194" height="1554" alt="388e28b6091dc366004fb911176805d8" src="https://github.com/user-attachments/assets/609ed037-0e39-4d07-a47f-b5bbaffe31a8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI/UX Improvements**
  * Snippet list: increased item height, tighter text spacing, reduced subtitle lines, right-aligned action icon, and unified tap navigation behavior.
  * Removed legacy split-view controls for a simpler scaffolded experience.
  * SSH tab: responsive tab widths and selection layout, updated tab ink/padding behavior, and deferred history dialog presentation with improved dialog sizing.
  * Grid layout: responsive item counts and desktop-vs-mobile text/truncation and alignment adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->