### PR TITLE
fix: improve sudo password detection in virtual keyboard

### DIFF
--- a/lib/view/page/ssh/page/page.dart
+++ b/lib/view/page/ssh/page/page.dart
@@ -660,7 +660,19 @@ class SSHPageState extends ConsumerState<SSHPage>
       return;
     }
 
-    if (!_hasPendingSudoPrompt()) {
+    // Retry detection up to 3 times with 200ms intervals
+    bool detected = false;
+    for (int i = 0; i < 3; i++) {
+      if (_hasPendingSudoPrompt()) {
+        detected = true;
+        break;
+      }
+      if (i < 2) {
+        await Future.delayed(const Duration(milliseconds: 200));
+      }
+    }
+
+    if (!detected) {
       if (!mounted) return;
       context.showSnackBar(libL10n.fail);
       return;
@@ -674,14 +686,17 @@ class SSHPageState extends ConsumerState<SSHPage>
   }
 
   bool _hasPendingSudoPrompt() {
-    final lines = _terminal.buffer.lines.toList().reversed.take(8);
+    final lines = _terminal.buffer.lines.toList().reversed.take(15);
     for (final line in lines) {
       final raw = line.toString().trim();
       if (raw.isEmpty) continue;
       final lower = raw.toLowerCase();
       if (Miscs.pwdRequestWithUserReg.hasMatch(raw)) return true;
       if (lower.contains('[sudo] password')) return true;
-      if (lower.contains('password') && lower.endsWith(':')) return true;
+      if (lower.endsWith(':') &&
+          (lower.contains('password') || lower.contains('密码'))) {
+        return true;
+      }
     }
     return false;
   }


### PR DESCRIPTION
- Add retry mechanism (3 attempts with 200ms intervals) to handle terminal buffer update timing
- Increase line scan range from 8 to 15 lines for better detection
- Add Chinese password prompt support (密码)
- Improve password prompt matching logic

#1180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced sudo password prompt detection with automatic retry mechanism during SSH sessions to improve reliability.
  * Improved password prompt recognition to accurately identify varied prompt formats and support multilingual interfaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lollipopkit/flutter_server_box/pull/1181?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->