### PR TITLE
Add dual jump-server failover

### DIFF
--- a/lib/core/utils/jump_chain.dart
+++ b/lib/core/utils/jump_chain.dart
@@ -7,47 +7,99 @@ bool wouldCreateJumpCycle({
   required String? candidateJumpId,
   required Map<String, Spi> serversById,
 }) {
-  if (candidateJumpId == null || candidateJumpId.isEmpty) {
+  return wouldCreateJumpCycleForCandidates(
+    currentServerId: currentServerId,
+    candidateJumpIds: candidateJumpId == null ? const [] : [candidateJumpId],
+    serversById: serversById,
+  );
+}
+
+/// Returns `true` when assigning [candidateJumpIds] to [currentServerId]
+/// would create a jump-server cycle.
+bool wouldCreateJumpCycleForCandidates({
+  required String? currentServerId,
+  required Iterable<String> candidateJumpIds,
+  required Map<String, Spi> serversById,
+}) {
+  for (final candidateJumpId in _normalizeJumpIds(candidateJumpIds)) {
+    if (_hasJumpCycleFrom(
+      currentServerId: currentServerId,
+      checkingId: candidateJumpId,
+      serversById: serversById,
+      path: <String>{},
+    )) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool _hasJumpCycleFrom({
+  required String? currentServerId,
+  required String checkingId,
+  required Map<String, Spi> serversById,
+  required Set<String> path,
+}) {
+  if (currentServerId != null && checkingId == currentServerId) {
+    return true;
+  }
+  if (!path.add(checkingId)) {
+    // Existing malformed cycle is treated as invalid to prevent linking into it.
+    return true;
+  }
+
+  final jumpSpi = serversById[checkingId];
+  if (jumpSpi == null) {
+    path.remove(checkingId);
     return false;
   }
 
-  final visited = <String>{};
-  var checkingId = candidateJumpId;
-
-  while (true) {
-    if (currentServerId != null && checkingId == currentServerId) {
+  for (final nextId in jumpSpi.resolvedJumpIds) {
+    if (_hasJumpCycleFrom(
+      currentServerId: currentServerId,
+      checkingId: nextId,
+      serversById: serversById,
+      path: path,
+    )) {
       return true;
     }
-    if (!visited.add(checkingId)) {
-      // Existing malformed cycle is treated as invalid to prevent linking into it.
-      return true;
-    }
-
-    final nextId = serversById[checkingId]?.jumpId;
-    if (nextId == null || nextId.isEmpty) {
-      return false;
-    }
-    checkingId = nextId;
   }
+
+  path.remove(checkingId);
+  return false;
 }
 
-/// Collects all reachable jump servers from [spi.jumpId], keyed by server id.
+/// Collects all reachable jump servers from [spi.resolvedJumpIds], keyed by server id.
 Map<String, Spi> collectJumpServers({
   required Spi spi,
   required Map<String, Spi> serversById,
 }) {
   final chain = <String, Spi>{};
   final visited = <String>{};
-  var jumpId = spi.jumpId;
+  final pending = <String>[...spi.resolvedJumpIds];
 
-  while (jumpId != null && jumpId.isNotEmpty && visited.add(jumpId)) {
+  while (pending.isNotEmpty) {
+    final jumpId = pending.removeAt(0);
+    if (jumpId.isEmpty || !visited.add(jumpId)) {
+      continue;
+    }
     final jumpSpi = serversById[jumpId];
     if (jumpSpi == null) {
-      break;
+      continue;
     }
     chain[jumpSpi.id] = jumpSpi;
-    jumpId = jumpSpi.jumpId;
+    pending.addAll(jumpSpi.resolvedJumpIds);
   }
 
   return chain;
+}
+
+List<String> _normalizeJumpIds(Iterable<String> ids) {
+  final normalized = <String>[];
+  for (final id in ids) {
+    if (id.isEmpty || normalized.contains(id)) continue;
+    normalized.add(id);
+    if (normalized.length >= 2) break;
+  }
+  return normalized;
 }

--- a/lib/core/utils/server.dart
+++ b/lib/core/utils/server.dart
@@ -98,6 +98,13 @@ Future<SSHClient> genClient(
       preloadedJumpSpi: jumpSpi,
       jumpSpisById: jumpSpisById,
     );
+    final jumpIds = spi.resolvedJumpIds;
+    if (jumpIds.isNotEmpty && jumpSpis.isEmpty) {
+      final message =
+          'Jump servers not found for ${spi.name}: ${jumpIds.join(', ')}';
+      Loggers.app.warning(message);
+      throw SSHErr(type: SSHErrType.connect, message: message);
+    }
     if (jumpSpis.isNotEmpty) {
       Object? lastNetworkError;
       StackTrace? lastNetworkStack;
@@ -122,6 +129,7 @@ Future<SSHClient> genClient(
             privateKeysByKeyId: privateKeysByKeyId,
             jumpSpisById: jumpSpisById,
             timeout: timeout,
+            onKeyboardInteractive: onKeyboardInteractive,
             knownHostFingerprints: hostKeyCache,
             onHostKeyAccepted: hostKeyPersist,
             onHostKeyPrompt: hostKeyPrompt,
@@ -437,9 +445,6 @@ Future<void> ensureKnownHostKey(
   }
 
   final cache = _loadKnownHostFingerprints();
-  if (_hasKnownHostFingerprintForSpi(spi, cache)) {
-    return;
-  }
 
   for (final jumpSpi in _resolveJumpCandidates(
     spi: spi,
@@ -455,8 +460,11 @@ Future<void> ensureKnownHostKey(
         visitedServerIds: {...chainVisitedServerIds},
       );
       cache.addAll(_loadKnownHostFingerprints());
-      if (_hasKnownHostFingerprintForSpi(spi, cache)) return;
     }
+  }
+
+  if (_hasKnownHostFingerprintForSpi(spi, cache)) {
+    return;
   }
 
   final client = await genClient(

--- a/lib/core/utils/server.dart
+++ b/lib/core/utils/server.dart
@@ -93,40 +93,65 @@ Future<SSHClient> genClient(
 
   final socket = await () async {
     // Proxy
-    final jumpSpi_ = () {
-      // Multi-thread or key login
-      if (jumpSpi != null) return jumpSpi;
-      // Main thread
-      final jumpId = spi.jumpId;
-      if (jumpId != null) {
-        return jumpSpisById?[jumpId] ?? Stores.server.box.get(jumpId);
-      }
-    }();
-    if (jumpSpi_ != null) {
-      String? nextJumpPrivateKey;
-      final jumpSpiKeyId = jumpSpi_.keyId;
-      if (jumpSpi != null &&
-          jumpSpi.id == jumpSpi_.id &&
-          jumpPrivateKey != null) {
-        // Isolate mode may preload first-hop key and pass it via [jumpPrivateKey].
-        nextJumpPrivateKey = jumpPrivateKey;
-      } else if (jumpSpiKeyId != null) {
-        nextJumpPrivateKey = privateKeysByKeyId?[jumpSpiKeyId];
+    final jumpSpis = _resolveJumpCandidates(
+      spi: spi,
+      preloadedJumpSpi: jumpSpi,
+      jumpSpisById: jumpSpisById,
+    );
+    if (jumpSpis.isNotEmpty) {
+      Object? lastNetworkError;
+      StackTrace? lastNetworkStack;
+
+      for (final jumpSpi_ in jumpSpis) {
+        SSHClient? jumpClient;
+        try {
+          String? nextJumpPrivateKey;
+          final jumpSpiKeyId = jumpSpi_.keyId;
+          if (jumpSpi != null &&
+              jumpSpi.id == jumpSpi_.id &&
+              jumpPrivateKey != null) {
+            // Isolate mode may preload first-hop key and pass it via [jumpPrivateKey].
+            nextJumpPrivateKey = jumpPrivateKey;
+          } else if (jumpSpiKeyId != null) {
+            nextJumpPrivateKey = privateKeysByKeyId?[jumpSpiKeyId];
+          }
+
+          jumpClient = await genClient(
+            jumpSpi_,
+            privateKey: nextJumpPrivateKey,
+            privateKeysByKeyId: privateKeysByKeyId,
+            jumpSpisById: jumpSpisById,
+            timeout: timeout,
+            knownHostFingerprints: hostKeyCache,
+            onHostKeyAccepted: hostKeyPersist,
+            onHostKeyPrompt: hostKeyPrompt,
+            visitedServerIds: {...chainVisitedServerIds},
+          );
+
+          return await jumpClient.forwardLocal(spi.ip, spi.port);
+        } catch (e, stack) {
+          if (!_isJumpFailoverError(e)) {
+            rethrow;
+          }
+          jumpClient?.close();
+          lastNetworkError = e;
+          lastNetworkStack = stack;
+          Loggers.app.warning(
+            'Jump server ${jumpSpi_.name} failed, trying next candidate',
+            e,
+            stack,
+          );
+        }
       }
 
-      final jumpClient = await genClient(
-        jumpSpi_,
-        privateKey: nextJumpPrivateKey,
-        privateKeysByKeyId: privateKeysByKeyId,
-        jumpSpisById: jumpSpisById,
-        timeout: timeout,
-        knownHostFingerprints: hostKeyCache,
-        onHostKeyAccepted: hostKeyPersist,
-        onHostKeyPrompt: hostKeyPrompt,
-        visitedServerIds: chainVisitedServerIds,
+      Error.throwWithStackTrace(
+        lastNetworkError ??
+            SSHErr(
+              type: SSHErrType.connect,
+              message: 'No jump server available.',
+            ),
+        lastNetworkStack ?? StackTrace.current,
       );
-
-      return await jumpClient.forwardLocal(spi.ip, spi.port);
     }
 
     final proxyCommand = spi.proxyCommand;
@@ -194,6 +219,43 @@ Future<SSHClient> genClient(
 
 typedef _HostKeyPersistCallback =
     void Function(String storageKey, String fingerprintHex);
+
+List<Spi> _resolveJumpCandidates({
+  required Spi spi,
+  required Spi? preloadedJumpSpi,
+  required Map<String, Spi>? jumpSpisById,
+}) {
+  final candidates = <Spi>[];
+  for (final jumpId in spi.resolvedJumpIds) {
+    final candidate = preloadedJumpSpi?.id == jumpId
+        ? preloadedJumpSpi
+        : jumpSpisById?[jumpId] ?? Stores.server.box.get(jumpId);
+    if (candidate == null || candidates.any((e) => e.id == candidate.id)) {
+      continue;
+    }
+    candidates.add(candidate);
+  }
+  return candidates;
+}
+
+bool _isJumpFailoverError(Object error) {
+  final errStr = error.toString().toLowerCase();
+  return errStr.contains('timed out') ||
+      errStr.contains('timeout') ||
+      errStr.contains('connection refused') ||
+      errStr.contains('connection reset') ||
+      errStr.contains('connection closed') ||
+      errStr.contains('no route to host') ||
+      errStr.contains('network') ||
+      errStr.contains('socket') ||
+      errStr.contains('failed host lookup') ||
+      errStr.contains('forward') ||
+      errStr.contains('proxycommand exited') ||
+      errStr.contains('proxycommand timed out');
+}
+
+@visibleForTesting
+bool isJumpFailoverErrorForTest(Object error) => _isJumpFailoverError(error);
 
 class HostKeyPromptInfo {
   HostKeyPromptInfo({
@@ -379,20 +441,22 @@ Future<void> ensureKnownHostKey(
     return;
   }
 
-  final jumpId = spi.jumpId;
-  final jumpSpi = jumpId != null
-      ? (jumpSpisById?[jumpId] ?? Stores.server.box.get(jumpId))
-      : null;
-  if (jumpSpi != null && !_hasKnownHostFingerprintForSpi(jumpSpi, cache)) {
-    await ensureKnownHostKey(
-      jumpSpi,
-      timeout: timeout,
-      onKeyboardInteractive: onKeyboardInteractive,
-      jumpSpisById: jumpSpisById,
-      visitedServerIds: chainVisitedServerIds,
-    );
-    cache.addAll(_loadKnownHostFingerprints());
-    if (_hasKnownHostFingerprintForSpi(spi, cache)) return;
+  for (final jumpSpi in _resolveJumpCandidates(
+    spi: spi,
+    preloadedJumpSpi: null,
+    jumpSpisById: jumpSpisById,
+  )) {
+    if (!_hasKnownHostFingerprintForSpi(jumpSpi, cache)) {
+      await ensureKnownHostKey(
+        jumpSpi,
+        timeout: timeout,
+        onKeyboardInteractive: onKeyboardInteractive,
+        jumpSpisById: jumpSpisById,
+        visitedServerIds: {...chainVisitedServerIds},
+      );
+      cache.addAll(_loadKnownHostFingerprints());
+      if (_hasKnownHostFingerprintForSpi(spi, cache)) return;
+    }
   }
 
   final client = await genClient(

--- a/lib/core/utils/server.dart
+++ b/lib/core/utils/server.dart
@@ -100,8 +100,7 @@ Future<SSHClient> genClient(
     );
     final jumpIds = spi.resolvedJumpIds;
     if (jumpIds.isNotEmpty && jumpSpis.isEmpty) {
-      final message =
-          'Jump servers not found for ${spi.name}: ${jumpIds.join(', ')}';
+      final message = l10n.jumpServersNotFoundFmt(spi.name, jumpIds.join(', '));
       Loggers.app.warning(message);
       throw SSHErr(type: SSHErrType.connect, message: message);
     }
@@ -138,10 +137,10 @@ Future<SSHClient> genClient(
 
           return await jumpClient.forwardLocal(spi.ip, spi.port);
         } catch (e, stack) {
+          jumpClient?.close();
           if (!_isJumpFailoverError(e)) {
             rethrow;
           }
-          jumpClient?.close();
           lastNetworkError = e;
           lastNetworkStack = stack;
           Loggers.app.warning(
@@ -156,7 +155,7 @@ Future<SSHClient> genClient(
         lastNetworkError ??
             SSHErr(
               type: SSHErrType.connect,
-              message: 'No jump server available.',
+              message: l10n.noJumpServerAvailable,
             ),
         lastNetworkStack ?? StackTrace.current,
       );

--- a/lib/data/model/server/server_private_info.dart
+++ b/lib/data/model/server/server_private_info.dart
@@ -46,8 +46,14 @@ abstract class Spi with _$Spi {
     String? alterUrl,
     @Default(true) bool autoConnect,
 
-    /// [id] of the jump server
+    /// [id] of the first jump server.
+    ///
+    /// Kept for compatibility with old storage and imports. New code should
+    /// read [resolvedJumpIds] so failover candidates are included.
     String? jumpId,
+
+    /// Ordered jump-server candidates. At most the first two are used.
+    List<String>? jumpIds,
     String? proxyCommand,
     ServerCustom? custom,
     WakeOnLanCfg? wolCfg,
@@ -76,8 +82,28 @@ abstract class Spi with _$Spi {
 }
 
 extension Spix on Spi {
+  List<String> get resolvedJumpIds {
+    final ids = <String>[];
+    void add(String? id) {
+      if (id == null || id.isEmpty || ids.contains(id)) return;
+      ids.add(id);
+    }
+
+    for (final id in jumpIds ?? const <String>[]) {
+      add(id);
+      if (ids.length >= 2) break;
+    }
+    if (ids.isEmpty) add(jumpId);
+    return ids;
+  }
+
+  String? get firstJumpId {
+    final ids = resolvedJumpIds;
+    return ids.isEmpty ? null : ids.first;
+  }
+
   SpiValidationError? validate() {
-    final hasJumpServer = jumpId != null && jumpId!.isNotEmpty;
+    final hasJumpServer = resolvedJumpIds.isNotEmpty;
     final hasProxyCommand =
         proxyCommand != null && proxyCommand!.trim().isNotEmpty;
     if (hasJumpServer && hasProxyCommand) {
@@ -122,7 +148,7 @@ extension Spix on Spi {
         port == other.port &&
         pwd == other.pwd &&
         keyId == other.keyId &&
-        jumpId == other.jumpId &&
+        _sameStringList(resolvedJumpIds, other.resolvedJumpIds) &&
         proxyCommand == other.proxyCommand;
   }
 
@@ -181,4 +207,12 @@ extension Spix on Spi {
 
   /// Returns true if the user is 'root'.
   bool get isRoot => user == 'root';
+}
+
+bool _sameStringList(List<String> a, List<String> b) {
+  if (a.length != b.length) return false;
+  for (var i = 0; i < a.length; i++) {
+    if (a[i] != b[i]) return false;
+  }
+  return true;
 }

--- a/lib/data/model/server/server_private_info.freezed.dart
+++ b/lib/data/model/server/server_private_info.freezed.dart
@@ -16,8 +16,12 @@ T _$identity<T>(T value) => value;
 mixin _$Spi {
 
  String get name; String get ip; int get port; String get user; String? get pwd;/// [id] of private key
-@JsonKey(name: 'pubKeyId') String? get keyId; List<String>? get tags; String? get alterUrl; bool get autoConnect;/// [id] of the jump server
- String? get jumpId; String? get proxyCommand; ServerCustom? get custom; WakeOnLanCfg? get wolCfg;/// It only applies to SSH terminal.
+@JsonKey(name: 'pubKeyId') String? get keyId; List<String>? get tags; String? get alterUrl; bool get autoConnect;/// [id] of the first jump server.
+///
+/// Kept for compatibility with old storage and imports. New code should
+/// read [resolvedJumpIds] so failover candidates are included.
+ String? get jumpId;/// Ordered jump-server candidates. At most the first two are used.
+ List<String>? get jumpIds; String? get proxyCommand; ServerCustom? get custom; WakeOnLanCfg? get wolCfg;/// It only applies to SSH terminal.
  Map<String, String>? get envs;@JsonKey(fromJson: Spi.parseId) String get id;/// Custom system type (unix or windows). If set, skip auto-detection.
 @JsonKey(includeIfNull: false) SystemType? get customSystemType;/// Disabled command types for this server
 @JsonKey(includeIfNull: false) List<String>? get disabledCmdTypes;
@@ -33,12 +37,12 @@ $SpiCopyWith<Spi> get copyWith => _$SpiCopyWithImpl<Spi>(this as Spi, _$identity
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Spi&&(identical(other.name, name) || other.name == name)&&(identical(other.ip, ip) || other.ip == ip)&&(identical(other.port, port) || other.port == port)&&(identical(other.user, user) || other.user == user)&&(identical(other.pwd, pwd) || other.pwd == pwd)&&(identical(other.keyId, keyId) || other.keyId == keyId)&&const DeepCollectionEquality().equals(other.tags, tags)&&(identical(other.alterUrl, alterUrl) || other.alterUrl == alterUrl)&&(identical(other.autoConnect, autoConnect) || other.autoConnect == autoConnect)&&(identical(other.jumpId, jumpId) || other.jumpId == jumpId)&&(identical(other.proxyCommand, proxyCommand) || other.proxyCommand == proxyCommand)&&(identical(other.custom, custom) || other.custom == custom)&&(identical(other.wolCfg, wolCfg) || other.wolCfg == wolCfg)&&const DeepCollectionEquality().equals(other.envs, envs)&&(identical(other.id, id) || other.id == id)&&(identical(other.customSystemType, customSystemType) || other.customSystemType == customSystemType)&&const DeepCollectionEquality().equals(other.disabledCmdTypes, disabledCmdTypes));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Spi&&(identical(other.name, name) || other.name == name)&&(identical(other.ip, ip) || other.ip == ip)&&(identical(other.port, port) || other.port == port)&&(identical(other.user, user) || other.user == user)&&(identical(other.pwd, pwd) || other.pwd == pwd)&&(identical(other.keyId, keyId) || other.keyId == keyId)&&const DeepCollectionEquality().equals(other.tags, tags)&&(identical(other.alterUrl, alterUrl) || other.alterUrl == alterUrl)&&(identical(other.autoConnect, autoConnect) || other.autoConnect == autoConnect)&&(identical(other.jumpId, jumpId) || other.jumpId == jumpId)&&const DeepCollectionEquality().equals(other.jumpIds, jumpIds)&&(identical(other.proxyCommand, proxyCommand) || other.proxyCommand == proxyCommand)&&(identical(other.custom, custom) || other.custom == custom)&&(identical(other.wolCfg, wolCfg) || other.wolCfg == wolCfg)&&const DeepCollectionEquality().equals(other.envs, envs)&&(identical(other.id, id) || other.id == id)&&(identical(other.customSystemType, customSystemType) || other.customSystemType == customSystemType)&&const DeepCollectionEquality().equals(other.disabledCmdTypes, disabledCmdTypes));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,name,ip,port,user,pwd,keyId,const DeepCollectionEquality().hash(tags),alterUrl,autoConnect,jumpId,proxyCommand,custom,wolCfg,const DeepCollectionEquality().hash(envs),id,customSystemType,const DeepCollectionEquality().hash(disabledCmdTypes));
+int get hashCode => Object.hash(runtimeType,name,ip,port,user,pwd,keyId,const DeepCollectionEquality().hash(tags),alterUrl,autoConnect,jumpId,const DeepCollectionEquality().hash(jumpIds),proxyCommand,custom,wolCfg,const DeepCollectionEquality().hash(envs),id,customSystemType,const DeepCollectionEquality().hash(disabledCmdTypes));
 
 
 
@@ -49,7 +53,7 @@ abstract mixin class $SpiCopyWith<$Res>  {
   factory $SpiCopyWith(Spi value, $Res Function(Spi) _then) = _$SpiCopyWithImpl;
 @useResult
 $Res call({
- String name, String ip, int port, String user, String? pwd,@JsonKey(name: 'pubKeyId') String? keyId, List<String>? tags, String? alterUrl, bool autoConnect, String? jumpId, String? proxyCommand, ServerCustom? custom, WakeOnLanCfg? wolCfg, Map<String, String>? envs,@JsonKey(fromJson: Spi.parseId) String id,@JsonKey(includeIfNull: false) SystemType? customSystemType,@JsonKey(includeIfNull: false) List<String>? disabledCmdTypes
+ String name, String ip, int port, String user, String? pwd,@JsonKey(name: 'pubKeyId') String? keyId, List<String>? tags, String? alterUrl, bool autoConnect, String? jumpId, List<String>? jumpIds, String? proxyCommand, ServerCustom? custom, WakeOnLanCfg? wolCfg, Map<String, String>? envs,@JsonKey(fromJson: Spi.parseId) String id,@JsonKey(includeIfNull: false) SystemType? customSystemType,@JsonKey(includeIfNull: false) List<String>? disabledCmdTypes
 });
 
 
@@ -66,7 +70,7 @@ class _$SpiCopyWithImpl<$Res>
 
 /// Create a copy of Spi
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? name = null,Object? ip = null,Object? port = null,Object? user = null,Object? pwd = freezed,Object? keyId = freezed,Object? tags = freezed,Object? alterUrl = freezed,Object? autoConnect = null,Object? jumpId = freezed,Object? proxyCommand = freezed,Object? custom = freezed,Object? wolCfg = freezed,Object? envs = freezed,Object? id = null,Object? customSystemType = freezed,Object? disabledCmdTypes = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? name = null,Object? ip = null,Object? port = null,Object? user = null,Object? pwd = freezed,Object? keyId = freezed,Object? tags = freezed,Object? alterUrl = freezed,Object? autoConnect = null,Object? jumpId = freezed,Object? jumpIds = freezed,Object? proxyCommand = freezed,Object? custom = freezed,Object? wolCfg = freezed,Object? envs = freezed,Object? id = null,Object? customSystemType = freezed,Object? disabledCmdTypes = freezed,}) {
   return _then(_self.copyWith(
 name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,ip: null == ip ? _self.ip : ip // ignore: cast_nullable_to_non_nullable
@@ -78,7 +82,8 @@ as String?,tags: freezed == tags ? _self.tags : tags // ignore: cast_nullable_to
 as List<String>?,alterUrl: freezed == alterUrl ? _self.alterUrl : alterUrl // ignore: cast_nullable_to_non_nullable
 as String?,autoConnect: null == autoConnect ? _self.autoConnect : autoConnect // ignore: cast_nullable_to_non_nullable
 as bool,jumpId: freezed == jumpId ? _self.jumpId : jumpId // ignore: cast_nullable_to_non_nullable
-as String?,proxyCommand: freezed == proxyCommand ? _self.proxyCommand : proxyCommand // ignore: cast_nullable_to_non_nullable
+as String?,jumpIds: freezed == jumpIds ? _self.jumpIds : jumpIds // ignore: cast_nullable_to_non_nullable
+as List<String>?,proxyCommand: freezed == proxyCommand ? _self.proxyCommand : proxyCommand // ignore: cast_nullable_to_non_nullable
 as String?,custom: freezed == custom ? _self.custom : custom // ignore: cast_nullable_to_non_nullable
 as ServerCustom?,wolCfg: freezed == wolCfg ? _self.wolCfg : wolCfg // ignore: cast_nullable_to_non_nullable
 as WakeOnLanCfg?,envs: freezed == envs ? _self.envs : envs // ignore: cast_nullable_to_non_nullable
@@ -170,10 +175,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String name,  String ip,  int port,  String user,  String? pwd, @JsonKey(name: 'pubKeyId')  String? keyId,  List<String>? tags,  String? alterUrl,  bool autoConnect,  String? jumpId,  String? proxyCommand,  ServerCustom? custom,  WakeOnLanCfg? wolCfg,  Map<String, String>? envs, @JsonKey(fromJson: Spi.parseId)  String id, @JsonKey(includeIfNull: false)  SystemType? customSystemType, @JsonKey(includeIfNull: false)  List<String>? disabledCmdTypes)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String name,  String ip,  int port,  String user,  String? pwd, @JsonKey(name: 'pubKeyId')  String? keyId,  List<String>? tags,  String? alterUrl,  bool autoConnect,  String? jumpId,  List<String>? jumpIds,  String? proxyCommand,  ServerCustom? custom,  WakeOnLanCfg? wolCfg,  Map<String, String>? envs, @JsonKey(fromJson: Spi.parseId)  String id, @JsonKey(includeIfNull: false)  SystemType? customSystemType, @JsonKey(includeIfNull: false)  List<String>? disabledCmdTypes)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _Spi() when $default != null:
-return $default(_that.name,_that.ip,_that.port,_that.user,_that.pwd,_that.keyId,_that.tags,_that.alterUrl,_that.autoConnect,_that.jumpId,_that.proxyCommand,_that.custom,_that.wolCfg,_that.envs,_that.id,_that.customSystemType,_that.disabledCmdTypes);case _:
+return $default(_that.name,_that.ip,_that.port,_that.user,_that.pwd,_that.keyId,_that.tags,_that.alterUrl,_that.autoConnect,_that.jumpId,_that.jumpIds,_that.proxyCommand,_that.custom,_that.wolCfg,_that.envs,_that.id,_that.customSystemType,_that.disabledCmdTypes);case _:
   return orElse();
 
 }
@@ -191,10 +196,10 @@ return $default(_that.name,_that.ip,_that.port,_that.user,_that.pwd,_that.keyId,
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String name,  String ip,  int port,  String user,  String? pwd, @JsonKey(name: 'pubKeyId')  String? keyId,  List<String>? tags,  String? alterUrl,  bool autoConnect,  String? jumpId,  String? proxyCommand,  ServerCustom? custom,  WakeOnLanCfg? wolCfg,  Map<String, String>? envs, @JsonKey(fromJson: Spi.parseId)  String id, @JsonKey(includeIfNull: false)  SystemType? customSystemType, @JsonKey(includeIfNull: false)  List<String>? disabledCmdTypes)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String name,  String ip,  int port,  String user,  String? pwd, @JsonKey(name: 'pubKeyId')  String? keyId,  List<String>? tags,  String? alterUrl,  bool autoConnect,  String? jumpId,  List<String>? jumpIds,  String? proxyCommand,  ServerCustom? custom,  WakeOnLanCfg? wolCfg,  Map<String, String>? envs, @JsonKey(fromJson: Spi.parseId)  String id, @JsonKey(includeIfNull: false)  SystemType? customSystemType, @JsonKey(includeIfNull: false)  List<String>? disabledCmdTypes)  $default,) {final _that = this;
 switch (_that) {
 case _Spi():
-return $default(_that.name,_that.ip,_that.port,_that.user,_that.pwd,_that.keyId,_that.tags,_that.alterUrl,_that.autoConnect,_that.jumpId,_that.proxyCommand,_that.custom,_that.wolCfg,_that.envs,_that.id,_that.customSystemType,_that.disabledCmdTypes);case _:
+return $default(_that.name,_that.ip,_that.port,_that.user,_that.pwd,_that.keyId,_that.tags,_that.alterUrl,_that.autoConnect,_that.jumpId,_that.jumpIds,_that.proxyCommand,_that.custom,_that.wolCfg,_that.envs,_that.id,_that.customSystemType,_that.disabledCmdTypes);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -211,10 +216,10 @@ return $default(_that.name,_that.ip,_that.port,_that.user,_that.pwd,_that.keyId,
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String name,  String ip,  int port,  String user,  String? pwd, @JsonKey(name: 'pubKeyId')  String? keyId,  List<String>? tags,  String? alterUrl,  bool autoConnect,  String? jumpId,  String? proxyCommand,  ServerCustom? custom,  WakeOnLanCfg? wolCfg,  Map<String, String>? envs, @JsonKey(fromJson: Spi.parseId)  String id, @JsonKey(includeIfNull: false)  SystemType? customSystemType, @JsonKey(includeIfNull: false)  List<String>? disabledCmdTypes)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String name,  String ip,  int port,  String user,  String? pwd, @JsonKey(name: 'pubKeyId')  String? keyId,  List<String>? tags,  String? alterUrl,  bool autoConnect,  String? jumpId,  List<String>? jumpIds,  String? proxyCommand,  ServerCustom? custom,  WakeOnLanCfg? wolCfg,  Map<String, String>? envs, @JsonKey(fromJson: Spi.parseId)  String id, @JsonKey(includeIfNull: false)  SystemType? customSystemType, @JsonKey(includeIfNull: false)  List<String>? disabledCmdTypes)?  $default,) {final _that = this;
 switch (_that) {
 case _Spi() when $default != null:
-return $default(_that.name,_that.ip,_that.port,_that.user,_that.pwd,_that.keyId,_that.tags,_that.alterUrl,_that.autoConnect,_that.jumpId,_that.proxyCommand,_that.custom,_that.wolCfg,_that.envs,_that.id,_that.customSystemType,_that.disabledCmdTypes);case _:
+return $default(_that.name,_that.ip,_that.port,_that.user,_that.pwd,_that.keyId,_that.tags,_that.alterUrl,_that.autoConnect,_that.jumpId,_that.jumpIds,_that.proxyCommand,_that.custom,_that.wolCfg,_that.envs,_that.id,_that.customSystemType,_that.disabledCmdTypes);case _:
   return null;
 
 }
@@ -226,7 +231,7 @@ return $default(_that.name,_that.ip,_that.port,_that.user,_that.pwd,_that.keyId,
 
 @JsonSerializable(includeIfNull: false)
 class _Spi extends Spi {
-  const _Spi({required this.name, required this.ip, required this.port, required this.user, this.pwd, @JsonKey(name: 'pubKeyId') this.keyId, final  List<String>? tags, this.alterUrl, this.autoConnect = true, this.jumpId, this.proxyCommand, this.custom, this.wolCfg, final  Map<String, String>? envs, @JsonKey(fromJson: Spi.parseId) this.id = '', @JsonKey(includeIfNull: false) this.customSystemType, @JsonKey(includeIfNull: false) final  List<String>? disabledCmdTypes}): _tags = tags,_envs = envs,_disabledCmdTypes = disabledCmdTypes,super._();
+  const _Spi({required this.name, required this.ip, required this.port, required this.user, this.pwd, @JsonKey(name: 'pubKeyId') this.keyId, final  List<String>? tags, this.alterUrl, this.autoConnect = true, this.jumpId, final  List<String>? jumpIds, this.proxyCommand, this.custom, this.wolCfg, final  Map<String, String>? envs, @JsonKey(fromJson: Spi.parseId) this.id = '', @JsonKey(includeIfNull: false) this.customSystemType, @JsonKey(includeIfNull: false) final  List<String>? disabledCmdTypes}): _tags = tags,_jumpIds = jumpIds,_envs = envs,_disabledCmdTypes = disabledCmdTypes,super._();
   factory _Spi.fromJson(Map<String, dynamic> json) => _$SpiFromJson(json);
 
 @override final  String name;
@@ -247,8 +252,22 @@ class _Spi extends Spi {
 
 @override final  String? alterUrl;
 @override@JsonKey() final  bool autoConnect;
-/// [id] of the jump server
+/// [id] of the first jump server.
+///
+/// Kept for compatibility with old storage and imports. New code should
+/// read [resolvedJumpIds] so failover candidates are included.
 @override final  String? jumpId;
+/// Ordered jump-server candidates. At most the first two are used.
+ final  List<String>? _jumpIds;
+/// Ordered jump-server candidates. At most the first two are used.
+@override List<String>? get jumpIds {
+  final value = _jumpIds;
+  if (value == null) return null;
+  if (_jumpIds is EqualUnmodifiableListView) return _jumpIds;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(value);
+}
+
 @override final  String? proxyCommand;
 @override final  ServerCustom? custom;
 @override final  WakeOnLanCfg? wolCfg;
@@ -291,12 +310,12 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Spi&&(identical(other.name, name) || other.name == name)&&(identical(other.ip, ip) || other.ip == ip)&&(identical(other.port, port) || other.port == port)&&(identical(other.user, user) || other.user == user)&&(identical(other.pwd, pwd) || other.pwd == pwd)&&(identical(other.keyId, keyId) || other.keyId == keyId)&&const DeepCollectionEquality().equals(other._tags, _tags)&&(identical(other.alterUrl, alterUrl) || other.alterUrl == alterUrl)&&(identical(other.autoConnect, autoConnect) || other.autoConnect == autoConnect)&&(identical(other.jumpId, jumpId) || other.jumpId == jumpId)&&(identical(other.proxyCommand, proxyCommand) || other.proxyCommand == proxyCommand)&&(identical(other.custom, custom) || other.custom == custom)&&(identical(other.wolCfg, wolCfg) || other.wolCfg == wolCfg)&&const DeepCollectionEquality().equals(other._envs, _envs)&&(identical(other.id, id) || other.id == id)&&(identical(other.customSystemType, customSystemType) || other.customSystemType == customSystemType)&&const DeepCollectionEquality().equals(other._disabledCmdTypes, _disabledCmdTypes));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Spi&&(identical(other.name, name) || other.name == name)&&(identical(other.ip, ip) || other.ip == ip)&&(identical(other.port, port) || other.port == port)&&(identical(other.user, user) || other.user == user)&&(identical(other.pwd, pwd) || other.pwd == pwd)&&(identical(other.keyId, keyId) || other.keyId == keyId)&&const DeepCollectionEquality().equals(other._tags, _tags)&&(identical(other.alterUrl, alterUrl) || other.alterUrl == alterUrl)&&(identical(other.autoConnect, autoConnect) || other.autoConnect == autoConnect)&&(identical(other.jumpId, jumpId) || other.jumpId == jumpId)&&const DeepCollectionEquality().equals(other._jumpIds, _jumpIds)&&(identical(other.proxyCommand, proxyCommand) || other.proxyCommand == proxyCommand)&&(identical(other.custom, custom) || other.custom == custom)&&(identical(other.wolCfg, wolCfg) || other.wolCfg == wolCfg)&&const DeepCollectionEquality().equals(other._envs, _envs)&&(identical(other.id, id) || other.id == id)&&(identical(other.customSystemType, customSystemType) || other.customSystemType == customSystemType)&&const DeepCollectionEquality().equals(other._disabledCmdTypes, _disabledCmdTypes));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,name,ip,port,user,pwd,keyId,const DeepCollectionEquality().hash(_tags),alterUrl,autoConnect,jumpId,proxyCommand,custom,wolCfg,const DeepCollectionEquality().hash(_envs),id,customSystemType,const DeepCollectionEquality().hash(_disabledCmdTypes));
+int get hashCode => Object.hash(runtimeType,name,ip,port,user,pwd,keyId,const DeepCollectionEquality().hash(_tags),alterUrl,autoConnect,jumpId,const DeepCollectionEquality().hash(_jumpIds),proxyCommand,custom,wolCfg,const DeepCollectionEquality().hash(_envs),id,customSystemType,const DeepCollectionEquality().hash(_disabledCmdTypes));
 
 
 
@@ -307,7 +326,7 @@ abstract mixin class _$SpiCopyWith<$Res> implements $SpiCopyWith<$Res> {
   factory _$SpiCopyWith(_Spi value, $Res Function(_Spi) _then) = __$SpiCopyWithImpl;
 @override @useResult
 $Res call({
- String name, String ip, int port, String user, String? pwd,@JsonKey(name: 'pubKeyId') String? keyId, List<String>? tags, String? alterUrl, bool autoConnect, String? jumpId, String? proxyCommand, ServerCustom? custom, WakeOnLanCfg? wolCfg, Map<String, String>? envs,@JsonKey(fromJson: Spi.parseId) String id,@JsonKey(includeIfNull: false) SystemType? customSystemType,@JsonKey(includeIfNull: false) List<String>? disabledCmdTypes
+ String name, String ip, int port, String user, String? pwd,@JsonKey(name: 'pubKeyId') String? keyId, List<String>? tags, String? alterUrl, bool autoConnect, String? jumpId, List<String>? jumpIds, String? proxyCommand, ServerCustom? custom, WakeOnLanCfg? wolCfg, Map<String, String>? envs,@JsonKey(fromJson: Spi.parseId) String id,@JsonKey(includeIfNull: false) SystemType? customSystemType,@JsonKey(includeIfNull: false) List<String>? disabledCmdTypes
 });
 
 
@@ -324,7 +343,7 @@ class __$SpiCopyWithImpl<$Res>
 
 /// Create a copy of Spi
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? name = null,Object? ip = null,Object? port = null,Object? user = null,Object? pwd = freezed,Object? keyId = freezed,Object? tags = freezed,Object? alterUrl = freezed,Object? autoConnect = null,Object? jumpId = freezed,Object? proxyCommand = freezed,Object? custom = freezed,Object? wolCfg = freezed,Object? envs = freezed,Object? id = null,Object? customSystemType = freezed,Object? disabledCmdTypes = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? name = null,Object? ip = null,Object? port = null,Object? user = null,Object? pwd = freezed,Object? keyId = freezed,Object? tags = freezed,Object? alterUrl = freezed,Object? autoConnect = null,Object? jumpId = freezed,Object? jumpIds = freezed,Object? proxyCommand = freezed,Object? custom = freezed,Object? wolCfg = freezed,Object? envs = freezed,Object? id = null,Object? customSystemType = freezed,Object? disabledCmdTypes = freezed,}) {
   return _then(_Spi(
 name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
 as String,ip: null == ip ? _self.ip : ip // ignore: cast_nullable_to_non_nullable
@@ -336,7 +355,8 @@ as String?,tags: freezed == tags ? _self._tags : tags // ignore: cast_nullable_t
 as List<String>?,alterUrl: freezed == alterUrl ? _self.alterUrl : alterUrl // ignore: cast_nullable_to_non_nullable
 as String?,autoConnect: null == autoConnect ? _self.autoConnect : autoConnect // ignore: cast_nullable_to_non_nullable
 as bool,jumpId: freezed == jumpId ? _self.jumpId : jumpId // ignore: cast_nullable_to_non_nullable
-as String?,proxyCommand: freezed == proxyCommand ? _self.proxyCommand : proxyCommand // ignore: cast_nullable_to_non_nullable
+as String?,jumpIds: freezed == jumpIds ? _self._jumpIds : jumpIds // ignore: cast_nullable_to_non_nullable
+as List<String>?,proxyCommand: freezed == proxyCommand ? _self.proxyCommand : proxyCommand // ignore: cast_nullable_to_non_nullable
 as String?,custom: freezed == custom ? _self.custom : custom // ignore: cast_nullable_to_non_nullable
 as ServerCustom?,wolCfg: freezed == wolCfg ? _self.wolCfg : wolCfg // ignore: cast_nullable_to_non_nullable
 as WakeOnLanCfg?,envs: freezed == envs ? _self._envs : envs // ignore: cast_nullable_to_non_nullable

--- a/lib/data/model/server/server_private_info.g.dart
+++ b/lib/data/model/server/server_private_info.g.dart
@@ -17,6 +17,9 @@ _Spi _$SpiFromJson(Map<String, dynamic> json) => _Spi(
   alterUrl: json['alterUrl'] as String?,
   autoConnect: json['autoConnect'] as bool? ?? true,
   jumpId: json['jumpId'] as String?,
+  jumpIds: (json['jumpIds'] as List<dynamic>?)
+      ?.map((e) => e as String)
+      .toList(),
   proxyCommand: json['proxyCommand'] as String?,
   custom: json['custom'] == null
       ? null
@@ -48,6 +51,7 @@ Map<String, dynamic> _$SpiToJson(_Spi instance) => <String, dynamic>{
   'alterUrl': ?instance.alterUrl,
   'autoConnect': instance.autoConnect,
   'jumpId': ?instance.jumpId,
+  'jumpIds': ?instance.jumpIds,
   'proxyCommand': ?instance.proxyCommand,
   'custom': ?instance.custom,
   'wolCfg': ?instance.wolCfg,

--- a/lib/data/model/sftp/req.dart
+++ b/lib/data/model/sftp/req.dart
@@ -28,8 +28,9 @@ class SftpReq {
     };
     jumpSpisById = collectJumpServers(spi: spi, serversById: allServers);
 
-    if (spi.jumpId != null) {
-      jumpSpi = jumpSpisById?[spi.jumpId];
+    final firstJumpId = spi.firstJumpId;
+    if (firstJumpId != null) {
+      jumpSpi = jumpSpisById?[firstJumpId];
       jumpPrivateKey = Stores.key.fetchOne(jumpSpi?.keyId)?.key;
       if (jumpSpi?.keyId case final jumpKeyId?) {
         if (jumpPrivateKey != null) {

--- a/lib/data/provider/pve.g.dart
+++ b/lib/data/provider/pve.g.dart
@@ -58,7 +58,7 @@ final class PveNotifierProvider
   }
 }
 
-String _$pveNotifierHash() => r'1f80a27896013a275e5222f19e5ee3c3a68e2f84';
+String _$pveNotifierHash() => r'71436a9bf520b838af7f9469e4cd6c679ffe174a';
 
 final class PveNotifierFamily extends $Family
     with $ClassFamilyOverride<PveNotifier, PveState, PveState, PveState, Spi> {

--- a/lib/data/provider/server/all.g.dart
+++ b/lib/data/provider/server/all.g.dart
@@ -41,7 +41,7 @@ final class ServersNotifierProvider
   }
 }
 
-String _$serversNotifierHash() => r'29a4cb286b7032e5e74841f4eba66941b0dec34e';
+String _$serversNotifierHash() => r'ef2a189efe38cb917189dd6f612745b78e362e79';
 
 abstract class _$ServersNotifier extends $Notifier<ServersState> {
   ServersState build();

--- a/lib/data/provider/server/single.dart
+++ b/lib/data/provider/server/single.dart
@@ -192,7 +192,7 @@ class ServerNotifier extends _$ServerNotifier {
 
         final time2 = DateTime.now();
         final spentTime = time2.difference(time1).inMilliseconds;
-        if (spi.jumpId == null) {
+        if (spi.resolvedJumpIds.isEmpty) {
           Loggers.app.info('Connected to ${spi.name} in $spentTime ms.');
         } else {
           Loggers.app.info('Jump to ${spi.name} in $spentTime ms.');

--- a/lib/data/provider/server/single.g.dart
+++ b/lib/data/provider/server/single.g.dart
@@ -58,7 +58,7 @@ final class ServerNotifierProvider
   }
 }
 
-String _$serverNotifierHash() => r'bf724a58c5d0ec99f4e00ebe7cea47a7b6b2cc64';
+String _$serverNotifierHash() => r'66806d093a4fb9822dc5cad88a62dd340ca1b45e';
 
 final class ServerNotifierFamily extends $Family
     with

--- a/lib/data/store/server.dart
+++ b/lib/data/store/server.dart
@@ -146,13 +146,9 @@ class ServerStore extends HiveStore {
 
       final spi = get<Spi>(newId);
       if (spi != null) {
-        final jumpId = spi.jumpId;
-        if (jumpId != null && idMap.containsKey(jumpId)) {
-          final newJumpId = idMap[jumpId];
-          if (spi.jumpId != newJumpId) {
-            final newSpi = spi.copyWith(jumpId: newJumpId);
-            update(spi, newSpi);
-          }
+        final newSpi = _replaceJumpIds(spi, idMap);
+        if (newSpi != null) {
+          update(spi, newSpi);
         }
       }
 
@@ -176,9 +172,8 @@ class ServerStore extends HiveStore {
 
     for (final spi in ss) {
       if (get(spi.id) == null) continue;
-      if (spi.jumpId != null && idMap.containsKey(spi.jumpId)) {
-        final newJumpId = idMap[spi.jumpId]!;
-        final newSpi = spi.copyWith(jumpId: newJumpId);
+      final newSpi = _replaceJumpIds(spi, idMap);
+      if (newSpi != null) {
         update(spi, newSpi);
       }
     }
@@ -187,4 +182,26 @@ class ServerStore extends HiveStore {
       SettingStore.instance.serverOrder.put(srvOrder);
     }
   }
+}
+
+Spi? _replaceJumpIds(Spi spi, Map<String, String> idMap) {
+  var changed = false;
+  final resolvedJumpIds = spi.resolvedJumpIds;
+  final newJumpIds = resolvedJumpIds.map((id) {
+    final newId = idMap[id];
+    if (newId == null) return id;
+    changed = true;
+    return newId;
+  }).toList();
+
+  final newJumpId = spi.jumpId != null && idMap.containsKey(spi.jumpId)
+      ? idMap[spi.jumpId]
+      : spi.jumpId;
+  changed = changed || newJumpId != spi.jumpId;
+
+  if (!changed) return null;
+  return spi.copyWith(
+    jumpId: newJumpIds.isEmpty ? newJumpId : newJumpIds.first,
+    jumpIds: newJumpIds.isEmpty ? null : newJumpIds,
+  );
 }

--- a/lib/generated/l10n/l10n.dart
+++ b/lib/generated/l10n/l10n.dart
@@ -900,6 +900,18 @@ abstract class AppLocalizations {
   /// **'Jump server'**
   String get jumpServer;
 
+  /// No description provided for @jumpServersNotFoundFmt.
+  ///
+  /// In en, this message translates to:
+  /// **'Jump servers not found for {serverName}: {jumpIds}'**
+  String jumpServersNotFoundFmt(Object serverName, Object jumpIds);
+
+  /// No description provided for @noJumpServerAvailable.
+  ///
+  /// In en, this message translates to:
+  /// **'No jump server available.'**
+  String get noJumpServerAvailable;
+
   /// No description provided for @jumpServerAndProxyCommandCannotBeUsedTogether.
   ///
   /// In en, this message translates to:

--- a/lib/generated/l10n/l10n_de.dart
+++ b/lib/generated/l10n/l10n_de.dart
@@ -448,6 +448,14 @@ class AppLocalizationsDe extends AppLocalizations {
   String get jumpServer => 'Server springen';
 
   @override
+  String jumpServersNotFoundFmt(Object serverName, Object jumpIds) {
+    return 'Jump servers not found for $serverName: $jumpIds';
+  }
+
+  @override
+  String get noJumpServerAvailable => 'No jump server available.';
+
+  @override
   String get jumpServerAndProxyCommandCannotBeUsedTogether =>
       'Jump server and ProxyCommand cannot be used together.';
 

--- a/lib/generated/l10n/l10n_en.dart
+++ b/lib/generated/l10n/l10n_en.dart
@@ -446,6 +446,14 @@ class AppLocalizationsEn extends AppLocalizations {
   String get jumpServer => 'Jump server';
 
   @override
+  String jumpServersNotFoundFmt(Object serverName, Object jumpIds) {
+    return 'Jump servers not found for $serverName: $jumpIds';
+  }
+
+  @override
+  String get noJumpServerAvailable => 'No jump server available.';
+
+  @override
   String get jumpServerAndProxyCommandCannotBeUsedTogether =>
       'Jump server and ProxyCommand cannot be used together.';
 

--- a/lib/generated/l10n/l10n_es.dart
+++ b/lib/generated/l10n/l10n_es.dart
@@ -447,6 +447,14 @@ class AppLocalizationsEs extends AppLocalizations {
   String get jumpServer => 'Servidor de salto';
 
   @override
+  String jumpServersNotFoundFmt(Object serverName, Object jumpIds) {
+    return 'Jump servers not found for $serverName: $jumpIds';
+  }
+
+  @override
+  String get noJumpServerAvailable => 'No jump server available.';
+
+  @override
   String get jumpServerAndProxyCommandCannotBeUsedTogether =>
       'Jump server and ProxyCommand cannot be used together.';
 

--- a/lib/generated/l10n/l10n_fr.dart
+++ b/lib/generated/l10n/l10n_fr.dart
@@ -448,6 +448,14 @@ class AppLocalizationsFr extends AppLocalizations {
   String get jumpServer => 'Aller au serveur';
 
   @override
+  String jumpServersNotFoundFmt(Object serverName, Object jumpIds) {
+    return 'Jump servers not found for $serverName: $jumpIds';
+  }
+
+  @override
+  String get noJumpServerAvailable => 'No jump server available.';
+
+  @override
   String get jumpServerAndProxyCommandCannotBeUsedTogether =>
       'Jump server and ProxyCommand cannot be used together.';
 

--- a/lib/generated/l10n/l10n_id.dart
+++ b/lib/generated/l10n/l10n_id.dart
@@ -446,6 +446,14 @@ class AppLocalizationsId extends AppLocalizations {
   String get jumpServer => 'Lompat server';
 
   @override
+  String jumpServersNotFoundFmt(Object serverName, Object jumpIds) {
+    return 'Jump servers not found for $serverName: $jumpIds';
+  }
+
+  @override
+  String get noJumpServerAvailable => 'No jump server available.';
+
+  @override
   String get jumpServerAndProxyCommandCannotBeUsedTogether =>
       'Jump server and ProxyCommand cannot be used together.';
 

--- a/lib/generated/l10n/l10n_it.dart
+++ b/lib/generated/l10n/l10n_it.dart
@@ -446,6 +446,14 @@ class AppLocalizationsIt extends AppLocalizations {
   String get jumpServer => 'Server di salto';
 
   @override
+  String jumpServersNotFoundFmt(Object serverName, Object jumpIds) {
+    return 'Jump servers not found for $serverName: $jumpIds';
+  }
+
+  @override
+  String get noJumpServerAvailable => 'No jump server available.';
+
+  @override
   String get jumpServerAndProxyCommandCannotBeUsedTogether =>
       'Jump server and ProxyCommand cannot be used together.';
 

--- a/lib/generated/l10n/l10n_ja.dart
+++ b/lib/generated/l10n/l10n_ja.dart
@@ -435,6 +435,14 @@ class AppLocalizationsJa extends AppLocalizations {
   String get jumpServer => 'ジャンプサーバー';
 
   @override
+  String jumpServersNotFoundFmt(Object serverName, Object jumpIds) {
+    return 'Jump servers not found for $serverName: $jumpIds';
+  }
+
+  @override
+  String get noJumpServerAvailable => 'No jump server available.';
+
+  @override
   String get jumpServerAndProxyCommandCannotBeUsedTogether =>
       'Jump server and ProxyCommand cannot be used together.';
 

--- a/lib/generated/l10n/l10n_ko.dart
+++ b/lib/generated/l10n/l10n_ko.dart
@@ -432,6 +432,14 @@ class AppLocalizationsKo extends AppLocalizations {
   String get jumpServer => '점프 서버';
 
   @override
+  String jumpServersNotFoundFmt(Object serverName, Object jumpIds) {
+    return 'Jump servers not found for $serverName: $jumpIds';
+  }
+
+  @override
+  String get noJumpServerAvailable => 'No jump server available.';
+
+  @override
   String get jumpServerAndProxyCommandCannotBeUsedTogether =>
       'Jump server and ProxyCommand cannot be used together.';
 

--- a/lib/generated/l10n/l10n_nl.dart
+++ b/lib/generated/l10n/l10n_nl.dart
@@ -447,6 +447,14 @@ class AppLocalizationsNl extends AppLocalizations {
   String get jumpServer => 'Spring naar server';
 
   @override
+  String jumpServersNotFoundFmt(Object serverName, Object jumpIds) {
+    return 'Jump servers not found for $serverName: $jumpIds';
+  }
+
+  @override
+  String get noJumpServerAvailable => 'No jump server available.';
+
+  @override
   String get jumpServerAndProxyCommandCannotBeUsedTogether =>
       'Jump server and ProxyCommand cannot be used together.';
 

--- a/lib/generated/l10n/l10n_pt.dart
+++ b/lib/generated/l10n/l10n_pt.dart
@@ -446,6 +446,14 @@ class AppLocalizationsPt extends AppLocalizations {
   String get jumpServer => 'Servidor de salto';
 
   @override
+  String jumpServersNotFoundFmt(Object serverName, Object jumpIds) {
+    return 'Jump servers not found for $serverName: $jumpIds';
+  }
+
+  @override
+  String get noJumpServerAvailable => 'No jump server available.';
+
+  @override
   String get jumpServerAndProxyCommandCannotBeUsedTogether =>
       'Jump server and ProxyCommand cannot be used together.';
 

--- a/lib/generated/l10n/l10n_ru.dart
+++ b/lib/generated/l10n/l10n_ru.dart
@@ -447,6 +447,14 @@ class AppLocalizationsRu extends AppLocalizations {
   String get jumpServer => 'прыжковый сервер';
 
   @override
+  String jumpServersNotFoundFmt(Object serverName, Object jumpIds) {
+    return 'Jump servers not found for $serverName: $jumpIds';
+  }
+
+  @override
+  String get noJumpServerAvailable => 'No jump server available.';
+
+  @override
   String get jumpServerAndProxyCommandCannotBeUsedTogether =>
       'Jump server and ProxyCommand cannot be used together.';
 

--- a/lib/generated/l10n/l10n_tr.dart
+++ b/lib/generated/l10n/l10n_tr.dart
@@ -446,6 +446,14 @@ class AppLocalizationsTr extends AppLocalizations {
   String get jumpServer => 'Atlama sunucusu';
 
   @override
+  String jumpServersNotFoundFmt(Object serverName, Object jumpIds) {
+    return 'Jump servers not found for $serverName: $jumpIds';
+  }
+
+  @override
+  String get noJumpServerAvailable => 'No jump server available.';
+
+  @override
   String get jumpServerAndProxyCommandCannotBeUsedTogether =>
       'Jump server and ProxyCommand cannot be used together.';
 

--- a/lib/generated/l10n/l10n_uk.dart
+++ b/lib/generated/l10n/l10n_uk.dart
@@ -448,6 +448,14 @@ class AppLocalizationsUk extends AppLocalizations {
   String get jumpServer => 'Стрибковий Сервер';
 
   @override
+  String jumpServersNotFoundFmt(Object serverName, Object jumpIds) {
+    return 'Jump servers not found for $serverName: $jumpIds';
+  }
+
+  @override
+  String get noJumpServerAvailable => 'No jump server available.';
+
+  @override
   String get jumpServerAndProxyCommandCannotBeUsedTogether =>
       'Jump server and ProxyCommand cannot be used together.';
 

--- a/lib/generated/l10n/l10n_zh.dart
+++ b/lib/generated/l10n/l10n_zh.dart
@@ -426,6 +426,14 @@ class AppLocalizationsZh extends AppLocalizations {
   String get jumpServer => '跳板服务器';
 
   @override
+  String jumpServersNotFoundFmt(Object serverName, Object jumpIds) {
+    return '未找到 $serverName 配置的跳板服务器：$jumpIds';
+  }
+
+  @override
+  String get noJumpServerAvailable => '没有可用的跳板服务器。';
+
+  @override
   String get jumpServerAndProxyCommandCannotBeUsedTogether =>
       '跳板服务器与 ProxyCommand 不能同时使用。';
 
@@ -1418,6 +1426,14 @@ class AppLocalizationsZhTw extends AppLocalizationsZh {
 
   @override
   String get jumpServer => '跳板伺服器';
+
+  @override
+  String jumpServersNotFoundFmt(Object serverName, Object jumpIds) {
+    return '未找到 $serverName 配置的跳板伺服器：$jumpIds';
+  }
+
+  @override
+  String get noJumpServerAvailable => '沒有可用的跳板伺服器。';
 
   @override
   String get keepForeground => '請讓 App 保持在前景執行';

--- a/lib/hive/hive_adapters.g.dart
+++ b/lib/hive/hive_adapters.g.dart
@@ -107,6 +107,7 @@ class SpiAdapter extends TypeAdapter<Spi> {
       alterUrl: fields[7] as String?,
       autoConnect: fields[8] == null ? true : fields[8] as bool,
       jumpId: fields[9] as String?,
+      jumpIds: (fields[17] as List?)?.cast<String>(),
       proxyCommand: fields[16] as String?,
       custom: fields[10] as ServerCustom?,
       wolCfg: fields[11] as WakeOnLanCfg?,
@@ -120,7 +121,7 @@ class SpiAdapter extends TypeAdapter<Spi> {
   @override
   void write(BinaryWriter writer, Spi obj) {
     writer
-      ..writeByte(17)
+      ..writeByte(18)
       ..writeByte(0)
       ..write(obj.name)
       ..writeByte(1)
@@ -154,7 +155,9 @@ class SpiAdapter extends TypeAdapter<Spi> {
       ..writeByte(15)
       ..write(obj.disabledCmdTypes)
       ..writeByte(16)
-      ..write(obj.proxyCommand);
+      ..write(obj.proxyCommand)
+      ..writeByte(17)
+      ..write(obj.jumpIds);
   }
 
   @override

--- a/lib/hive/hive_adapters.g.yaml
+++ b/lib/hive/hive_adapters.g.yaml
@@ -27,7 +27,7 @@ types:
         index: 4
   Spi:
     typeId: 3
-    nextIndex: 17
+    nextIndex: 18
     fields:
       name:
         index: 0
@@ -49,8 +49,6 @@ types:
         index: 8
       jumpId:
         index: 9
-      proxyCommand:
-        index: 16
       custom:
         index: 10
       wolCfg:
@@ -63,6 +61,10 @@ types:
         index: 14
       disabledCmdTypes:
         index: 15
+      proxyCommand:
+        index: 16
+      jumpIds:
+        index: 17
   VirtKey:
     typeId: 4
     nextIndex: 46

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -129,6 +129,14 @@
   "invalidUrl": "Invalid URL",
   "invalidHostFormat": "Invalid host format. Only IPv4, IPv6, and domain characters are allowed.",
   "jumpServer": "Jump server",
+  "jumpServersNotFoundFmt": "Jump servers not found for {serverName}: {jumpIds}",
+  "@jumpServersNotFoundFmt": {
+    "placeholders": {
+      "serverName": {},
+      "jumpIds": {}
+    }
+  },
+  "noJumpServerAvailable": "No jump server available.",
   "jumpServerAndProxyCommandCannotBeUsedTogether": "Jump server and ProxyCommand cannot be used together.",
   "keepForeground": "Keep app foreground!",
   "keepStatusWhenErr": "Preserve the last server state",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -126,6 +126,8 @@
   "invalid": "无效",
   "invalidHostFormat": "主机格式无效，仅支持 IPv4、IPv6 和域名字符。",
   "jumpServer": "跳板服务器",
+  "jumpServersNotFoundFmt": "未找到 {serverName} 配置的跳板服务器：{jumpIds}",
+  "noJumpServerAvailable": "没有可用的跳板服务器。",
   "keepForeground": "请将应用保持在前台运行",
   "keepStatusWhenErr": "保留上次的服务器状态",
   "keepStatusWhenErrTip": "仅限于执行脚本出错",

--- a/lib/l10n/app_zh_tw.arb
+++ b/lib/l10n/app_zh_tw.arb
@@ -126,6 +126,8 @@
   "invalid": "無效",
   "invalidHostFormat": "主機格式無效，僅支援 IPv4、IPv6 和網域字元。",
   "jumpServer": "跳板伺服器",
+  "jumpServersNotFoundFmt": "未找到 {serverName} 配置的跳板伺服器：{jumpIds}",
+  "noJumpServerAvailable": "沒有可用的跳板伺服器。",
   "keepForeground": "請讓 App 保持在前景執行",
   "keepStatusWhenErr": "保留上次的伺服器狀態",
   "keepStatusWhenErrTip": "僅在執行腳本出錯時",

--- a/lib/view/page/server/edit/actions.dart
+++ b/lib/view/page/server/edit/actions.dart
@@ -270,7 +270,7 @@ extension _Actions on _ServerEditPageState {
       alterUrl: _altUrlController.text.selfNotEmptyOrNull,
       autoConnect: _autoConnect.value,
       jumpId: _jumpServers.value.isEmpty ? null : _jumpServers.value.first,
-      jumpIds: _jumpServers.value.isEmpty ? null : _jumpServers.value.toList(),
+      jumpIds: _jumpServers.value.isEmpty ? null : _jumpServers.value,
       proxyCommand: proxyCommandText.selfNotEmptyOrNull,
       custom: custom,
       wolCfg: wol,
@@ -427,7 +427,7 @@ extension _Utils on _ServerEditPageState {
 
     _altUrlController.text = spi.alterUrl ?? '';
     _autoConnect.value = spi.autoConnect;
-    _jumpServers.value = spi.resolvedJumpIds.toSet();
+    _jumpServers.value = spi.resolvedJumpIds;
     _proxyCommandCtrl.text = spi.proxyCommand ?? '';
 
     final custom = spi.custom;

--- a/lib/view/page/server/edit/actions.dart
+++ b/lib/view/page/server/edit/actions.dart
@@ -151,10 +151,16 @@ extension _Actions on _ServerEditPageState {
   }
 
   bool _isInvalidJumpSelection(String? candidateJumpId) {
+    return _areInvalidJumpSelections(
+      candidateJumpId == null ? const [] : [candidateJumpId],
+    );
+  }
+
+  bool _areInvalidJumpSelections(Iterable<String> candidateJumpIds) {
     final currentServer = spi;
-    return wouldCreateJumpCycle(
+    return wouldCreateJumpCycleForCandidates(
       currentServerId: currentServer?.id,
-      candidateJumpId: candidateJumpId,
+      candidateJumpIds: candidateJumpIds,
       serversById: ref.read(serversProvider).servers,
     );
   }
@@ -208,7 +214,7 @@ extension _Actions on _ServerEditPageState {
     if (_portController.text.isEmpty) {
       _portController.text = '22';
     }
-    if (_isInvalidJumpSelection(_jumpServer.value)) {
+    if (_areInvalidJumpSelections(_jumpServers.value)) {
       context.showSnackBar('${l10n.invalid}: ${l10n.jumpServer}');
       return;
     }
@@ -263,7 +269,8 @@ extension _Actions on _ServerEditPageState {
       tags: _tags.value.isEmpty ? null : _tags.value.toList(),
       alterUrl: _altUrlController.text.selfNotEmptyOrNull,
       autoConnect: _autoConnect.value,
-      jumpId: _jumpServer.value,
+      jumpId: _jumpServers.value.isEmpty ? null : _jumpServers.value.first,
+      jumpIds: _jumpServers.value.isEmpty ? null : _jumpServers.value.toList(),
       proxyCommand: proxyCommandText.selfNotEmptyOrNull,
       custom: custom,
       wolCfg: wol,
@@ -420,7 +427,7 @@ extension _Utils on _ServerEditPageState {
 
     _altUrlController.text = spi.alterUrl ?? '';
     _autoConnect.value = spi.autoConnect;
-    _jumpServer.value = spi.jumpId;
+    _jumpServers.value = spi.resolvedJumpIds.toSet();
     _proxyCommandCtrl.text = spi.proxyCommand ?? '';
 
     final custom = spi.custom;

--- a/lib/view/page/server/edit/edit.dart
+++ b/lib/view/page/server/edit/edit.dart
@@ -73,7 +73,7 @@ class _ServerEditPageState extends ConsumerState<ServerEditPage>
   /// -1: non selected, null: password, others: index of private key
   final _keyIdx = ValueNotifier<int?>(null);
   final _autoConnect = ValueNotifier(true);
-  final _jumpServer = nvn<String?>();
+  final _jumpServers = <String>{}.vn;
   final _pveIgnoreCert = ValueNotifier(false);
   final _tempIsCelsius = ValueNotifier(false);
   final _env = <String, String>{}.vn;
@@ -121,7 +121,7 @@ class _ServerEditPageState extends ConsumerState<ServerEditPage>
 
     _keyIdx.dispose();
     _autoConnect.dispose();
-    _jumpServer.dispose();
+    _jumpServers.dispose();
     _pveIgnoreCert.dispose();
     _tempIsCelsius.dispose();
     _env.dispose();
@@ -154,9 +154,7 @@ class _ServerEditPageState extends ConsumerState<ServerEditPage>
   }
 
   Widget _buildForm() {
-    final topItems = [
-      _buildWriteScriptTip(),
-    ];
+    final topItems = [_buildWriteScriptTip()];
     final children = [
       SizedBox(
         height: 50,

--- a/lib/view/page/server/edit/edit.dart
+++ b/lib/view/page/server/edit/edit.dart
@@ -73,7 +73,7 @@ class _ServerEditPageState extends ConsumerState<ServerEditPage>
   /// -1: non selected, null: password, others: index of private key
   final _keyIdx = ValueNotifier<int?>(null);
   final _autoConnect = ValueNotifier(true);
-  final _jumpServers = <String>{}.vn;
+  final _jumpServers = <String>[].vn;
   final _pveIgnoreCert = ValueNotifier(false);
   final _tempIsCelsius = ValueNotifier(false);
   final _env = <String, String>{}.vn;

--- a/lib/view/page/server/edit/widget.dart
+++ b/lib/view/page/server/edit/widget.dart
@@ -469,7 +469,11 @@ extension _Widgets on _ServerEditPageState {
         .where((e) => !_isInvalidJumpSelection(e.id))
         .toList();
     final choice = _jumpServers.listenVal((val) {
-      final selectedSrvs = srvs.where((e) => val.contains(e.id)).toList();
+      final selectedSrvs = <Spi>[];
+      for (final id in val) {
+        final srv = srvs.firstWhereOrNull((e) => e.id == id);
+        if (srv != null) selectedSrvs.add(srv);
+      }
       return Choice<Spi>(
         multiple: true,
         clearable: true,
@@ -477,14 +481,18 @@ extension _Widgets on _ServerEditPageState {
         builder: (state, _) => Wrap(
           children: List<Widget>.generate(srvs.length, (index) {
             final item = srvs[index];
+            final selectedIndex = val.indexOf(item.id);
             return ChoiceChipX<Spi>(
               key: ValueKey(item),
-              label: item.name,
+              label: selectedIndex == -1
+                  ? item.name
+                  : '${selectedIndex + 1}. ${item.name}',
               state: state,
               value: item,
               onSelected: (srv, on) {
-                final next = Set<String>.from(_jumpServers.value);
+                final next = List<String>.from(_jumpServers.value);
                 if (on) {
+                  if (next.contains(srv.id)) return;
                   if (next.length >= 2) {
                     context.showSnackBar('${l10n.jumpServer}: 2');
                     return;

--- a/lib/view/page/server/edit/widget.dart
+++ b/lib/view/page/server/edit/widget.dart
@@ -468,12 +468,12 @@ extension _Widgets on _ServerEditPageState {
         .where((e) => e.id != spi?.id)
         .where((e) => !_isInvalidJumpSelection(e.id))
         .toList();
-    final choice = _jumpServer.listenVal((val) {
-      final srv = srvs.firstWhereOrNull((e) => e.id == _jumpServer.value);
+    final choice = _jumpServers.listenVal((val) {
+      final selectedSrvs = srvs.where((e) => val.contains(e.id)).toList();
       return Choice<Spi>(
-        multiple: false,
+        multiple: true,
         clearable: true,
-        value: srv != null ? [srv] : [],
+        value: selectedSrvs,
         builder: (state, _) => Wrap(
           children: List<Widget>.generate(srvs.length, (index) {
             final item = srvs[index];
@@ -483,11 +483,17 @@ extension _Widgets on _ServerEditPageState {
               state: state,
               value: item,
               onSelected: (srv, on) {
+                final next = Set<String>.from(_jumpServers.value);
                 if (on) {
-                  _jumpServer.value = srv.id;
+                  if (next.length >= 2) {
+                    context.showSnackBar('${l10n.jumpServer}: 2');
+                    return;
+                  }
+                  next.add(srv.id);
                 } else {
-                  _jumpServer.value = null;
+                  next.remove(srv.id);
                 }
+                _jumpServers.value = next;
               },
             );
           }),
@@ -496,7 +502,7 @@ extension _Widgets on _ServerEditPageState {
     });
     return ExpandTile(
       leading: const Icon(Icons.map),
-      initiallyExpanded: _jumpServer.value != null,
+      initiallyExpanded: _jumpServers.value.isNotEmpty,
       childrenPadding: padding,
       title: Text(l10n.jumpServer),
       children: [choice],

--- a/test/jump_chain_test.dart
+++ b/test/jump_chain_test.dart
@@ -2,7 +2,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:server_box/core/utils/jump_chain.dart';
 import 'package:server_box/data/model/server/server_private_info.dart';
 
-Spi _spi({required String id, required String name, String? jumpId}) {
+Spi _spi({
+  required String id,
+  required String name,
+  String? jumpId,
+  List<String>? jumpIds,
+}) {
   return Spi(
     id: id,
     name: name,
@@ -10,6 +15,7 @@ Spi _spi({required String id, required String name, String? jumpId}) {
     port: 22,
     user: 'root',
     jumpId: jumpId,
+    jumpIds: jumpIds,
   );
 }
 
@@ -86,6 +92,45 @@ void main() {
       final chain = collectJumpServers(spi: target, serversById: servers);
 
       expect(chain.keys.toList(), ['A', 'B']);
+    });
+
+    test('collectJumpServers collects both jump candidates', () {
+      final target = _spi(id: 'T', name: 'target', jumpIds: ['A', 'C']);
+      final servers = <String, Spi>{
+        'A': _spi(id: 'A', name: 'a', jumpId: 'B'),
+        'B': _spi(id: 'B', name: 'b'),
+        'C': _spi(id: 'C', name: 'c', jumpId: 'D'),
+        'D': _spi(id: 'D', name: 'd'),
+      };
+
+      final chain = collectJumpServers(spi: target, serversById: servers);
+
+      expect(chain.keys.toList(), ['A', 'C', 'B', 'D']);
+    });
+
+    test(
+      'wouldCreateJumpCycleForCandidates detects either candidate cycle',
+      () {
+        final servers = <String, Spi>{
+          'A': _spi(id: 'A', name: 'a'),
+          'B': _spi(id: 'B', name: 'b', jumpId: 'T'),
+        };
+
+        final result = wouldCreateJumpCycleForCandidates(
+          currentServerId: 'T',
+          candidateJumpIds: ['A', 'B'],
+          serversById: servers,
+        );
+
+        expect(result, isTrue);
+      },
+    );
+
+    test('resolvedJumpIds falls back to legacy jumpId', () {
+      final target = _spi(id: 'T', name: 'target', jumpId: 'A');
+
+      expect(target.resolvedJumpIds, ['A']);
+      expect(target.firstJumpId, 'A');
     });
   });
 }

--- a/test/jump_failover_test.dart
+++ b/test/jump_failover_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:server_box/core/utils/server.dart';
+
+void main() {
+  group('Jump failover errors', () {
+    test('network errors can fail over', () {
+      expect(isJumpFailoverErrorForTest('Connection refused'), isTrue);
+      expect(isJumpFailoverErrorForTest('SocketException: timed out'), isTrue);
+      expect(isJumpFailoverErrorForTest('forwardLocal failed'), isTrue);
+    });
+
+    test('auth and host key errors do not fail over', () {
+      expect(isJumpFailoverErrorForTest('Authentication failed'), isFalse);
+      expect(
+        isJumpFailoverErrorForTest('User rejected new SSH host key'),
+        isFalse,
+      );
+      expect(isJumpFailoverErrorForTest('Permission denied'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Add support for up to two ordered jump-server candidates per server, while keeping legacy `jumpId` data compatible.
- Update SSH connection flow to try jump servers in order and fall back only on network-style failures.
- Update jump-chain validation, SFTP preload handling, server ID migration, and the server edit UI to work with the new candidate list.
- Regenerate model and Hive artifacts for the updated schema.

## Testing
- Added unit coverage for jump-chain collection, cycle detection, legacy fallback, and failover error classification.
- Ran targeted `flutter analyze` on the changed files with no issues.
- Ran `flutter test` for the affected test set; all tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-candidate jump-server failover with automatic retry and known-host provisioning for all candidates
  * Support for configuring up to two ordered jump servers

* **UI Changes**
  * Jump server selection is multi-select with ordered numbering and a two-server limit
  * Validation updated for multi-candidate selections

* **Improvements**
  * More robust cycle detection and discovery of reachable jump servers
  * Refined failover error recognition
  * Data migration and storage updated to persist ordered jump candidates

* **Tests**
  * Added tests for cycle detection, resolution, and failover behavior

* **Localization**
  * Added user-facing messages for jump-server not-found and no-available-jump-server
<!-- end of auto-generated comment: release notes by coderabbit.ai -->