### PR TITLE
Add SFTP timeouts and stabilize build workflow

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -30,8 +30,8 @@ jobs:
           java-version: "21"
       - name: Fetch secrets
         run: |
-          curl -u ${{ secrets.BASIC_AUTH }} -o android/app/app.key ${{ secrets.URL_PREFIX }}app.key
-          curl -u ${{ secrets.BASIC_AUTH }} -o android/key.properties ${{ secrets.URL_PREFIX }}key.properties
+          curl --fail --show-error --location -u ${{ secrets.BASIC_AUTH }} -o android/app/app.key ${{ secrets.URL_PREFIX }}app.key
+          curl --fail --show-error --location -u ${{ secrets.BASIC_AUTH }} -o android/key.properties ${{ secrets.URL_PREFIX }}key.properties
       - name: Build
         run: dart run fl_build -p android
       - name: Verify F-Droid native libraries

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -1,0 +1,113 @@
+name: Flutter Test Build
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  APP_NAME: ServerBox
+  BUILD_TAG: test-build-${{ github.run_number }}-${{ github.sha }}
+
+jobs:
+  buildAndroid:
+    name: Build android
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+          flutter-version: "3.41.4"
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "zulu"
+          java-version: "21"
+      - name: Fetch secrets
+        run: |
+          curl -u ${{ secrets.BASIC_AUTH }} -o android/app/app.key ${{ secrets.URL_PREFIX }}app.key
+          curl -u ${{ secrets.BASIC_AUTH }} -o android/key.properties ${{ secrets.URL_PREFIX }}key.properties
+      - name: Build
+        run: dart run fl_build -p android
+      - name: Verify F-Droid native libraries
+        run: scripts/release/verify-fdroid-native-libs.sh
+      - name: Collect artifacts
+        shell: bash
+        run: |
+          mkdir -p artifacts/android
+          cp build/app/outputs/flutter-apk/*.apk artifacts/android/
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.APP_NAME }}-${{ env.BUILD_TAG }}-android
+          path: artifacts/android/*.apk
+          if-no-files-found: error
+          retention-days: 14
+
+  buildLinux:
+    name: Build linux
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runs_on: ubuntu-latest
+            artifact_suffix: ""
+          - runs_on: ubuntu-22.04
+            artifact_suffix: "-legacy"
+    runs-on: ${{ matrix.runs_on }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y clang cmake ninja-build pkg-config libgtk-3-dev mesa-utils libvulkan-dev desktop-file-utils wget
+          sudo apt install -y libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libunwind-dev libsecret-1-dev
+      - name: Build
+        run: dart run fl_build -p linux
+      - name: Collect artifacts
+        shell: bash
+        run: |
+          mkdir -p artifacts/linux
+          cp *.AppImage artifacts/linux/
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.APP_NAME }}-${{ env.BUILD_TAG }}-linux${{ matrix.artifact_suffix }}
+          path: artifacts/linux/*.AppImage
+          if-no-files-found: error
+          retention-days: 14
+
+  buildWindows:
+    name: Build windows
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+      - name: Build
+        run: dart run fl_build -p windows
+      - name: Collect artifacts
+        shell: bash
+        run: |
+          mkdir -p artifacts/windows
+          cp *_windows_amd64.zip artifacts/windows/
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.APP_NAME }}-${{ env.BUILD_TAG }}-windows
+          path: artifacts/windows/*_windows_amd64.zip
+          if-no-files-found: error
+          retention-days: 14

--- a/lib/core/utils/sftp_sudo.dart
+++ b/lib/core/utils/sftp_sudo.dart
@@ -14,14 +14,14 @@ final _octalPermReg = RegExp(r'^[0-7]{3,4}$');
 final class SftpSudoHelper {
   final SSHClient client;
   final Spi spi;
-  final BuildContext context;
+  final BuildContext? Function() contextProvider;
 
   String? _cachedPassword;
 
   SftpSudoHelper({
     required this.client,
     required this.spi,
-    required this.context,
+    required this.contextProvider,
   });
 
   bool get enabled => !spi.isRoot;
@@ -36,6 +36,9 @@ final class SftpSudoHelper {
     } else if (_rememberPwd && _cachedPassword != null) {
       return _cachedPassword;
     }
+
+    final context = contextProvider();
+    if (context == null || !context.mounted) return null;
 
     final pwd = await context.showPwdDialog(
       title: l10n.trySudo,
@@ -86,13 +89,13 @@ final class SftpSudoHelper {
     );
   }
 
-  Future<void> chmod(
-    String perm,
-    String remotePath, {
-    String? password,
-  }) async {
+  Future<void> chmod(String perm, String remotePath, {String? password}) async {
     if (!_octalPermReg.hasMatch(perm)) {
-      throw ArgumentError.value(perm, 'perm', 'Permission must be a 3 or 4 digit octal string');
+      throw ArgumentError.value(
+        perm,
+        'perm',
+        'Permission must be a 3 or 4 digit octal string',
+      );
     }
     await _runAndRead(
       'chmod $perm ${_shellQuote(remotePath)}',
@@ -100,24 +103,12 @@ final class SftpSudoHelper {
     );
   }
 
-  Future<void> mkdir(
-    String remotePath, {
-    String? password,
-  }) async {
-    await _runAndRead(
-      'mkdir ${_shellQuote(remotePath)}',
-      password: password,
-    );
+  Future<void> mkdir(String remotePath, {String? password}) async {
+    await _runAndRead('mkdir ${_shellQuote(remotePath)}', password: password);
   }
 
-  Future<void> touch(
-    String remotePath, {
-    String? password,
-  }) async {
-    await _runAndRead(
-      'touch ${_shellQuote(remotePath)}',
-      password: password,
-    );
+  Future<void> touch(String remotePath, {String? password}) async {
+    await _runAndRead('touch ${_shellQuote(remotePath)}', password: password);
   }
 
   Future<void> rename(
@@ -145,10 +136,7 @@ final class SftpSudoHelper {
     await _runAndRead(cmd, password: password);
   }
 
-  Future<List<SftpName>> listDir(
-    String remotePath, {
-    String? password,
-  }) async {
+  Future<List<SftpName>> listDir(String remotePath, {String? password}) async {
     final output = await _runAndRead(
       'find ${_shellQuote(remotePath)} '
       '-mindepth 1 -maxdepth 1 '
@@ -193,11 +181,7 @@ final class SftpSudoHelper {
         SftpName(
           filename: filename,
           longname: filename,
-          attr: SftpFileAttrs(
-            size: size,
-            mode: mode,
-            modifyTime: modifyTime,
-          ),
+          attr: SftpFileAttrs(size: size, mode: mode, modifyTime: modifyTime),
         ),
       );
     }
@@ -205,16 +189,13 @@ final class SftpSudoHelper {
     return items;
   }
 
-  Future<String> _runAndRead(
-    String innerCommand, {
-    String? password,
-  }) async {
+  Future<String> _runAndRead(String innerCommand, {String? password}) async {
     final pwd = password ?? await ensurePassword();
     if (pwd == null) throw const _SftpSudoCancelled();
 
     final (code, output) = await client.execWithPwd(
       _buildSudoCommand(innerCommand, pwd),
-      context: context,
+      context: contextProvider(),
       id: '${spi.id}_sftp_sudo',
     );
 
@@ -225,7 +206,7 @@ final class SftpSudoHelper {
 
       final retry = await client.execWithPwd(
         _buildSudoCommand(innerCommand, retryPwd),
-        context: context,
+        context: contextProvider(),
         id: '${spi.id}_sftp_sudo',
       );
       if (retry.$1 == 2) {
@@ -233,13 +214,17 @@ final class SftpSudoHelper {
         throw Exception('Incorrect sudo password');
       }
       if (retry.$1 != 0) {
-        throw Exception(retry.$2.trim().isEmpty ? 'Sudo command failed' : retry.$2.trim());
+        throw Exception(
+          retry.$2.trim().isEmpty ? 'Sudo command failed' : retry.$2.trim(),
+        );
       }
       return retry.$2;
     }
 
     if (code != 0) {
-      throw Exception(output.trim().isEmpty ? 'Sudo command failed' : output.trim());
+      throw Exception(
+        output.trim().isEmpty ? 'Sudo command failed' : output.trim(),
+      );
     }
     return output;
   }

--- a/lib/data/model/sftp/browser_status.dart
+++ b/lib/data/model/sftp/browser_status.dart
@@ -8,10 +8,6 @@ class SftpBrowserStatus {
   final List<SftpName> files = [];
   final path = _AbsolutePath(_sep);
   SftpClient? client;
-
-  SftpBrowserStatus(SSHClient client) {
-    client.sftp().then((value) => this.client = value);
-  }
 }
 
 class _AbsolutePath {

--- a/lib/data/model/sftp/worker.dart
+++ b/lib/data/model/sftp/worker.dart
@@ -16,6 +16,17 @@ part 'req.dart';
 const _sftpTransferChunkSize = 64 * 1024;
 const _sftpDownloadMaxPendingRequests = 16;
 const _sftpUploadMaxBytesOnTheWire = _sftpTransferChunkSize * 4;
+const _sftpOperationTimeout = Duration(seconds: 30);
+
+Future<T> _withSftpTimeout<T>(Future<T> future, String operation) {
+  return future.timeout(
+    _sftpOperationTimeout,
+    onTimeout: () => throw TimeoutException(
+      'SFTP $operation timed out',
+      _sftpOperationTimeout,
+    ),
+  );
+}
 
 class SftpWorker {
   final Function(Object event) onNotify;
@@ -94,12 +105,18 @@ Future<void> _download(
     );
     await Directory(dirPath).create(recursive: true);
 
-    final sftp = await client.sftp();
+    final sftp = await _withSftpTimeout(client.sftp(), 'open session');
 
-    final remoteFile = await sftp.open(req.remotePath);
+    final remoteFile = await _withSftpTimeout(
+      sftp.open(req.remotePath),
+      'open remote file',
+    );
     int? size;
     try {
-      size = (await remoteFile.stat()).size;
+      size = (await _withSftpTimeout(
+        remoteFile.stat(),
+        'stat remote file',
+      )).size;
       if (size == null) {
         mainSendPort.send(Exception('can\'t get file size: ${req.remotePath}'));
         return;
@@ -169,14 +186,17 @@ Future<void> _upload(
     mainSendPort.send(localLen);
     mainSendPort.send(SftpWorkerStatus.loading);
     final localFile = local.openRead().cast<Uint8List>();
-    final sftp = await client.sftp();
+    final sftp = await _withSftpTimeout(client.sftp(), 'open session');
     // If remote exists, overwrite it
-    final file = await sftp.open(
-      req.remotePath,
-      mode:
-          SftpFileOpenMode.truncate |
-          SftpFileOpenMode.create |
-          SftpFileOpenMode.write,
+    final file = await _withSftpTimeout(
+      sftp.open(
+        req.remotePath,
+        mode:
+            SftpFileOpenMode.truncate |
+            SftpFileOpenMode.create |
+            SftpFileOpenMode.write,
+      ),
+      'open remote file',
     );
     var lastProgress = -1;
     final writer = file.write(

--- a/lib/data/provider/server/single.dart
+++ b/lib/data/provider/server/single.dart
@@ -463,6 +463,20 @@ class ServerNotifier extends _$ServerNotifier {
         );
         return;
       }
+    } on TimeoutException catch (e) {
+      final newStatus = _copyStatus(
+        state.status,
+        err: SSHErr(type: SSHErrType.getStatus, message: e.toString()),
+        setErr: true,
+      );
+      updateStatus(newStatus);
+      if (state.client != null && !state.client!.isClosed) {
+        updateConnection(ServerConn.connected);
+        final sessionId = 'ssh_${spi.id}';
+        TermSessionManager.updateStatus(sessionId, TermSessionStatus.connected);
+      }
+      Loggers.app.warning('Get status from ${spi.name} timed out', e);
+      return;
     } catch (e) {
       TryLimiter.inc(sid);
       final newStatus = _copyStatus(

--- a/lib/view/page/storage/sftp.dart
+++ b/lib/view/page/storage/sftp.dart
@@ -29,6 +29,17 @@ final _sftpPermissionDeniedReg = RegExp(
   r'permission denied',
   caseSensitive: false,
 );
+const _sftpOperationTimeout = Duration(seconds: 30);
+
+Future<T> _withSftpTimeout<T>(Future<T> future, String operation) {
+  return future.timeout(
+    _sftpOperationTimeout,
+    onTimeout: () => throw TimeoutException(
+      'SFTP $operation timed out',
+      _sftpOperationTimeout,
+    ),
+  );
+}
 
 final class SftpPageArgs {
   final Spi spi;
@@ -71,11 +82,11 @@ class _SftpPageState extends ConsumerState<SftpPage> with AfterLayoutMixin {
     super.initState();
     final serverState = ref.read(serverProvider(widget.args.spi.id));
     _client = serverState.client!;
-    _status = SftpBrowserStatus(_client);
+    _status = SftpBrowserStatus();
     _sudoHelper = SftpSudoHelper(
       client: _client,
       spi: widget.args.spi,
-      context: context,
+      contextProvider: () => mounted ? context : null,
     );
   }
 
@@ -136,8 +147,11 @@ class _SftpPageState extends ConsumerState<SftpPage> with AfterLayoutMixin {
         SftpClient? sftp;
         try {
           final normalizedHistory = _normalizeSftpPath(history);
-          sftp = await _client.sftp();
-          await sftp.listdir(normalizedHistory);
+          sftp = await _withSftpTimeout(_client.sftp(), 'open session');
+          await _withSftpTimeout(
+            sftp!.listdir(normalizedHistory),
+            'list directory',
+          );
           initPath = normalizedHistory;
         } catch (_) {
         } finally {
@@ -147,7 +161,7 @@ class _SftpPageState extends ConsumerState<SftpPage> with AfterLayoutMixin {
     }
 
     _status.path.path = widget.args.initPath ?? initPath;
-    unawaited(_listDir());
+    unawaited(_listDir(context));
   }
 }
 
@@ -946,7 +960,11 @@ extension _Actions on _SftpPageState {
   }
 
   /// Only return true if the path is changed
-  Future<bool?> _listDir() async {
+  Future<bool?> _listDir([BuildContext? dialogContext]) async {
+    if (dialogContext == null && !mounted) return false;
+    final context = dialogContext ?? this.context;
+    if (!context.mounted) return false;
+
     final (ret, err) = await context.showLoadingDialog(
       fn: () async {
         final listPath = _status.path.path;
@@ -1004,8 +1022,11 @@ extension _Actions on _SftpPageState {
     }
 
     try {
-      _status.client ??= await _client.sftp();
-      return await _status.client?.listdir(listPath);
+      _status.client ??= await _withSftpTimeout(_client.sftp(), 'open session');
+      return await _withSftpTimeout(
+        _status.client!.listdir(listPath),
+        'list directory',
+      );
     } on SftpStatusError catch (e) {
       final canFallback =
           _sudoHelper.enabled &&


### PR DESCRIPTION
## Summary
- Add 30s timeouts around SFTP session, file, and directory operations to prevent hangs during browse, upload, and download flows.
- Make SFTP sudo password prompting resilient when the page context is no longer mounted.
- Handle SFTP status timeouts explicitly so the server connection state stays consistent.
- Remove the eager SFTP client creation from browser status initialization and keep the page flow lazy.
- Add a manual GitHub Actions workflow to build Android, Linux, and Windows artifacts.

## Testing
- Not run (not requested)
- Workflow and timeout paths were validated by code review; no local build or integration run was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated test build workflow for Android, Linux, and Windows platforms.

* **Bug Fixes**
  * Improved timeout handling for SFTP operations with a 30-second timeout limit.
  * Enhanced server status retrieval to handle timeout exceptions gracefully, maintaining connection state when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->