### PR TITLE
fix: Fix issues with the SFTP lifecycle and protocol timing

### DIFF
--- a/lib/core/utils/sftp_sudo.dart
+++ b/lib/core/utils/sftp_sudo.dart
@@ -14,14 +14,14 @@ final _octalPermReg = RegExp(r'^[0-7]{3,4}$');
 final class SftpSudoHelper {
   final SSHClient client;
   final Spi spi;
-  final BuildContext context;
+  final BuildContext? Function() contextProvider;
 
   String? _cachedPassword;
 
   SftpSudoHelper({
     required this.client,
     required this.spi,
-    required this.context,
+    required this.contextProvider,
   });
 
   bool get enabled => !spi.isRoot;
@@ -36,6 +36,9 @@ final class SftpSudoHelper {
     } else if (_rememberPwd && _cachedPassword != null) {
       return _cachedPassword;
     }
+
+    final context = contextProvider();
+    if (context == null || !context.mounted) return null;
 
     final pwd = await context.showPwdDialog(
       title: l10n.trySudo,
@@ -86,13 +89,13 @@ final class SftpSudoHelper {
     );
   }
 
-  Future<void> chmod(
-    String perm,
-    String remotePath, {
-    String? password,
-  }) async {
+  Future<void> chmod(String perm, String remotePath, {String? password}) async {
     if (!_octalPermReg.hasMatch(perm)) {
-      throw ArgumentError.value(perm, 'perm', 'Permission must be a 3 or 4 digit octal string');
+      throw ArgumentError.value(
+        perm,
+        'perm',
+        'Permission must be a 3 or 4 digit octal string',
+      );
     }
     await _runAndRead(
       'chmod $perm ${_shellQuote(remotePath)}',
@@ -100,24 +103,12 @@ final class SftpSudoHelper {
     );
   }
 
-  Future<void> mkdir(
-    String remotePath, {
-    String? password,
-  }) async {
-    await _runAndRead(
-      'mkdir ${_shellQuote(remotePath)}',
-      password: password,
-    );
+  Future<void> mkdir(String remotePath, {String? password}) async {
+    await _runAndRead('mkdir ${_shellQuote(remotePath)}', password: password);
   }
 
-  Future<void> touch(
-    String remotePath, {
-    String? password,
-  }) async {
-    await _runAndRead(
-      'touch ${_shellQuote(remotePath)}',
-      password: password,
-    );
+  Future<void> touch(String remotePath, {String? password}) async {
+    await _runAndRead('touch ${_shellQuote(remotePath)}', password: password);
   }
 
   Future<void> rename(
@@ -145,10 +136,7 @@ final class SftpSudoHelper {
     await _runAndRead(cmd, password: password);
   }
 
-  Future<List<SftpName>> listDir(
-    String remotePath, {
-    String? password,
-  }) async {
+  Future<List<SftpName>> listDir(String remotePath, {String? password}) async {
     final output = await _runAndRead(
       'find ${_shellQuote(remotePath)} '
       '-mindepth 1 -maxdepth 1 '
@@ -193,11 +181,7 @@ final class SftpSudoHelper {
         SftpName(
           filename: filename,
           longname: filename,
-          attr: SftpFileAttrs(
-            size: size,
-            mode: mode,
-            modifyTime: modifyTime,
-          ),
+          attr: SftpFileAttrs(size: size, mode: mode, modifyTime: modifyTime),
         ),
       );
     }
@@ -205,12 +189,11 @@ final class SftpSudoHelper {
     return items;
   }
 
-  Future<String> _runAndRead(
-    String innerCommand, {
-    String? password,
-  }) async {
+  Future<String> _runAndRead(String innerCommand, {String? password}) async {
     final pwd = password ?? await ensurePassword();
     if (pwd == null) throw const _SftpSudoCancelled();
+    final context = contextProvider();
+    if (context == null || !context.mounted) throw const _SftpSudoCancelled();
 
     final (code, output) = await client.execWithPwd(
       _buildSudoCommand(innerCommand, pwd),
@@ -222,10 +205,14 @@ final class SftpSudoHelper {
       _cachedPassword = null;
       final retryPwd = await ensurePassword(force: true);
       if (retryPwd == null) throw const _SftpSudoCancelled();
+      final retryContext = contextProvider();
+      if (retryContext == null || !retryContext.mounted) {
+        throw const _SftpSudoCancelled();
+      }
 
       final retry = await client.execWithPwd(
         _buildSudoCommand(innerCommand, retryPwd),
-        context: context,
+        context: retryContext,
         id: '${spi.id}_sftp_sudo',
       );
       if (retry.$1 == 2) {
@@ -233,13 +220,17 @@ final class SftpSudoHelper {
         throw Exception('Incorrect sudo password');
       }
       if (retry.$1 != 0) {
-        throw Exception(retry.$2.trim().isEmpty ? 'Sudo command failed' : retry.$2.trim());
+        throw Exception(
+          retry.$2.trim().isEmpty ? 'Sudo command failed' : retry.$2.trim(),
+        );
       }
       return retry.$2;
     }
 
     if (code != 0) {
-      throw Exception(output.trim().isEmpty ? 'Sudo command failed' : output.trim());
+      throw Exception(
+        output.trim().isEmpty ? 'Sudo command failed' : output.trim(),
+      );
     }
     return output;
   }

--- a/lib/data/model/sftp/browser_status.dart
+++ b/lib/data/model/sftp/browser_status.dart
@@ -9,9 +9,7 @@ class SftpBrowserStatus {
   final path = _AbsolutePath(_sep);
   SftpClient? client;
 
-  SftpBrowserStatus(SSHClient client) {
-    client.sftp().then((value) => this.client = value);
-  }
+  SftpBrowserStatus();
 }
 
 class _AbsolutePath {

--- a/lib/data/model/sftp/req.dart
+++ b/lib/data/model/sftp/req.dart
@@ -11,8 +11,10 @@ class SftpReq {
   Map<String, Spi>? jumpSpisById;
   Map<String, String>? privateKeysByKeyId;
   Map<String, String>? knownHostFingerprints;
+  late final int timeoutSeconds;
 
   SftpReq(this.spi, this.remotePath, this.localPath, this.type) {
+    timeoutSeconds = Stores.setting.timeout.fetch();
     privateKeysByKeyId = {};
 
     final keyId = spi.keyId;

--- a/lib/data/model/sftp/worker.dart
+++ b/lib/data/model/sftp/worker.dart
@@ -13,9 +13,29 @@ import 'package:server_box/data/res/store.dart';
 
 part 'req.dart';
 
-const _sftpTransferChunkSize = 64 * 1024;
-const _sftpDownloadMaxPendingRequests = 16;
-const _sftpUploadMaxBytesOnTheWire = _sftpTransferChunkSize * 4;
+const _sftpTransferChunkSize = 32 * 1024;
+const _sftpDownloadMaxPendingRequests = 64;
+const _sftpUploadMaxBytesOnTheWire = _sftpTransferChunkSize * 64;
+
+Duration _sftpPrepareTimeout(SftpReq req) {
+  final seconds = req.timeoutSeconds;
+  return Duration(seconds: seconds <= 0 ? 5 : seconds);
+}
+
+Future<T> _withSftpPrepareTimeout<T>(
+  SftpReq req,
+  String operation,
+  Future<T> future,
+) async {
+  final timeout = _sftpPrepareTimeout(req);
+  try {
+    return await future.timeout(timeout);
+  } on TimeoutException catch (e, s) {
+    final error = TimeoutException('SFTP $operation timed out', timeout);
+    Loggers.app.warning(error.message, e, s);
+    throw error;
+  }
+}
 
 class SftpWorker {
   final Function(Object event) onNotify;
@@ -87,6 +107,7 @@ Future<void> _download(
       knownHostFingerprints: req.knownHostFingerprints,
     );
     mainSendPort.send(SftpWorkerStatus.sshConnectted);
+    Loggers.app.info('SFTP download SSH connected: ${req.remotePath}');
 
     final dirPath = req.localPath.substring(
       0,
@@ -94,34 +115,48 @@ Future<void> _download(
     );
     await Directory(dirPath).create(recursive: true);
 
-    final sftp = await client.sftp();
+    Loggers.app.info('SFTP download opening session: ${req.remotePath}');
+    final sftp = await _withSftpPrepareTimeout(
+      req,
+      'open download session',
+      client.sftp(),
+    );
 
-    final remoteFile = await sftp.open(req.remotePath);
-    int? size;
-    try {
-      size = (await remoteFile.stat()).size;
-      if (size == null) {
-        mainSendPort.send(Exception('can\'t get file size: ${req.remotePath}'));
-        return;
-      }
-    } finally {
+    Loggers.app.info('SFTP download opening remote file: ${req.remotePath}');
+    final remoteFile = await _withSftpPrepareTimeout(
+      req,
+      'open remote file for download',
+      sftp.open(req.remotePath),
+    );
+    Loggers.app.info('SFTP download reading remote size: ${req.remotePath}');
+    final size = (await _withSftpPrepareTimeout(
+      req,
+      'stat remote file',
+      remoteFile.stat(),
+    )).size;
+    if (size == null) {
       await remoteFile.close();
+      mainSendPort.send(Exception('can\'t get file size: ${req.remotePath}'));
+      return;
     }
 
     mainSendPort.send(size);
     mainSendPort.send(SftpWorkerStatus.loading);
+    Loggers.app.info(
+      'SFTP download started: ${req.remotePath}, '
+      'chunk=$_sftpTransferChunkSize, pending=$_sftpDownloadMaxPendingRequests',
+    );
 
     var lastProgress = -1.0;
     final localFile = File(req.localPath).openWrite(mode: FileMode.write);
 
     try {
-      await sftp.download(
-        req.remotePath,
+      await remoteFile.downloadTo(
         localFile,
+        length: size,
         onProgress: (bytesRead) {
-          final s = size;
-          if (s == null || s == 0) return;
-          final progress = (bytesRead / s * 100).roundToDouble();
+          if (size == 0) return;
+          final progress = (bytesRead / size * 100).roundToDouble();
           if (progress != lastProgress) {
             lastProgress = progress;
             mainSendPort.send(progress);
@@ -132,11 +167,13 @@ Future<void> _download(
       );
     } finally {
       await localFile.close();
+      await remoteFile.close();
     }
 
     mainSendPort.send(watch.elapsed);
     mainSendPort.send(SftpWorkerStatus.finished);
-  } catch (e) {
+  } catch (e, s) {
+    Loggers.app.warning('SFTP download failed: ${req.remotePath}', e, s);
     mainSendPort.send(e);
   }
 }
@@ -159,6 +196,7 @@ Future<void> _upload(
       knownHostFingerprints: req.knownHostFingerprints,
     );
     mainSendPort.send(SftpWorkerStatus.sshConnectted);
+    Loggers.app.info('SFTP upload SSH connected: ${req.remotePath}');
 
     final local = File(req.localPath);
     if (!await local.exists()) {
@@ -167,36 +205,54 @@ Future<void> _upload(
     }
     final localLen = await local.length();
     mainSendPort.send(localLen);
-    mainSendPort.send(SftpWorkerStatus.loading);
     final localFile = local.openRead().cast<Uint8List>();
-    final sftp = await client.sftp();
+    Loggers.app.info('SFTP upload opening session: ${req.remotePath}');
+    final sftp = await _withSftpPrepareTimeout(
+      req,
+      'open upload session',
+      client.sftp(),
+    );
     // If remote exists, overwrite it
-    final file = await sftp.open(
-      req.remotePath,
-      mode:
-          SftpFileOpenMode.truncate |
-          SftpFileOpenMode.create |
-          SftpFileOpenMode.write,
+    Loggers.app.info('SFTP upload opening remote file: ${req.remotePath}');
+    final file = await _withSftpPrepareTimeout(
+      req,
+      'open remote file for upload',
+      sftp.open(
+        req.remotePath,
+        mode:
+            SftpFileOpenMode.truncate |
+            SftpFileOpenMode.create |
+            SftpFileOpenMode.write,
+      ),
+    );
+    mainSendPort.send(SftpWorkerStatus.loading);
+    Loggers.app.info(
+      'SFTP upload started: ${req.remotePath}, '
+      'chunk=$_sftpTransferChunkSize, maxBytes=$_sftpUploadMaxBytesOnTheWire',
     );
     var lastProgress = -1;
-    final writer = file.write(
-      localFile,
-      onProgress: (total) {
-        if (localLen == 0) return;
-        final progress = (total / localLen * 100).round();
-        if (progress != lastProgress) {
-          lastProgress = progress;
-          mainSendPort.send(progress.toDouble());
-        }
-      },
-      chunkSize: _sftpTransferChunkSize,
-      maxBytesOnTheWire: _sftpUploadMaxBytesOnTheWire,
-    );
-    await writer.done;
-    await file.close();
+    try {
+      final writer = file.write(
+        localFile,
+        onProgress: (total) {
+          if (localLen == 0) return;
+          final progress = (total / localLen * 100).round();
+          if (progress != lastProgress) {
+            lastProgress = progress;
+            mainSendPort.send(progress.toDouble());
+          }
+        },
+        chunkSize: _sftpTransferChunkSize,
+        maxBytesOnTheWire: _sftpUploadMaxBytesOnTheWire,
+      );
+      await writer.done;
+    } finally {
+      await file.close();
+    }
     mainSendPort.send(watch.elapsed);
     mainSendPort.send(SftpWorkerStatus.finished);
-  } catch (e) {
+  } catch (e, s) {
+    Loggers.app.warning('SFTP upload failed: ${req.remotePath}', e, s);
     mainSendPort.send(e);
   }
 }

--- a/lib/data/model/sftp/worker.dart
+++ b/lib/data/model/sftp/worker.dart
@@ -94,10 +94,16 @@ Future<void> _download(
   SendPort mainSendPort,
   SendErrorFunction sendError,
 ) async {
+  SSHClient? client;
+  SftpClient? sftp;
+  SftpFile? remoteFile;
+  Object? error;
+  StackTrace? stackTrace;
+
   try {
     mainSendPort.send(SftpWorkerStatus.preparing);
     final watch = Stopwatch()..start();
-    final client = await genClient(
+    client = await genClient(
       req.spi,
       privateKey: req.privateKey,
       jumpSpi: req.jumpSpi,
@@ -116,28 +122,28 @@ Future<void> _download(
     await Directory(dirPath).create(recursive: true);
 
     Loggers.app.info('SFTP download opening session: ${req.remotePath}');
-    final sftp = await _withSftpPrepareTimeout(
+    final openedSftp = await _withSftpPrepareTimeout(
       req,
       'open download session',
       client.sftp(),
     );
+    sftp = openedSftp;
 
     Loggers.app.info('SFTP download opening remote file: ${req.remotePath}');
-    final remoteFile = await _withSftpPrepareTimeout(
+    final openedRemoteFile = await _withSftpPrepareTimeout(
       req,
       'open remote file for download',
-      sftp.open(req.remotePath),
+      openedSftp.open(req.remotePath),
     );
+    remoteFile = openedRemoteFile;
     Loggers.app.info('SFTP download reading remote size: ${req.remotePath}');
     final size = (await _withSftpPrepareTimeout(
       req,
       'stat remote file',
-      remoteFile.stat(),
+      openedRemoteFile.stat(),
     )).size;
     if (size == null) {
-      await remoteFile.close();
-      mainSendPort.send(Exception('can\'t get file size: ${req.remotePath}'));
-      return;
+      throw Exception('can\'t get file size: ${req.remotePath}');
     }
 
     mainSendPort.send(size);
@@ -151,7 +157,7 @@ Future<void> _download(
     final localFile = File(req.localPath).openWrite(mode: FileMode.write);
 
     try {
-      await remoteFile.downloadTo(
+      await openedRemoteFile.downloadTo(
         localFile,
         length: size,
         onProgress: (bytesRead) {
@@ -167,14 +173,28 @@ Future<void> _download(
       );
     } finally {
       await localFile.close();
-      await remoteFile.close();
     }
 
     mainSendPort.send(watch.elapsed);
     mainSendPort.send(SftpWorkerStatus.finished);
   } catch (e, s) {
-    Loggers.app.warning('SFTP download failed: ${req.remotePath}', e, s);
-    mainSendPort.send(e);
+    error = e;
+    stackTrace = s;
+  } finally {
+    await _closeSftpResources(
+      remoteFile: remoteFile,
+      sftp: sftp,
+      client: client,
+    );
+  }
+
+  if (error != null) {
+    Loggers.app.warning(
+      'SFTP download failed: ${req.remotePath}',
+      error,
+      stackTrace,
+    );
+    mainSendPort.send(error);
   }
 }
 
@@ -183,10 +203,16 @@ Future<void> _upload(
   SendPort mainSendPort,
   SendErrorFunction sendError,
 ) async {
+  SSHClient? client;
+  SftpClient? sftp;
+  SftpFile? remoteFile;
+  Object? error;
+  StackTrace? stackTrace;
+
   try {
     mainSendPort.send(SftpWorkerStatus.preparing);
     final watch = Stopwatch()..start();
-    final client = await genClient(
+    client = await genClient(
       req.spi,
       privateKey: req.privateKey,
       jumpSpi: req.jumpSpi,
@@ -207,17 +233,18 @@ Future<void> _upload(
     mainSendPort.send(localLen);
     final localFile = local.openRead().cast<Uint8List>();
     Loggers.app.info('SFTP upload opening session: ${req.remotePath}');
-    final sftp = await _withSftpPrepareTimeout(
+    final openedSftp = await _withSftpPrepareTimeout(
       req,
       'open upload session',
       client.sftp(),
     );
+    sftp = openedSftp;
     // If remote exists, overwrite it
     Loggers.app.info('SFTP upload opening remote file: ${req.remotePath}');
-    final file = await _withSftpPrepareTimeout(
+    final openedRemoteFile = await _withSftpPrepareTimeout(
       req,
       'open remote file for upload',
-      sftp.open(
+      openedSftp.open(
         req.remotePath,
         mode:
             SftpFileOpenMode.truncate |
@@ -225,34 +252,76 @@ Future<void> _upload(
             SftpFileOpenMode.write,
       ),
     );
+    remoteFile = openedRemoteFile;
     mainSendPort.send(SftpWorkerStatus.loading);
     Loggers.app.info(
       'SFTP upload started: ${req.remotePath}, '
       'chunk=$_sftpTransferChunkSize, maxBytes=$_sftpUploadMaxBytesOnTheWire',
     );
     var lastProgress = -1;
-    try {
-      final writer = file.write(
-        localFile,
-        onProgress: (total) {
-          if (localLen == 0) return;
-          final progress = (total / localLen * 100).round();
-          if (progress != lastProgress) {
-            lastProgress = progress;
-            mainSendPort.send(progress.toDouble());
-          }
-        },
-        chunkSize: _sftpTransferChunkSize,
-        maxBytesOnTheWire: _sftpUploadMaxBytesOnTheWire,
-      );
-      await writer.done;
-    } finally {
-      await file.close();
-    }
+    final writer = openedRemoteFile.write(
+      localFile,
+      onProgress: (total) {
+        if (localLen == 0) return;
+        final progress = (total / localLen * 100).round();
+        if (progress != lastProgress) {
+          lastProgress = progress;
+          mainSendPort.send(progress.toDouble());
+        }
+      },
+      chunkSize: _sftpTransferChunkSize,
+      maxBytesOnTheWire: _sftpUploadMaxBytesOnTheWire,
+    );
+    await writer.done;
     mainSendPort.send(watch.elapsed);
     mainSendPort.send(SftpWorkerStatus.finished);
   } catch (e, s) {
-    Loggers.app.warning('SFTP upload failed: ${req.remotePath}', e, s);
-    mainSendPort.send(e);
+    error = e;
+    stackTrace = s;
+  } finally {
+    await _closeSftpResources(
+      remoteFile: remoteFile,
+      sftp: sftp,
+      client: client,
+    );
+  }
+
+  if (error != null) {
+    Loggers.app.warning(
+      'SFTP upload failed: ${req.remotePath}',
+      error,
+      stackTrace,
+    );
+    mainSendPort.send(error);
+  }
+}
+
+Future<void> _closeSftpResources({
+  required SftpFile? remoteFile,
+  required SftpClient? sftp,
+  required SSHClient? client,
+}) async {
+  if (remoteFile != null && !remoteFile.isClosed) {
+    try {
+      await remoteFile.close();
+    } catch (e, s) {
+      Loggers.app.warning('Failed to close SFTP remote file', e, s);
+    }
+  }
+
+  if (sftp != null) {
+    try {
+      sftp.close();
+    } catch (e, s) {
+      Loggers.app.warning('Failed to close SFTP session', e, s);
+    }
+  }
+
+  if (client != null) {
+    try {
+      client.close();
+    } catch (e, s) {
+      Loggers.app.warning('Failed to close SSH client', e, s);
+    }
   }
 }

--- a/lib/data/provider/server/single.dart
+++ b/lib/data/provider/server/single.dart
@@ -463,6 +463,21 @@ class ServerNotifier extends _$ServerNotifier {
         );
         return;
       }
+    } on TimeoutException catch (e, s) {
+      final newStatus = _copyStatus(
+        state.status,
+        err: SSHErr(type: SSHErrType.getStatus, message: e.toString()),
+        setErr: true,
+      );
+      updateStatus(newStatus);
+      if (state.client != null && state.conn != ServerConn.finished) {
+        updateConnection(ServerConn.connected);
+      }
+      Loggers.app.warning('Get status from ${spi.name} timed out', e, s);
+
+      final sessionId = 'ssh_${spi.id}';
+      TermSessionManager.updateStatus(sessionId, TermSessionStatus.connected);
+      return;
     } catch (e) {
       TryLimiter.inc(sid);
       final newStatus = _copyStatus(

--- a/lib/view/page/storage/sftp.dart
+++ b/lib/view/page/storage/sftp.dart
@@ -71,11 +71,11 @@ class _SftpPageState extends ConsumerState<SftpPage> with AfterLayoutMixin {
     super.initState();
     final serverState = ref.read(serverProvider(widget.args.spi.id));
     _client = serverState.client!;
-    _status = SftpBrowserStatus(_client);
+    _status = SftpBrowserStatus();
     _sudoHelper = SftpSudoHelper(
       client: _client,
       spi: widget.args.spi,
-      context: context,
+      contextProvider: () => mounted ? context : null,
     );
   }
 
@@ -136,8 +136,14 @@ class _SftpPageState extends ConsumerState<SftpPage> with AfterLayoutMixin {
         SftpClient? sftp;
         try {
           final normalizedHistory = _normalizeSftpPath(history);
-          sftp = await _client.sftp();
-          await sftp.listdir(normalizedHistory);
+          sftp = await _withSftpOpTimeout(
+            'open session for last path',
+            _client.sftp(),
+          );
+          await _withSftpOpTimeout(
+            'list last path',
+            sftp!.listdir(normalizedHistory),
+          );
           initPath = normalizedHistory;
         } catch (_) {
         } finally {
@@ -147,7 +153,7 @@ class _SftpPageState extends ConsumerState<SftpPage> with AfterLayoutMixin {
     }
 
     _status.path.path = widget.args.initPath ?? initPath;
-    unawaited(_listDir());
+    unawaited(_listDir(context));
   }
 }
 
@@ -946,7 +952,27 @@ extension _Actions on _SftpPageState {
   }
 
   /// Only return true if the path is changed
-  Future<bool?> _listDir() async {
+  Duration get _sftpOpTimeout {
+    final seconds = Stores.setting.timeout.fetch();
+    return Duration(seconds: seconds <= 0 ? 5 : seconds);
+  }
+
+  Future<T> _withSftpOpTimeout<T>(String operation, Future<T> future) async {
+    final timeout = _sftpOpTimeout;
+    try {
+      return await future.timeout(timeout);
+    } on TimeoutException catch (e, s) {
+      final error = TimeoutException('SFTP $operation timed out', timeout);
+      Loggers.app.warning(error.message, e, s);
+      throw error;
+    }
+  }
+
+  Future<bool?> _listDir([BuildContext? dialogContext]) async {
+    if (dialogContext == null && !mounted) return false;
+    final context = dialogContext ?? this.context;
+    if (!context.mounted) return false;
+
     final (ret, err) = await context.showLoadingDialog(
       fn: () async {
         final listPath = _status.path.path;
@@ -1004,8 +1030,16 @@ extension _Actions on _SftpPageState {
     }
 
     try {
-      _status.client ??= await _client.sftp();
-      return await _status.client?.listdir(listPath);
+      _status.client ??= await _withSftpOpTimeout(
+        'open browser session',
+        _client.sftp(),
+      );
+      final client = _status.client;
+      if (client == null) return null;
+      return await _withSftpOpTimeout(
+        'list directory',
+        client.listdir(listPath),
+      );
     } on SftpStatusError catch (e) {
       final canFallback =
           _sudoHelper.enabled &&


### PR DESCRIPTION
**Summary**
- Adjusted the lifecycle of SFTP browsing and downloading to prevent premature initiation of background sessions, context expiration, and unintended timeouts.
- Added more robust timeout and connection opening controls for SFTP requests to reduce stuttering and failures during initial connections, on slow links, and with long-lived connections.
- Fixed several protocol timing issues in `dartssh2` to enhance the reliability of channel opening and SFTP read-back packet handling.
- Removed temporary diagnostic logic introduced during debugging, retaining only confirmed fixes.

**Testing**
- Added and passed SFTP protocol regression tests in `packages/dartssh2`.
- Ran relevant `dart analyze` and targeted tests; results passed.
- Verified in local SFTP scenarios; confirmed that known timing-related crashes no longer occur during connection and download processes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added timeout support for SFTP operations and context-aware sudo UI behavior.

* **Bug Fixes**
  * Improved server status timeout handling and clearer error messages for failed SFTP commands.
  * Safer UI behavior when views unmount during SFTP actions.

* **Performance**
  * Adjusted SFTP transfer tuning to improve download/upload throughput and parallelism.

* **Refactor**
  * Per-request timeout state introduced for SFTP operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->