### PR TITLE
fix(sftp): close persistent SFTP channel on page dispose and guard async race

### DIFF
--- a/lib/view/page/storage/sftp.dart
+++ b/lib/view/page/storage/sftp.dart
@@ -84,9 +84,10 @@ class _SftpPageState extends ConsumerState<SftpPage> with AfterLayoutMixin {
 
   @override
   void dispose() {
-    super.dispose();
+    _status.client?.close();
     _sortOption.dispose();
     _sudoMode.dispose();
+    super.dispose();
   }
 
   @override
@@ -1033,10 +1034,13 @@ extension _Actions on _SftpPageState {
     }
 
     try {
-      _status.client ??= await _withSftpOpTimeout(
-        'open browser session',
-        _client.sftp(),
-      );
+      // ignore: prefer_conditional_assignment
+      if (_status.client == null) {
+        _status.client = await _withSftpOpTimeout(
+          'open browser session',
+          _client.sftp(),
+        );
+      }
       final client = _status.client;
       if (client == null) return null;
       return await _withSftpOpTimeout(
@@ -1054,6 +1058,12 @@ extension _Actions on _SftpPageState {
       final items = await _sudoHelper.listDir(listPath, password: pwd);
       _sudoMode.value = true;
       return items;
+    } catch (e) {
+      if (e is! SftpStatusError) {
+        _status.client?.close();
+        _status.client = null;
+      }
+      rethrow;
     }
   }
 

--- a/lib/view/page/storage/sftp.dart
+++ b/lib/view/page/storage/sftp.dart
@@ -66,6 +66,7 @@ class _SftpPageState extends ConsumerState<SftpPage> with AfterLayoutMixin {
   _SortOption? _sortedFilesOption;
   bool? _sortedFilesShowFoldersFirst;
   List<SftpName>? _sortedFilesCache;
+  Future<SftpClient>? _openingClientFuture;
 
   bool get _useSudo => _sudoHelper.enabled && _sudoMode.value;
 
@@ -85,6 +86,7 @@ class _SftpPageState extends ConsumerState<SftpPage> with AfterLayoutMixin {
   @override
   void dispose() {
     _status.client?.close();
+    _openingClientFuture = null;
     _sortOption.dispose();
     _sudoMode.dispose();
     super.dispose();
@@ -1034,13 +1036,15 @@ extension _Actions on _SftpPageState {
     }
 
     try {
-      // ignore: prefer_conditional_assignment
-      if (_status.client == null) {
-        _status.client = await _withSftpOpTimeout(
+      if (_status.client == null && _openingClientFuture == null) {
+        _openingClientFuture = _withSftpOpTimeout(
           'open browser session',
           _client.sftp(),
         );
       }
+      _status.client ??= await _openingClientFuture;
+      _openingClientFuture = null;
+      if (!mounted) return null;
       final client = _status.client;
       if (client == null) return null;
       return await _withSftpOpTimeout(
@@ -1048,6 +1052,7 @@ extension _Actions on _SftpPageState {
         client.listdir(listPath),
       );
     } on SftpStatusError catch (e) {
+      _openingClientFuture = null;
       final canFallback =
           _sudoHelper.enabled &&
           (e.code == 3 || _sftpPermissionDeniedReg.hasMatch(e.message));
@@ -1063,6 +1068,7 @@ extension _Actions on _SftpPageState {
         _status.client?.close();
         _status.client = null;
       }
+      _openingClientFuture = null;
       rethrow;
     }
   }


### PR DESCRIPTION
- Close _status.client in dispose() to prevent channel leak when navigating away from the SFTP browser page.
- Replace ??= with explicit null check to avoid concurrent double-open race when multiple _listDir calls overlap.
- Add catch block to close and null-out stale client on non-SftpStatusError, allowing recovery on next call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SFTP connection cleanup to prevent stale connections from persisting.
  * Coordinated concurrent connection attempts to avoid race conditions when opening sessions.
  * Ensured ongoing connection attempts are cleared and active connections are closed during shutdown.
  * Non-standard errors now trigger a proactive connection reset to avoid leaving a broken session open.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lollipopkit/flutter_server_box/pull/1173?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->