### PR TITLE
Pin Flutter version to 3.41.9 as 3.44 have compatibility issues

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
+          flutter-version: '3.41.9'
 
       - name: Install dependencies
         run: flutter pub get

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: "stable"
-          flutter-version: "3.41.4"
+          flutter-version: "3.41.9"
       - uses: actions/setup-java@v4
         with:
           distribution: "zulu"
@@ -98,6 +98,9 @@ jobs:
           submodules: recursive
       - name: Install Flutter
         uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          flutter-version: '3.41.9'
       - name: Install dependencies
         run: |
           sudo apt update
@@ -144,6 +147,9 @@ jobs:
           submodules: recursive
       - name: Install Flutter
         uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          flutter-version: '3.41.9'
       - name: Build
         run: dart run fl_build -p windows
       - name: Rename for release


### PR DESCRIPTION
The compilation issues with upstream third-party dependencies in Flutter 3.44 are not caused by ServerBox code:
The various IconData subclasses in `icons_plus: ^5.0.0` (such as `AntDesignIconData` and `BootstrapIconData`) extend the `final class IconData` in Flutter 3.44, which causes a compilation error.
re_editor: Version ^0.8.0 does not implement the TextInputClient.onFocusReceived() method introduced in Flutter 3.44, which also causes a compilation failure.

Until these issues are resolved, Flutter version is temporary locked at 3.41.9 and consider migrating later based on the status of the upstream packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration and testing infrastructure to use the latest compatible Flutter version, ensuring improved build reliability and consistency across all automated testing environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lollipopkit/flutter_server_box/pull/1177?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->