### PR TITLE
Fix SFTP transfers stalling at 0%

### DIFF
--- a/lib/data/model/sftp/worker.dart
+++ b/lib/data/model/sftp/worker.dart
@@ -13,6 +13,10 @@ import 'package:server_box/data/res/store.dart';
 
 part 'req.dart';
 
+const _sftpTransferChunkSize = 64 * 1024;
+const _sftpDownloadMaxPendingRequests = 16;
+const _sftpUploadMaxBytesOnTheWire = _sftpTransferChunkSize * 4;
+
 class SftpWorker {
   final Function(Object event) onNotify;
   final SftpReq req;
@@ -107,7 +111,6 @@ Future<void> _download(
     mainSendPort.send(size);
     mainSendPort.send(SftpWorkerStatus.loading);
 
-    const chunkSize = 1024 * 1024 * 5;
     var lastProgress = 0;
     final localFile = File(req.localPath).openWrite(mode: FileMode.write);
 
@@ -124,7 +127,8 @@ Future<void> _download(
             mainSendPort.send(progress);
           }
         },
-        chunkSize: chunkSize,
+        chunkSize: _sftpTransferChunkSize,
+        maxPendingRequests: _sftpDownloadMaxPendingRequests,
       );
     } finally {
       await localFile.close();
@@ -179,6 +183,8 @@ Future<void> _upload(
       onProgress: (total) {
         mainSendPort.send(total / localLen * 100);
       },
+      chunkSize: _sftpTransferChunkSize,
+      maxBytesOnTheWire: _sftpUploadMaxBytesOnTheWire,
     );
     await writer.done;
     await file.close();

--- a/lib/data/model/sftp/worker.dart
+++ b/lib/data/model/sftp/worker.dart
@@ -111,7 +111,7 @@ Future<void> _download(
     mainSendPort.send(size);
     mainSendPort.send(SftpWorkerStatus.loading);
 
-    var lastProgress = 0;
+    var lastProgress = -1.0;
     final localFile = File(req.localPath).openWrite(mode: FileMode.write);
 
     try {
@@ -121,7 +121,7 @@ Future<void> _download(
         onProgress: (bytesRead) {
           final s = size;
           if (s == null || s == 0) return;
-          final progress = (bytesRead / s * 100).round();
+          final progress = (bytesRead / s * 100).roundToDouble();
           if (progress != lastProgress) {
             lastProgress = progress;
             mainSendPort.send(progress);

--- a/lib/data/model/sftp/worker.dart
+++ b/lib/data/model/sftp/worker.dart
@@ -178,10 +178,16 @@ Future<void> _upload(
           SftpFileOpenMode.create |
           SftpFileOpenMode.write,
     );
+    var lastProgress = -1;
     final writer = file.write(
       localFile,
       onProgress: (total) {
-        mainSendPort.send(total / localLen * 100);
+        if (localLen == 0) return;
+        final progress = (total / localLen * 100).round();
+        if (progress != lastProgress) {
+          lastProgress = progress;
+          mainSendPort.send(progress.toDouble());
+        }
       },
       chunkSize: _sftpTransferChunkSize,
       maxBytesOnTheWire: _sftpUploadMaxBytesOnTheWire,


### PR DESCRIPTION
Relate to #1147.

## Summary
- Reduce SFTP transfer concurrency to avoid progress stalling on tunneled or high-latency networks.
- Use a smaller shared chunk size for both download and upload paths.
- Cap pending download reads and in-flight upload bytes to keep progress updates moving.

## Testing
- `dart analyze lib test` passed.
- Focused SFTP-related logic was updated to use the new transfer limits; no UI behavior changes were introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * SFTP download and upload transfers optimized using shared transfer tuning for more consistent throughput and resource use.

* **Bug Fixes / UX**
  * Download progress now reported only on meaningful rounded changes to reduce noise.
  * Upload progress smoothed, de-duplicated and emitted as integer-based values for steadier, clearer updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->