### PR TITLE
添加手动 test-build 工作流并上传全平台构建产物

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -30,8 +30,8 @@ jobs:
           java-version: "21"
       - name: Fetch secrets
         run: |
-          curl -u ${{ secrets.BASIC_AUTH }} -o android/app/app.key ${{ secrets.URL_PREFIX }}app.key
-          curl -u ${{ secrets.BASIC_AUTH }} -o android/key.properties ${{ secrets.URL_PREFIX }}key.properties
+          curl --fail --show-error --location -u ${{ secrets.BASIC_AUTH }} -o android/app/app.key ${{ secrets.URL_PREFIX }}app.key
+          curl --fail --show-error --location -u ${{ secrets.BASIC_AUTH }} -o android/key.properties ${{ secrets.URL_PREFIX }}key.properties
       - name: Build
         run: dart run fl_build -p android
       - name: Verify F-Droid native libraries

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,113 @@
+name: Flutter Test Build
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  APP_NAME: ServerBox
+  BUILD_TAG: test-build-${{ github.run_number }}-${{ github.sha }}
+
+jobs:
+  buildAndroid:
+    name: Build android
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+          flutter-version: "3.41.4"
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "zulu"
+          java-version: "21"
+      - name: Fetch secrets
+        run: |
+          curl -u ${{ secrets.BASIC_AUTH }} -o android/app/app.key ${{ secrets.URL_PREFIX }}app.key
+          curl -u ${{ secrets.BASIC_AUTH }} -o android/key.properties ${{ secrets.URL_PREFIX }}key.properties
+      - name: Build
+        run: dart run fl_build -p android
+      - name: Verify F-Droid native libraries
+        run: scripts/release/verify-fdroid-native-libs.sh
+      - name: Collect artifacts
+        shell: bash
+        run: |
+          mkdir -p artifacts/android
+          cp build/app/outputs/flutter-apk/*.apk artifacts/android/
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.APP_NAME }}-${{ env.BUILD_TAG }}-android
+          path: artifacts/android/*.apk
+          if-no-files-found: error
+          retention-days: 14
+
+  buildLinux:
+    name: Build linux
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runs_on: ubuntu-latest
+            artifact_suffix: ""
+          - runs_on: ubuntu-22.04
+            artifact_suffix: "-legacy"
+    runs-on: ${{ matrix.runs_on }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y clang cmake ninja-build pkg-config libgtk-3-dev mesa-utils libvulkan-dev desktop-file-utils wget
+          sudo apt install -y libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libunwind-dev libsecret-1-dev
+      - name: Build
+        run: dart run fl_build -p linux
+      - name: Collect artifacts
+        shell: bash
+        run: |
+          mkdir -p artifacts/linux
+          cp *.AppImage artifacts/linux/
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.APP_NAME }}-${{ env.BUILD_TAG }}-linux${{ matrix.artifact_suffix }}
+          path: artifacts/linux/*.AppImage
+          if-no-files-found: error
+          retention-days: 14
+
+  buildWindows:
+    name: Build windows
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+      - name: Build
+        run: dart run fl_build -p windows
+      - name: Collect artifacts
+        shell: bash
+        run: |
+          mkdir -p artifacts/windows
+          cp *_windows_amd64.zip artifacts/windows/
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.APP_NAME }}-${{ env.BUILD_TAG }}-windows
+          path: artifacts/windows/*_windows_amd64.zip
+          if-no-files-found: error
+          retention-days: 14


### PR DESCRIPTION
## Summary
- 新增 `workflow_dispatch` 的通用 `test-build` 工作流，独立于正式 Release 流程。
- 复用现有构建步骤，分别生成 Android、Linux（含 legacy）和 Windows 产物。
- 仅上传 GitHub Actions Artifacts，不执行发布到任何平台。

## Testing
- 已检查 workflow 内容与现有 `release.yml` 的构建路径一致性。
- 未运行实际 CI 构建；仅进行了配置层面的核对。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated build workflow producing artifacts for Android, Linux, and Windows.
  * Per-build artifacts are generated and uploaded for each platform for easy retrieval.
  * Linux builds now produce both standard and legacy variants for broader compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->