### PR TITLE
Add per-process disk I/O read and write speed to process management

### DIFF
--- a/lib/data/model/app/scripts/script_builders.dart
+++ b/lib/data/model/app/scripts/script_builders.dart
@@ -258,7 +258,9 @@ if [ "\$macSign" = "" ] && [ "\$bsdSign" = "" ]; then
 \telse
 \t\tprintf 'PID USER %%CPU %%MEM VSZ RSS TTY STAT START TIME READ_BYTES WRITE_BYTES COMMAND\\n'
 \t\tps -axo pid=,user=,%cpu=,%mem=,vsz=,rss=,tty=,stat=,start=,time=,args= | while IFS= read -r line; do
+\t\t\tset -f
 \t\t\tset -- \$line
+\t\t\tset +f
 \t\t\tpid=\$1; user=\$2; cpu=\$3; mem=\$4; vsz=\$5; rss=\$6; tty=\$7; stat=\$8; start=\$9; time=\${10}
 \t\t\tshift 10
 \t\t\tcmd=\$*

--- a/lib/data/model/app/scripts/script_builders.dart
+++ b/lib/data/model/app/scripts/script_builders.dart
@@ -111,7 +111,10 @@ switch (\$args[0]) {
       disabledCmdTypes: disabledCmdTypes ?? [],
     ),
     ShellFunc.process =>
-      'Get-Process | Select-Object ProcessName, Id, CPU, WorkingSet | ConvertTo-Json',
+      r'''
+Get-Process | Select-Object ProcessName, Id, CPU, WorkingSet,
+    @{Name='IOReadBytes';Expression={$_.IOReadBytes}},
+    @{Name='IOWriteBytes';Expression={$_.IOWriteBytes}} | ConvertTo-Json''',
     ShellFunc.shutdown => 'Stop-Computer -Force',
     ShellFunc.reboot => 'Restart-Computer -Force',
     ShellFunc.suspend =>
@@ -253,7 +256,20 @@ if [ "\$macSign" = "" ] && [ "\$bsdSign" = "" ]; then
 \tif [ "\$isBusybox" != "" ]; then
 \t\tps w
 \telse
-\t\tps -aux
+\t\tprintf 'PID USER %%CPU %%MEM VSZ RSS TTY STAT START TIME READ_BYTES WRITE_BYTES COMMAND\\n'
+\t\tps -axo pid=,user=,%cpu=,%mem=,vsz=,rss=,tty=,stat=,start=,time=,args= | while IFS= read -r line; do
+\t\t\tset -- \$line
+\t\t\tpid=\$1; user=\$2; cpu=\$3; mem=\$4; vsz=\$5; rss=\$6; tty=\$7; stat=\$8; start=\$9; time=\${10}
+\t\t\tshift 10
+\t\t\tcmd=\$*
+\t\t\tread_bytes='-'
+\t\t\twrite_bytes='-'
+\t\t\tif [ -r "/proc/\$pid/io" ]; then
+\t\t\t\tread_bytes=\$(awk '/^read_bytes:/ {print \$2}' "/proc/\$pid/io")
+\t\t\t\twrite_bytes=\$(awk '/^write_bytes:/ {print \$2}' "/proc/\$pid/io")
+\t\t\tfi
+\t\t\tprintf '%s %s %s %s %s %s %s %s %s %s %s %s %s\\n' "\$pid" "\$user" "\$cpu" "\$mem" "\$vsz" "\$rss" "\$tty" "\$stat" "\$start" "\$time" "\$read_bytes" "\$write_bytes" "\$cmd"
+\t\tdone
 \tfi
 else
 \tps -ax

--- a/lib/data/model/server/proc.dart
+++ b/lib/data/model/server/proc.dart
@@ -1,4 +1,4 @@
-import 'package:fl_lib/fl_lib.dart';
+import 'dart:convert';
 
 import 'package:server_box/data/res/misc.dart';
 
@@ -13,6 +13,8 @@ class _ProcValIdxMap {
   final int? stat;
   final int? start;
   final int? time;
+  final int? readBytes;
+  final int? writeBytes;
   final int command;
 
   const _ProcValIdxMap({
@@ -26,6 +28,8 @@ class _ProcValIdxMap {
     this.stat,
     this.start,
     this.time,
+    this.readBytes,
+    this.writeBytes,
     required this.command,
   });
 }
@@ -42,6 +46,10 @@ class Proc {
   final String? stat;
   final String? start;
   final String? time;
+  final int? readBytes;
+  final int? writeBytes;
+  final double? readSpeed;
+  final double? writeSpeed;
   final String command;
 
   const Proc({
@@ -55,11 +63,28 @@ class Proc {
     this.stat,
     this.start,
     this.time,
+    this.readBytes,
+    this.writeBytes,
+    this.readSpeed,
+    this.writeSpeed,
     required this.command,
   });
 
-  factory Proc._parse(String raw, _ProcValIdxMap map) {
+  factory Proc._parse(
+    String raw,
+    _ProcValIdxMap map, {
+    Proc? previous,
+    double? elapsedSeconds,
+  }) {
     final parts = raw.split(RegExp(r'\s+'));
+    final readBytes = _parseNullableInt(parts, map.readBytes);
+    final writeBytes = _parseNullableInt(parts, map.writeBytes);
+    final (readSpeed, writeSpeed) = _calculateSpeeds(
+      readBytes: readBytes,
+      writeBytes: writeBytes,
+      previous: previous,
+      elapsedSeconds: elapsedSeconds,
+    );
     return Proc(
       user: map.user == null ? null : parts[map.user!],
       pid: int.parse(parts[map.pid]),
@@ -71,7 +96,44 @@ class Proc {
       stat: map.stat == null ? null : parts[map.stat!],
       start: map.start == null ? null : parts[map.start!],
       time: map.time == null ? null : parts[map.time!],
+      readBytes: readBytes,
+      writeBytes: writeBytes,
+      readSpeed: readSpeed,
+      writeSpeed: writeSpeed,
       command: parts.sublist(map.command).join(' '),
+    );
+  }
+
+  factory Proc._parseWindowsJson(
+    Map<String, dynamic> raw, {
+    Proc? previous,
+    double? elapsedSeconds,
+  }) {
+    final readBytes = _parseDynamicInt(
+      raw['IOReadBytes'] ?? raw['ReadTransferCount'],
+    );
+    final writeBytes = _parseDynamicInt(
+      raw['IOWriteBytes'] ?? raw['WriteTransferCount'],
+    );
+    final (readSpeed, writeSpeed) = _calculateSpeeds(
+      readBytes: readBytes,
+      writeBytes: writeBytes,
+      previous: previous,
+      elapsedSeconds: elapsedSeconds,
+    );
+    final name = raw['ProcessName'] ?? raw['Name'];
+    final command = raw['CommandLine'] ?? raw['Path'] ?? name ?? '';
+    return Proc(
+      pid: _parseDynamicInt(raw['Id'] ?? raw['ProcessId'])!,
+      cpu: _parseDynamicDouble(raw['CPU']),
+      rss: _parseDynamicInt(
+        raw['WorkingSet'] ?? raw['WorkingSetSize'],
+      )?.toString(),
+      readBytes: readBytes,
+      writeBytes: writeBytes,
+      readSpeed: readSpeed,
+      writeSpeed: writeSpeed,
+      command: command.toString(),
     );
   }
 
@@ -87,6 +149,10 @@ class Proc {
       'stat': stat,
       'start': start,
       'time': time,
+      'readBytes': readBytes,
+      'writeBytes': writeBytes,
+      'readSpeed': readSpeed,
+      'writeSpeed': writeSpeed,
       'command': command,
     };
   }
@@ -106,12 +172,41 @@ class Proc {
 class PsResult {
   final List<Proc> procs;
   final String? error;
+  final int sampledAtMillis;
 
-  const PsResult({required this.procs, this.error});
+  const PsResult({required this.procs, this.error, this.sampledAtMillis = 0});
 
-  factory PsResult.parse(String raw, {ProcSortMode sort = ProcSortMode.cpu}) {
-    final lines = raw.split('\n').map((e) => e.trim()).toList();
-    if (lines.isEmpty) return const PsResult(procs: [], error: null);
+  factory PsResult.parse(
+    String raw, {
+    ProcSortMode sort = ProcSortMode.cpu,
+    PsResult? previous,
+    int? sampledAtMillis,
+  }) {
+    final currentSampledAtMillis =
+        sampledAtMillis ?? DateTime.now().millisecondsSinceEpoch;
+    final previousByPid = {
+      for (final proc in previous?.procs ?? const <Proc>[]) proc.pid: proc,
+    };
+    final elapsedSeconds = previous == null || previous.sampledAtMillis <= 0
+        ? null
+        : (currentSampledAtMillis - previous.sampledAtMillis) / 1000.0;
+    final jsonResult = _parseWindowsJsonResult(
+      raw,
+      previousByPid: previousByPid,
+      elapsedSeconds: elapsedSeconds,
+      sampledAtMillis: currentSampledAtMillis,
+      sort: sort,
+    );
+    if (jsonResult != null) return jsonResult;
+
+    final lines = raw
+        .split('\n')
+        .map((e) => e.trim())
+        .where((e) => e.isNotEmpty)
+        .toList();
+    if (lines.isEmpty) {
+      return PsResult(procs: const [], sampledAtMillis: currentSampledAtMillis);
+    }
 
     final header = lines[0];
     final parts = header.split(RegExp(r'\s+'));
@@ -127,6 +222,8 @@ class PsResult {
       stat: parts.indexOfOrNull('STAT'),
       start: parts.indexOfOrNull('START'),
       time: parts.indexOfOrNull('TIME'),
+      readBytes: parts.indexOfOrNull('READ_BYTES'),
+      writeBytes: parts.indexOfOrNull('WRITE_BYTES'),
       command: parts.indexOfOrNull('COMMAND') ?? parts.indexOfOrNull('CMD')!,
     );
 
@@ -136,19 +233,83 @@ class PsResult {
       final line = lines[i];
       if (line.isEmpty) continue;
       try {
-        procs.add(Proc._parse(line, map));
-      } catch (e, trace) {
+        final pid = _parsePid(line, map.pid);
+        procs.add(
+          Proc._parse(
+            line,
+            map,
+            previous: previousByPid[pid],
+            elapsedSeconds: elapsedSeconds,
+          ),
+        );
+      } catch (e) {
         errs.add('$line: $e');
-        Loggers.app.warning('Process failed', e, trace);
       }
     }
 
+    _sort(procs, sort);
+    return PsResult(
+      procs: procs,
+      error: errs.isEmpty ? null : errs.join('\n'),
+      sampledAtMillis: currentSampledAtMillis,
+    );
+  }
+
+  static PsResult? _parseWindowsJsonResult(
+    String raw, {
+    required Map<int, Proc> previousByPid,
+    required double? elapsedSeconds,
+    required int sampledAtMillis,
+    required ProcSortMode sort,
+  }) {
+    final trimmed = raw.trim();
+    if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) return null;
+    try {
+      final decoded = json.decode(trimmed);
+      final items = decoded is List ? decoded : [decoded];
+      final procs = <Proc>[];
+      final errs = <String>[];
+      for (final item in items) {
+        if (item is! Map) continue;
+        try {
+          final map = Map<String, dynamic>.from(item);
+          final pid = _parseDynamicInt(map['Id'] ?? map['ProcessId']);
+          if (pid == null) continue;
+          procs.add(
+            Proc._parseWindowsJson(
+              map,
+              previous: previousByPid[pid],
+              elapsedSeconds: elapsedSeconds,
+            ),
+          );
+        } catch (e) {
+          errs.add('$item: $e');
+        }
+      }
+      _sort(procs, sort);
+      return PsResult(
+        procs: procs,
+        error: errs.isEmpty ? null : errs.join('\n'),
+        sampledAtMillis: sampledAtMillis,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static void _sort(List<Proc> procs, ProcSortMode sort) {
     switch (sort) {
       case ProcSortMode.cpu:
-        procs.sort((a, b) => b.cpu?.compareTo(a.cpu ?? 0) ?? 0);
+        procs.sort((a, b) => _compareNullableDesc(a.cpu, b.cpu));
         break;
       case ProcSortMode.mem:
-        procs.sort((a, b) => b.mem?.compareTo(a.mem ?? 0) ?? 0);
+        procs.sort((a, b) => _compareNullableDesc(a.mem, b.mem));
+        break;
+      case ProcSortMode.read:
+        procs.sort((a, b) => _compareNullableDesc(a.readSpeed, b.readSpeed));
+        break;
+      case ProcSortMode.write:
+        procs.sort((a, b) => _compareNullableDesc(a.writeSpeed, b.writeSpeed));
         break;
       case ProcSortMode.pid:
         procs.sort((a, b) => a.pid.compareTo(b.pid));
@@ -160,15 +321,71 @@ class PsResult {
         procs.sort((a, b) => a.binary.compareTo(b.binary));
         break;
     }
-    return PsResult(procs: procs, error: errs.isEmpty ? null : errs.join('\n'));
   }
 }
 
-enum ProcSortMode { cpu, mem, pid, user, name }
+enum ProcSortMode { cpu, mem, read, write, pid, user, name }
 
 extension _StrIndex on List<String> {
   int? indexOfOrNull(String val) {
     final idx = indexOf(val);
     return idx == -1 ? null : idx;
   }
+}
+
+int _parsePid(String raw, int pidIndex) {
+  final parts = raw.split(RegExp(r'\s+'));
+  return int.parse(parts[pidIndex]);
+}
+
+int? _parseNullableInt(List<String> parts, int? idx) {
+  if (idx == null || idx >= parts.length) return null;
+  return _parseDynamicInt(parts[idx]);
+}
+
+int? _parseDynamicInt(Object? val) {
+  if (val == null) return null;
+  if (val is int) return val;
+  if (val is num) return val.toInt();
+  final str = val.toString();
+  if (str.isEmpty || str == '-') return null;
+  return int.tryParse(str);
+}
+
+double? _parseDynamicDouble(Object? val) {
+  if (val == null) return null;
+  if (val is double) return val;
+  if (val is num) return val.toDouble();
+  final str = val.toString();
+  if (str.isEmpty || str == '-') return null;
+  return double.tryParse(str);
+}
+
+(double?, double?) _calculateSpeeds({
+  required int? readBytes,
+  required int? writeBytes,
+  required Proc? previous,
+  required double? elapsedSeconds,
+}) {
+  if (previous == null || elapsedSeconds == null || elapsedSeconds <= 0) {
+    return (null, null);
+  }
+  return (
+    _calculateSpeed(readBytes, previous.readBytes, elapsedSeconds),
+    _calculateSpeed(writeBytes, previous.writeBytes, elapsedSeconds),
+  );
+}
+
+double? _calculateSpeed(int? current, int? previous, double elapsedSeconds) {
+  if (current == null || previous == null) return null;
+  final diff = current - previous;
+  if (diff < 0) return null;
+  return diff / elapsedSeconds;
+}
+
+int _compareNullableDesc(num? a, num? b) {
+  if (a == null && b == null) return 0;
+  if (a == null) return 1;
+  if (b == null) return -1;
+  return b.compareTo(a);
 }

--- a/lib/data/res/github_id.dart
+++ b/lib/data/res/github_id.dart
@@ -175,6 +175,8 @@ abstract final class GithubIds {
     'kuilei0926',
     'ci-sourcerer',
     'misaki258',
+    'Muska-Ami',
+    'wu4339'
   };
 }
 

--- a/lib/view/page/process.dart
+++ b/lib/view/page/process.dart
@@ -179,7 +179,9 @@ class _ProcessPageState extends ConsumerState<ProcessPage> {
       ),
     );
   }
+}
 
+extension _ProcessPageStateWidgets on _ProcessPageState {
   Widget _buildItemTrail(Proc proc) {
     final items = <Widget>[
       if (proc.cpu != null)
@@ -229,6 +231,8 @@ class _ProcessPageState extends ConsumerState<ProcessPage> {
       ],
     );
   }
+}
 
+extension _ProcessPageStateUtils on _ProcessPageState {
   String _formatSpeed(double bytes) => '${bytes.bytes2Str}/s';
 }

--- a/lib/view/page/process.dart
+++ b/lib/view/page/process.dart
@@ -79,7 +79,7 @@ class _ProcessPageState extends ConsumerState<ProcessPage> {
         context.showSnackBar(libL10n.empty);
         return;
       }
-      _result = PsResult.parse(result, sort: _procSortMode);
+      _result = PsResult.parse(result, sort: _procSortMode, previous: _result);
 
       if (!_checkedIncompleteData) {
         final isAnyProcDataNotComplete = _result.procs.any(
@@ -89,6 +89,17 @@ class _ProcessPageState extends ConsumerState<ProcessPage> {
           _sortModes.removeWhere(
             (e) => e == ProcSortMode.cpu || e == ProcSortMode.mem,
           );
+        }
+        final hasAnyProcIoData = _result.procs.any(
+          (e) => e.readBytes != null || e.writeBytes != null,
+        );
+        if (!hasAnyProcIoData) {
+          _sortModes.removeWhere(
+            (e) => e == ProcSortMode.read || e == ProcSortMode.write,
+          );
+        }
+        if (!_sortModes.contains(_procSortMode)) {
+          _procSortMode = _sortModes.first;
         }
         _checkedIncompleteData = true;
       }
@@ -170,15 +181,24 @@ class _ProcessPageState extends ConsumerState<ProcessPage> {
   }
 
   Widget _buildItemTrail(Proc proc) {
+    final items = <Widget>[
+      if (proc.cpu != null)
+        TwoLineText(up: proc.cpu!.toStringAsFixed(1), down: 'cpu'),
+      if (proc.mem != null)
+        TwoLineText(up: proc.mem!.toStringAsFixed(1), down: 'mem'),
+      if (proc.readSpeed != null)
+        TwoLineText(up: _formatSpeed(proc.readSpeed!), down: 'R'),
+      if (proc.writeSpeed != null)
+        TwoLineText(up: _formatSpeed(proc.writeSpeed!), down: 'W'),
+    ];
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        if (proc.cpu != null)
-          TwoLineText(up: proc.cpu!.toStringAsFixed(1), down: 'cpu'),
-        if (proc.cpu != null && proc.mem != null) UIs.width13,
-        if (proc.mem != null)
-          TwoLineText(up: proc.mem!.toStringAsFixed(1), down: 'mem'),
-        if (proc.cpu != null || proc.mem != null) UIs.width13,
+        for (final (idx, item) in items.indexed) ...[
+          if (idx > 0) UIs.width13,
+          item,
+        ],
+        if (items.isNotEmpty) UIs.width13,
         IconButton(
           icon: const Icon(Icons.stop),
           onPressed: () {
@@ -209,4 +229,6 @@ class _ProcessPageState extends ConsumerState<ProcessPage> {
       ],
     );
   }
+
+  String _formatSpeed(double bytes) => '${bytes.bytes2Str}/s';
 }

--- a/test/proc_test.dart
+++ b/test/proc_test.dart
@@ -1,5 +1,5 @@
-import 'package:flutter_test/flutter_test.dart';
 import 'package:server_box/data/model/server/proc.dart';
+import 'package:test/test.dart';
 
 void main() {
   test('parse process', () {
@@ -9,5 +9,124 @@ void main() {
 ''';
     final psResult = PsResult.parse(raw);
     expect(psResult.procs.length, 1);
+    expect(psResult.procs.single.pid, 1);
+    expect(psResult.procs.single.command, '/sbin/procd');
+  });
+
+  test('parse linux process io counters', () {
+    const raw = '''
+PID USER %CPU %MEM VSZ RSS TTY STAT START TIME READ_BYTES WRITE_BYTES COMMAND
+1 root 0.1 1.2 1276 512 ? S 10:00 00:01 1024 2048 /sbin/procd
+2 app 3.4 5.6 4096 2048 ? R 10:01 00:02 - - /usr/bin/app --flag
+''';
+    final psResult = PsResult.parse(raw, sampledAtMillis: 1000);
+    expect(psResult.procs.length, 2);
+    expect(psResult.procs[0].pid, 2);
+    expect(psResult.procs[1].readBytes, 1024);
+    expect(psResult.procs[1].writeBytes, 2048);
+    expect(psResult.procs[1].readSpeed, isNull);
+    expect(psResult.procs[1].writeSpeed, isNull);
+    expect(psResult.procs[1].command, '/sbin/procd');
+  });
+
+  test('calculate process io speed from previous snapshot', () {
+    const first = '''
+PID USER %CPU %MEM VSZ RSS TTY STAT START TIME READ_BYTES WRITE_BYTES COMMAND
+1 root 0.1 1.2 1276 512 ? S 10:00 00:01 1000 2000 /sbin/procd
+2 app 3.4 5.6 4096 2048 ? R 10:01 00:02 500 700 /usr/bin/app
+''';
+    const second = '''
+PID USER %CPU %MEM VSZ RSS TTY STAT START TIME READ_BYTES WRITE_BYTES COMMAND
+1 root 0.1 1.2 1276 512 ? S 10:00 00:01 3000 5000 /sbin/procd
+2 app 3.4 5.6 4096 2048 ? R 10:01 00:02 1000 1200 /usr/bin/app
+''';
+    final previous = PsResult.parse(first, sampledAtMillis: 1000);
+    final current = PsResult.parse(
+      second,
+      previous: previous,
+      sampledAtMillis: 3000,
+    );
+    final proc = current.procs.firstWhere((e) => e.pid == 1);
+    expect(proc.readSpeed, 1000);
+    expect(proc.writeSpeed, 1500);
+  });
+
+  test('io speed is null for missing previous and counter rollback', () {
+    const first = '''
+PID USER %CPU %MEM VSZ RSS TTY STAT START TIME READ_BYTES WRITE_BYTES COMMAND
+1 root 0.1 1.2 1276 512 ? S 10:00 00:01 3000 5000 /sbin/procd
+''';
+    const second = '''
+PID USER %CPU %MEM VSZ RSS TTY STAT START TIME READ_BYTES WRITE_BYTES COMMAND
+1 root 0.1 1.2 1276 512 ? S 10:00 00:01 1000 4000 /sbin/procd
+2 app 3.4 5.6 4096 2048 ? R 10:01 00:02 1000 1200 /usr/bin/app
+''';
+    final previous = PsResult.parse(first, sampledAtMillis: 1000);
+    final current = PsResult.parse(
+      second,
+      previous: previous,
+      sampledAtMillis: 3000,
+    );
+    final rolledBack = current.procs.firstWhere((e) => e.pid == 1);
+    final newProc = current.procs.firstWhere((e) => e.pid == 2);
+    expect(rolledBack.readSpeed, isNull);
+    expect(rolledBack.writeSpeed, isNull);
+    expect(newProc.readSpeed, isNull);
+    expect(newProc.writeSpeed, isNull);
+  });
+
+  test('sort process by io speed with null last', () {
+    const first = '''
+PID USER %CPU %MEM VSZ RSS TTY STAT START TIME READ_BYTES WRITE_BYTES COMMAND
+1 root 0.1 1.2 1276 512 ? S 10:00 00:01 1000 1000 /sbin/procd
+2 app 3.4 5.6 4096 2048 ? R 10:01 00:02 1000 1000 /usr/bin/app
+3 nobody 0.0 0.1 1024 256 ? S 10:02 00:00 - - idle
+''';
+    const second = '''
+PID USER %CPU %MEM VSZ RSS TTY STAT START TIME READ_BYTES WRITE_BYTES COMMAND
+1 root 0.1 1.2 1276 512 ? S 10:00 00:01 2000 6000 /sbin/procd
+2 app 3.4 5.6 4096 2048 ? R 10:01 00:02 5000 2000 /usr/bin/app
+3 nobody 0.0 0.1 1024 256 ? S 10:02 00:00 - - idle
+''';
+    final previous = PsResult.parse(first, sampledAtMillis: 1000);
+    final byRead = PsResult.parse(
+      second,
+      previous: previous,
+      sampledAtMillis: 2000,
+      sort: ProcSortMode.read,
+    );
+    final byWrite = PsResult.parse(
+      second,
+      previous: previous,
+      sampledAtMillis: 2000,
+      sort: ProcSortMode.write,
+    );
+    expect(byRead.procs.map((e) => e.pid), [2, 1, 3]);
+    expect(byWrite.procs.map((e) => e.pid), [1, 2, 3]);
+  });
+
+  test('parse windows process json io counters', () {
+    const first = '''
+[
+  {"ProcessName":"a","Id":1,"CPU":1.5,"WorkingSet":1024,"IOReadBytes":100,"IOWriteBytes":200},
+  {"ProcessName":"b","Id":2,"CPU":0.5,"WorkingSet":512,"IOReadBytes":1000,"IOWriteBytes":1200}
+]
+''';
+    const second = '''
+[
+  {"ProcessName":"a","Id":1,"CPU":1.5,"WorkingSet":1024,"IOReadBytes":1100,"IOWriteBytes":2200},
+  {"ProcessName":"b","Id":2,"CPU":0.5,"WorkingSet":512,"IOReadBytes":1200,"IOWriteBytes":1600}
+]
+''';
+    final previous = PsResult.parse(first, sampledAtMillis: 1000);
+    final current = PsResult.parse(
+      second,
+      previous: previous,
+      sampledAtMillis: 2000,
+      sort: ProcSortMode.write,
+    );
+    expect(current.procs.first.pid, 1);
+    expect(current.procs.first.readSpeed, 1000);
+    expect(current.procs.first.writeSpeed, 2000);
   });
 }


### PR DESCRIPTION
#1175 #1178

## Summary
- Add per-process disk I/O tracking to the process management view, including read and write speed calculation across refresh snapshots.
- Extend process collection and parsing for Linux and Windows so IO counters are surfaced alongside existing CPU and memory data.
- Update the process list UI to display IO throughput when available and support sorting by read or write speed.
- Add unit coverage for parsing, delta calculation, sorting, and Windows JSON-shaped process output.

## Testing
- `dart analyze` passed for the touched Dart model, UI, and script builder files.
- `dart test test/proc_test.dart` passed with coverage for legacy process parsing plus the new IO speed scenarios.
- Manual validation confirmed the new IO columns remain hidden when data is unavailable and do not disturb existing process actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Process monitoring now displays disk I/O metrics including read and write transfer speeds for each process.
  * I/O data collection enabled across Windows and Unix-like systems.
  * Added sort options to organize processes by read and write transfer speeds.

* **Tests**
  * Expanded test coverage for process I/O metric parsing and speed calculations across different platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lollipopkit/flutter_server_box/pull/1179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->