### PR TITLE
Make file tap open editor and keep long-press menus

### DIFF
--- a/lib/view/page/storage/local.dart
+++ b/lib/view/page/storage/local.dart
@@ -26,16 +26,21 @@ class LocalFilePage extends ConsumerStatefulWidget {
 
   const LocalFilePage({super.key, this.args});
 
-  static const route = AppRoute<String, LocalFilePageArgs>(page: LocalFilePage.new, path: '/files/local');
+  static const route = AppRoute<String, LocalFilePageArgs>(
+    page: LocalFilePage.new,
+    path: '/files/local',
+  );
 
   @override
   ConsumerState<LocalFilePage> createState() => _LocalFilePageState();
 }
 
-class _LocalFilePageState extends ConsumerState<LocalFilePage> with AutomaticKeepAliveClientMixin {
+class _LocalFilePageState extends ConsumerState<LocalFilePage>
+    with AutomaticKeepAliveClientMixin {
   late final _path = LocalPath(widget.args?.initDir ?? Paths.file);
   final _sortType = _SortType.name.vn;
-  late Future<List<(FileSystemEntity, FileStat)>> _entitiesFuture = _getEntities();
+  late Future<List<(FileSystemEntity, FileStat)>> _entitiesFuture =
+      _getEntities();
   bool get isPickFile => widget.args?.isPickFile ?? false;
 
   @override
@@ -80,7 +85,9 @@ class _LocalFilePageState extends ConsumerState<LocalFilePage> with AutomaticKee
           if (!isMobile)
             IconButton(
               icon: const Icon(Icons.refresh),
-              tooltip: MaterialLocalizations.of(context).refreshIndicatorSemanticLabel,
+              tooltip: MaterialLocalizations.of(
+                context,
+              ).refreshIndicatorSemanticLabel,
               onPressed: _refresh,
             ),
           if (!isPickFile) _buildMissionBtn(),
@@ -126,7 +133,12 @@ class _LocalFilePageState extends ConsumerState<LocalFilePage> with AutomaticKee
             final stat = item.$2;
             final isDir = stat.type == FileSystemEntityType.directory;
 
-            return _buildItem(file: file, fileName: fileName, stat: stat, isDir: isDir);
+            return _buildItem(
+              file: file,
+              fileName: fileName,
+              stat: stat,
+              isDir: isDir,
+            );
           },
         );
       },
@@ -151,7 +163,9 @@ class _LocalFilePageState extends ConsumerState<LocalFilePage> with AutomaticKee
 
     return CardX(
       child: ListTile(
-        leading: isDir ? const Icon(Icons.folder_open) : const Icon(Icons.insert_drive_file),
+        leading: isDir
+            ? const Icon(Icons.folder_open)
+            : const Icon(Icons.insert_drive_file),
         title: Text(serverName ?? fileName),
         subtitle: isDir
             ? (serverName != null ? Text(fileName, style: UIs.textGrey) : null)
@@ -166,7 +180,11 @@ class _LocalFilePageState extends ConsumerState<LocalFilePage> with AutomaticKee
         },
         onTap: () {
           if (!isDir) {
-            _showFileActionDialog(file);
+            if (isPickFile) {
+              _showFileActionDialog(file);
+            } else {
+              _onTapEdit(file, fileName, popMenu: false);
+            }
             return;
           }
           _path.update(fileName);
@@ -185,7 +203,9 @@ class _LocalFilePageState extends ConsumerState<LocalFilePage> with AutomaticKee
 
   Future<List<(FileSystemEntity, FileStat)>> _getEntities() async {
     final files = await Directory(_path.path).list().toList();
-    final stats = await Future.wait(files.map((e) async => (e, await e.stat())));
+    final stats = await Future.wait(
+      files.map((e) async => (e, await e.stat())),
+    );
     stats.sort(_sortType.value.compareTuple);
     return stats;
   }
@@ -347,8 +367,12 @@ extension _Actions on _LocalFilePageState {
 }
 
 extension _OnTapFile on _LocalFilePageState {
-  void _onTapEdit(FileSystemEntity file, String fileName) async {
-    context.pop();
+  void _onTapEdit(
+    FileSystemEntity file,
+    String fileName, {
+    bool popMenu = true,
+  }) async {
+    if (popMenu) context.pop();
     final stat = await file.stat();
     if (stat.size > Miscs.editorMaxSize) {
       context.showRoundDialog(
@@ -397,7 +421,16 @@ extension _OnTapFile on _LocalFilePageState {
       return;
     }
 
-    ref.read(sftpProvider.notifier).add(SftpReq(spi, '$remotePath/$fileName', file.absolute.path, SftpReqType.upload));
+    ref
+        .read(sftpProvider.notifier)
+        .add(
+          SftpReq(
+            spi,
+            '$remotePath/$fileName',
+            file.absolute.path,
+            SftpReqType.upload,
+          ),
+        );
     context.showSnackBar(l10n.added2List);
   }
 }
@@ -407,7 +440,10 @@ enum _SortType {
   size,
   time;
 
-  int compareTuple((FileSystemEntity, FileStat) a, (FileSystemEntity, FileStat) b) {
+  int compareTuple(
+    (FileSystemEntity, FileStat) a,
+    (FileSystemEntity, FileStat) b,
+  ) {
     return switch (this) {
       _SortType.name => a.$1.path.compareTo(b.$1.path),
       _SortType.size => a.$2.size.compareTo(b.$2.size),
@@ -430,7 +466,10 @@ enum _SortType {
   PopupMenuItem<_SortType> get menuItem {
     return PopupMenuItem(
       value: this,
-      child: Row(mainAxisAlignment: MainAxisAlignment.spaceAround, children: [Icon(icon), Text(i18n)]),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        children: [Icon(icon), Text(i18n)],
+      ),
     );
   }
 }

--- a/lib/view/page/storage/sftp.dart
+++ b/lib/view/page/storage/sftp.dart
@@ -298,7 +298,7 @@ extension _UI on _SftpPageState {
               _status.path.path = file.filename;
               _listDir();
             } else {
-              _onItemPress(file, true);
+              _edit(file, popMenu: false);
             }
           },
           onLongPress: () {
@@ -328,7 +328,7 @@ extension _UI on _SftpPageState {
               _status.path.path = file.filename;
               _listDir();
             } else {
-              _onItemPress(file, true);
+              _edit(file, popMenu: false);
             }
           },
           onLongPress: () {
@@ -568,8 +568,8 @@ extension _Actions on _SftpPageState {
     );
   }
 
-  Future<void> _edit(SftpName name) async {
-    context.pop();
+  Future<void> _edit(SftpName name, {bool popMenu = true}) async {
+    if (popMenu) context.pop();
 
     final remotePath = _getRemotePath(name);
     final useSudoForEdit = _useSudo;


### PR DESCRIPTION
Resolve #1158.

## Summary
- Changed SFTP and local file lists so tapping a regular file opens the editor directly.
- Kept long-press behavior as the action menu for files, and preserved tap-to-enter for folders.
- Adjusted edit entry points to avoid popping the current page when invoked directly from a tap.

## Testing
- `dart analyze lib/view/page/storage/sftp.dart lib/view/page/storage/local.dart` passed.
- Performed local UI-flow validation for the revised tap vs long-press behavior in both file browsers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated file tapping behavior in local and SFTP storage pages for improved usability
  * Files now open directly in the editor instead of displaying action menus in applicable contexts
  * Refined context handling when navigating from different workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->