### PR TITLE
Fix Windows SSH key file permissions

### DIFF
--- a/lib/view/widget/server_func_btns.dart
+++ b/lib/view/widget/server_func_btns.dart
@@ -217,9 +217,7 @@ void _gotoSSH(Spi spi, BuildContext context) async {
           ? keyContent
           : '$keyContent\n';
       await file.writeAsString(keyContentWithNewline);
-      if (!Platform.isWindows) {
-        await Process.run('chmod', ['600', path]);
-      }
+      await _restrictPrivateKeyFile(path);
       extraArgs.addAll(['-i', path]);
     }
 
@@ -276,6 +274,47 @@ void _gotoSSH(Spi spi, BuildContext context) async {
         }),
       );
     }
+  }
+}
+
+Future<void> _restrictPrivateKeyFile(String path) async {
+  if (!Platform.isWindows) {
+    final result = await Process.run('chmod', ['600', path]);
+    if (result.exitCode != 0) {
+      throw ProcessException(
+        'chmod',
+        ['600', path],
+        '${result.stdout}${result.stderr}',
+        result.exitCode,
+      );
+    }
+    return;
+  }
+
+  final whoami = await Process.run('whoami', []);
+  if (whoami.exitCode != 0) {
+    throw ProcessException(
+      'whoami',
+      const [],
+      '${whoami.stdout}${whoami.stderr}',
+      whoami.exitCode,
+    );
+  }
+
+  final user = whoami.stdout.toString().trim();
+  final icacls = await Process.run('icacls', [
+    path,
+    '/inheritance:r',
+    '/grant:r',
+    '$user:F',
+  ]);
+  if (icacls.exitCode != 0) {
+    throw ProcessException(
+      'icacls',
+      [path, '/inheritance:r', '/grant:r', '$user:F'],
+      '${icacls.stdout}${icacls.stderr}',
+      icacls.exitCode,
+    );
   }
 }
 

--- a/lib/view/widget/server_func_btns.dart
+++ b/lib/view/widget/server_func_btns.dart
@@ -217,7 +217,25 @@ void _gotoSSH(Spi spi, BuildContext context) async {
           ? keyContent
           : '$keyContent\n';
       await file.writeAsString(keyContentWithNewline);
-      await _restrictPrivateKeyFile(path);
+      try {
+        await _restrictPrivateKeyFile(path);
+      } on ProcessException catch (e, s) {
+        Loggers.app.warning(
+          'Failed to restrict temporary SSH key file permissions',
+          e,
+          s,
+        );
+        if (context.mounted) {
+          context.showErrDialog(e, s, libL10n.error);
+        }
+        return;
+      } on Exception catch (e, s) {
+        Loggers.app.warning('Failed to prepare temporary SSH key file', e, s);
+        if (context.mounted) {
+          context.showErrDialog(e, s, libL10n.error);
+        }
+        return;
+      }
       extraArgs.addAll(['-i', path]);
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for temporary SSH private key files with platform-specific permission hardening on Windows and Unix-like systems.
  * Failures to apply permissions are now surfaced to the user via an error dialog and prevent continuing the SSH launch to avoid using insecure keys.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lollipopkit/flutter_server_box/pull/1168)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->