### PR TITLE
Fix intro flow home window frame wrapping

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -12,6 +12,10 @@ import 'package:server_box/view/page/home.dart';
 
 part 'intro.dart';
 
+Widget _buildHomeWithWindowFrame() {
+  return VirtualWindowFrame(title: BuildData.name, child: const HomePage());
+}
+
 class MyApp extends StatefulWidget {
   const MyApp({super.key});
 
@@ -136,6 +140,7 @@ class _MyAppState extends State<MyApp> {
           if (appL10n != null) l10n = appL10n;
 
           Widget child;
+          var hasWindowFrame = false;
           if (snapshot.connectionState == ConnectionState.waiting) {
             child = const Scaffold(body: Center(child: CircularProgressIndicator()));
           } else {
@@ -143,10 +148,12 @@ class _MyAppState extends State<MyApp> {
             if (intros.isNotEmpty) {
               child = _IntroPage(intros);
             } else {
-              child = const HomePage();
+              child = _buildHomeWithWindowFrame();
+              hasWindowFrame = true;
             }
           }
 
+          if (hasWindowFrame) return child;
           return VirtualWindowFrame(title: BuildData.name, child: child);
         },
       ),

--- a/lib/intro.dart
+++ b/lib/intro.dart
@@ -18,7 +18,7 @@ final class _IntroPage extends StatelessWidget {
             pages: pages_,
             onDone: (ctx) {
               Stores.setting.introVer.put(BuildData.build);
-              Navigator.of(ctx).pushReplacement(MaterialPageRoute(builder: (_) => const HomePage()));
+              Navigator.of(ctx).pushReplacement(MaterialPageRoute(builder: (_) => _buildHomeWithWindowFrame()));
             },
           ),
         );


### PR DESCRIPTION
Resolve #1132 .

## Summary
- Reuse a shared `VirtualWindowFrame` wrapper for the home page.
- Ensure the intro completion path enters the same wrapped home route as normal startup.
- Prevent first-launch title bar overlap on macOS and affected Linux desktops.

## Testing
- Verified with targeted Dart analysis on `lib/app.dart`, `lib/intro.dart`, and `lib/view/page/home.dart`.
- Confirmed the analyzer reports no issues for the changed code path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the application window frame could be duplicated during navigation, particularly after completing the introduction sequence. This ensures consistent presentation across all navigation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->