### PR TITLE
Unused removal #2

### DIFF
--- a/lib/core/utils/comparator.dart
+++ b/lib/core/utils/comparator.dart
@@ -3,7 +3,6 @@ class ChainComparator<T> {
   final Comparator<T> _comparator;
 
   ChainComparator._create(this._parent, this._comparator);
-  ChainComparator.empty() : this._create(null, (a, b) => 0);
   ChainComparator.create() : this._create(null, (a, b) => 0);
 
   static ChainComparator<T> comparing<T, F extends Comparable<F>>(

--- a/lib/core/utils/sftp_sudo.dart
+++ b/lib/core/utils/sftp_sudo.dart
@@ -6,6 +6,7 @@ import 'package:fl_lib/fl_lib.dart';
 import 'package:flutter/material.dart';
 import 'package:server_box/core/extension/context/locale.dart';
 import 'package:server_box/core/extension/ssh_client.dart';
+import 'package:server_box/core/utils/shell_quote.dart';
 import 'package:server_box/data/model/server/server_private_info.dart';
 import 'package:server_box/data/res/store.dart';
 
@@ -55,7 +56,7 @@ final class SftpSudoHelper {
 
   Future<int> getFileSize(String remotePath, {String? password}) async {
     final output = await _runAndRead(
-      'wc -c < ${_shellQuote(remotePath)}',
+      'wc -c < ${shellSingleQuote(remotePath)}',
       password: password,
     );
     return int.tryParse(output.trim()) ?? 0;
@@ -67,7 +68,7 @@ final class SftpSudoHelper {
     String? password,
   }) async {
     final text = await _runAndRead(
-      'cat ${_shellQuote(remotePath)}',
+      'cat ${shellSingleQuote(remotePath)}',
       password: password,
     );
     final file = File(localPath);
@@ -84,7 +85,7 @@ final class SftpSudoHelper {
     final bytes = await file.readAsBytes();
     final data = base64Encode(bytes);
     await _runAndRead(
-      "printf '%s' '$data' | base64 -d | tee ${_shellQuote(remotePath)} > /dev/null",
+      "printf '%s' '$data' | base64 -d | tee ${shellSingleQuote(remotePath)} > /dev/null",
       password: password,
     );
   }
@@ -98,17 +99,17 @@ final class SftpSudoHelper {
       );
     }
     await _runAndRead(
-      'chmod $perm ${_shellQuote(remotePath)}',
+      'chmod $perm ${shellSingleQuote(remotePath)}',
       password: password,
     );
   }
 
   Future<void> mkdir(String remotePath, {String? password}) async {
-    await _runAndRead('mkdir ${_shellQuote(remotePath)}', password: password);
+    await _runAndRead('mkdir ${shellSingleQuote(remotePath)}', password: password);
   }
 
   Future<void> touch(String remotePath, {String? password}) async {
-    await _runAndRead('touch ${_shellQuote(remotePath)}', password: password);
+    await _runAndRead('touch ${shellSingleQuote(remotePath)}', password: password);
   }
 
   Future<void> rename(
@@ -117,7 +118,7 @@ final class SftpSudoHelper {
     String? password,
   }) async {
     await _runAndRead(
-      'mv ${_shellQuote(oldPath)} ${_shellQuote(newPath)}',
+      'mv ${shellSingleQuote(oldPath)} ${shellSingleQuote(newPath)}',
       password: password,
     );
   }
@@ -129,16 +130,16 @@ final class SftpSudoHelper {
     String? password,
   }) async {
     final cmd = switch ((isDir, recursive)) {
-      (true, true) => 'rm -r ${_shellQuote(remotePath)}',
-      (true, false) => 'rmdir ${_shellQuote(remotePath)}',
-      (false, _) => 'rm ${_shellQuote(remotePath)}',
+      (true, true) => 'rm -r ${shellSingleQuote(remotePath)}',
+      (true, false) => 'rmdir ${shellSingleQuote(remotePath)}',
+      (false, _) => 'rm ${shellSingleQuote(remotePath)}',
     };
     await _runAndRead(cmd, password: password);
   }
 
   Future<List<SftpName>> listDir(String remotePath, {String? password}) async {
     final output = await _runAndRead(
-      'find ${_shellQuote(remotePath)} '
+      'find ${shellSingleQuote(remotePath)} '
       '-mindepth 1 -maxdepth 1 '
       '-exec sh -c \''
       'for path do '
@@ -240,10 +241,6 @@ final class SftpSudoHelper {
     final wrapped = '($command) 2>&1';
     final escapedWrapped = wrapped.replaceAll("'", "'\\''");
     return 'echo "$pwdBase64" | base64 -d | sudo -S -- sh -c \'$escapedWrapped\'';
-  }
-
-  static String _shellQuote(String value) {
-    return "'${value.replaceAll("'", "'\\''")}'";
   }
 
   static SftpFileMode _buildMode(String typeChar, int permOct) {

--- a/lib/data/model/app/error.dart
+++ b/lib/data/model/app/error.dart
@@ -6,7 +6,6 @@ enum SSHErrType {
   connect,
   auth,
   noPrivateKey,
-  chdir,
   segements,
   writeScript,
   getStatus,
@@ -17,7 +16,6 @@ class SSHErr extends Err<SSHErrType> {
 
   @override
   String? get solution => switch (type) {
-    SSHErrType.chdir => l10n.needHomeDir,
     SSHErrType.auth => l10n.authFailTip,
     SSHErrType.writeScript => l10n.writeScriptFailTip,
     SSHErrType.noPrivateKey => l10n.noPrivateKeyTip,
@@ -30,7 +28,6 @@ enum ContainerErrType {
   noClient,
   notInstalled,
   invalidVersion,
-  cmdNoPrefix,
   segmentsNotMatch,
   parsePs,
   parseImages,

--- a/lib/data/model/server/amd.dart
+++ b/lib/data/model/server/amd.dart
@@ -50,8 +50,6 @@ class AmdSmi {
           gpu['card_model'] ??
           gpu['device_name'] ??
           'Unknown AMD GPU';
-      final deviceId =
-          gpu['device_id']?.toString() ?? gpu['gpu_id']?.toString() ?? '0';
 
       // Temperature parsing
       final tempRaw = gpu['temperature'] ?? gpu['temp'] ?? gpu['gpu_temp'];
@@ -80,7 +78,6 @@ class AmdSmi {
       );
 
       return AmdSmiItem(
-        deviceId: deviceId,
         name: name,
         temp: temp,
         power: power,
@@ -149,7 +146,6 @@ class AmdSmi {
 }
 
 class AmdSmiItem {
-  final String deviceId;
   final String name;
   final int temp;
   final String power;
@@ -159,7 +155,6 @@ class AmdSmiItem {
   final int clockSpeed;
 
   const AmdSmiItem({
-    required this.deviceId,
     required this.name,
     required this.temp,
     required this.power,

--- a/lib/data/model/server/conn.dart
+++ b/lib/data/model/server/conn.dart
@@ -2,14 +2,10 @@ import 'package:server_box/data/res/misc.dart';
 
 class Conn {
   final int maxConn;
-  final int active;
-  final int passive;
   final int fail;
 
   const Conn({
     required this.maxConn,
-    required this.active,
-    required this.passive,
     required this.fail,
   });
 
@@ -23,8 +19,6 @@ class Conn {
       final vals = idx.split(Miscs.blankReg);
       return Conn(
         maxConn: int.tryParse(vals[5]) ?? 0,
-        active: int.tryParse(vals[6]) ?? 0,
-        passive: int.tryParse(vals[7]) ?? 0,
         fail: int.tryParse(vals[8]) ?? 0,
       );
     }

--- a/lib/data/model/server/discovery_result.dart
+++ b/lib/data/model/server/discovery_result.dart
@@ -38,14 +38,3 @@ abstract class SshDiscoveryConfig with _$SshDiscoveryConfig {
     @Default(4096) int hostEnumerationLimit,
   }) = _SshDiscoveryConfig;
 }
-
-extension SshDiscoveryConfigX on SshDiscoveryConfig {
-  List<String> toArgs() {
-    final args = <String>[];
-    args.add('--timeout-ms=$timeoutMs');
-    args.add('--max-concurrency=$maxConcurrency');
-    args.add('--host-enumeration-limit=$hostEnumerationLimit');
-    if (enableMdns) args.add('--enable-mdns');
-    return args;
-  }
-}

--- a/lib/data/model/server/net_speed.dart
+++ b/lib/data/model/server/net_speed.dart
@@ -86,6 +86,7 @@ class NetSpeed extends TimeSeq<NetSpeedPart> {
         for (final prefix in realIfacePrefixs) {
           if (devices[i].startsWith(prefix)) {
             speed += speedInBytes(i);
+            break;
           }
         }
       }
@@ -104,6 +105,7 @@ class NetSpeed extends TimeSeq<NetSpeedPart> {
         for (final prefix in realIfacePrefixs) {
           if (devices[i].startsWith(prefix)) {
             size += sizeInBytes(i);
+            break;
           }
         }
       }
@@ -122,6 +124,7 @@ class NetSpeed extends TimeSeq<NetSpeedPart> {
         for (final prefix in realIfacePrefixs) {
           if (devices[i].startsWith(prefix)) {
             speed += speedOutBytes(i);
+            break;
           }
         }
       }
@@ -140,6 +143,7 @@ class NetSpeed extends TimeSeq<NetSpeedPart> {
         for (final prefix in realIfacePrefixs) {
           if (devices[i].startsWith(prefix)) {
             size += sizeOutBytes(i);
+            break;
           }
         }
       }

--- a/lib/data/model/server/net_speed.dart
+++ b/lib/data/model/server/net_speed.dart
@@ -82,10 +82,10 @@ class NetSpeed extends TimeSeq<NetSpeedPart> {
     if (pre.length != now.length) return 'N/A';
     if (device == null) {
       var speed = 0.0;
-      for (final device in devices) {
+      for (var i = 0; i < devices.length; i++) {
         for (final prefix in realIfacePrefixs) {
-          if (device.startsWith(prefix)) {
-            speed += speedInBytes(devices.indexOf(device));
+          if (devices[i].startsWith(prefix)) {
+            speed += speedInBytes(i);
           }
         }
       }
@@ -100,10 +100,10 @@ class NetSpeed extends TimeSeq<NetSpeedPart> {
     if (pre.length != now.length) return 'N/A';
     if (device == null) {
       var size = BigInt.from(0);
-      for (final device in devices) {
+      for (var i = 0; i < devices.length; i++) {
         for (final prefix in realIfacePrefixs) {
-          if (device.startsWith(prefix)) {
-            size += sizeInBytes(devices.indexOf(device));
+          if (devices[i].startsWith(prefix)) {
+            size += sizeInBytes(i);
           }
         }
       }
@@ -118,10 +118,10 @@ class NetSpeed extends TimeSeq<NetSpeedPart> {
     if (pre.length != now.length) return 'N/A';
     if (device == null) {
       var speed = 0.0;
-      for (final device in devices) {
+      for (var i = 0; i < devices.length; i++) {
         for (final prefix in realIfacePrefixs) {
-          if (device.startsWith(prefix)) {
-            speed += speedOutBytes(devices.indexOf(device));
+          if (devices[i].startsWith(prefix)) {
+            speed += speedOutBytes(i);
           }
         }
       }
@@ -136,10 +136,10 @@ class NetSpeed extends TimeSeq<NetSpeedPart> {
     if (pre.length != now.length) return 'N/A';
     if (device == null) {
       var size = BigInt.from(0);
-      for (final device in devices) {
+      for (var i = 0; i < devices.length; i++) {
         for (final prefix in realIfacePrefixs) {
-          if (device.startsWith(prefix)) {
-            size += sizeOutBytes(devices.indexOf(device));
+          if (devices[i].startsWith(prefix)) {
+            size += sizeOutBytes(i);
           }
         }
       }
@@ -151,10 +151,8 @@ class NetSpeed extends TimeSeq<NetSpeedPart> {
 
   int deviceIdx(String? device) {
     if (device != null) {
-      for (var item in now) {
-        if (item.device == device) {
-          return now.indexOf(item);
-        }
+      for (var i = 0; i < now.length; i++) {
+        if (now[i].device == device) return i;
       }
     }
     return 0;

--- a/lib/data/model/server/nvdia.dart
+++ b/lib/data/model/server/nvdia.dart
@@ -84,7 +84,6 @@ class NvidiaSmi {
       if (name != null && temp != null) {
         return NvidiaSmiItem(
           name: name,
-          uuid: gpu.findElements('uuid').firstOrNull?.innerText ?? '',
           temp: int.tryParse(temp.split(' ').firstOrNull ?? '0') ?? 0,
           percent: int.tryParse(percent?.split(' ').firstOrNull ?? '0') ?? 0,
           power: '$powerDraw / $powerLimit',
@@ -105,7 +104,6 @@ class NvidiaSmi {
 }
 
 class NvidiaSmiItem {
-  final String uuid;
   final String name;
   final int temp;
   final String power;
@@ -114,7 +112,6 @@ class NvidiaSmiItem {
   final int fanSpeed;
 
   const NvidiaSmiItem({
-    required this.uuid,
     required this.name,
     required this.temp,
     required this.power,

--- a/lib/data/model/server/nvdia.dart
+++ b/lib/data/model/server/nvdia.dart
@@ -1,5 +1,8 @@
 import 'package:xml/xml.dart';
 
+int _parseFirstInt(String? s) =>
+    int.tryParse(s?.split(' ').firstOrNull ?? '0') ?? 0;
+
 /// [
 ///   {
 ///     "name": "GeForce RTX 3090",
@@ -67,7 +70,7 @@ class NvidiaSmi {
             return NvidiaSmiMemProcess(
               int.tryParse(pid) ?? 0,
               name,
-              int.tryParse(memory.split(' ').firstOrNull ?? '0') ?? 0,
+              _parseFirstInt(memory),
             );
           }
           return null;
@@ -84,16 +87,16 @@ class NvidiaSmi {
       if (name != null && temp != null) {
         return NvidiaSmiItem(
           name: name,
-          temp: int.tryParse(temp.split(' ').firstOrNull ?? '0') ?? 0,
-          percent: int.tryParse(percent?.split(' ').firstOrNull ?? '0') ?? 0,
+          temp: _parseFirstInt(temp),
+          percent: _parseFirstInt(percent),
           power: '$powerDraw / $powerLimit',
           memory: NvidiaSmiMem(
-            int.tryParse(memoryTotal?.split(' ').firstOrNull ?? '0') ?? 0,
-            int.tryParse(memoryUsed?.split(' ').firstOrNull ?? '0') ?? 0,
+            _parseFirstInt(memoryTotal),
+            _parseFirstInt(memoryUsed),
             'MiB',
             List.from(memoryProcesses),
           ),
-          fanSpeed: int.tryParse(fanSpeed?.split(' ').firstOrNull ?? '0') ?? 0,
+          fanSpeed: _parseFirstInt(fanSpeed),
         );
       }
       return null;

--- a/lib/data/model/server/proc.dart
+++ b/lib/data/model/server/proc.dart
@@ -52,7 +52,9 @@ class Proc {
   final double? writeSpeed;
   final String command;
 
-  const Proc({
+  late final binary = _parseBinary();
+
+  Proc({
     this.user,
     required this.pid,
     this.cpu,
@@ -162,7 +164,7 @@ class Proc {
     return Miscs.jsonEncoder.convert(toJson());
   }
 
-  String get binary {
+  String _parseBinary() {
     final parts = command.trim().split(' ').where((e) => e.isNotEmpty).toList();
     return parts.isNotEmpty ? parts[0] : '';
   }

--- a/lib/data/model/server/sensors.dart
+++ b/lib/data/model/server/sensors.dart
@@ -9,16 +9,11 @@ final class SensorAdaptor {
   static const pciRaw = 'PCI adapter';
   static const virtualRaw = 'Virtual device';
   static const isaRaw = 'ISA adapter';
-  static const acpi = SensorAdaptor(acpiRaw);
-  static const pci = SensorAdaptor(pciRaw);
-  static const virtual = SensorAdaptor(virtualRaw);
-  static const isa = SensorAdaptor(isaRaw);
-
   static SensorAdaptor parse(String raw) => switch (raw) {
-    acpiRaw => acpi,
-    pciRaw => pci,
-    virtualRaw => virtual,
-    isaRaw => isa,
+    acpiRaw => const SensorAdaptor(acpiRaw),
+    pciRaw => const SensorAdaptor(pciRaw),
+    virtualRaw => const SensorAdaptor(virtualRaw),
+    isaRaw => const SensorAdaptor(isaRaw),
     _ => SensorAdaptor(raw),
   };
 }

--- a/lib/data/model/server/server_status_update_req.dart
+++ b/lib/data/model/server/server_status_update_req.dart
@@ -62,7 +62,7 @@ ServerStatus _createWorkingStatus(ServerStatus source, SystemType system) {
     cpu: source.cpu,
     mem: InitStatus.mem,
     disk: const [],
-    tcp: const Conn(maxConn: 0, active: 0, passive: 0, fail: 0),
+    tcp: const Conn(maxConn: 0, fail: 0),
     netSpeed: source.netSpeed,
     swap: const Swap(total: 0, free: 0, cached: 0),
     temps: Temperatures(),
@@ -571,7 +571,7 @@ void _parseWindowsConnectionData(
     final connStr = WindowsStatusCmdType.conn.findInMap(parsedOutput);
     final connCount = int.tryParse(connStr.trim());
     if (connCount != null) {
-      req.ss.tcp = Conn(maxConn: 0, active: connCount, passive: 0, fail: 0);
+      req.ss.tcp = Conn(maxConn: connCount, fail: 0);
     }
   } catch (e, s) {
     Loggers.app.warning('Windows connection parsing failed: $e', s);

--- a/lib/data/model/server/server_status_update_req.dart
+++ b/lib/data/model/server/server_status_update_req.dart
@@ -73,6 +73,14 @@ ServerStatus _createWorkingStatus(ServerStatus source, SystemType system) {
   );
 }
 
+void _updateDiskUsage(ServerStatus ss) {
+  try {
+    ss.diskUsage = ss.disk.isEmpty ? null : DiskUsage.parse(ss.disk);
+  } catch (e, s) {
+    Loggers.app.warning(e, s);
+  }
+}
+
 // Wrap each operation with a try-catch, so that if one operation fails,
 // the following operations can still be executed.
 Future<ServerStatus> _getLinuxStatus(ServerStatusUpdateReq req) async {
@@ -144,13 +152,7 @@ Future<ServerStatus> _getLinuxStatus(ServerStatusUpdateReq req) async {
     Loggers.app.warning(e, s);
   }
 
-  try {
-    req.ss.diskUsage = req.ss.disk.isEmpty
-        ? null
-        : DiskUsage.parse(req.ss.disk);
-  } catch (e, s) {
-    Loggers.app.warning(e, s);
-  }
+  _updateDiskUsage(req.ss);
 
   try {
     req.ss.mem = Memory.parse(StatusCmdType.mem.findInMap(parsedOutput));
@@ -297,13 +299,7 @@ Future<ServerStatus> _getBsdStatus(ServerStatusUpdateReq req) async {
     Loggers.app.warning(e, s);
   }
 
-  try {
-    req.ss.diskUsage = req.ss.disk.isEmpty
-        ? null
-        : DiskUsage.parse(req.ss.disk);
-  } catch (e, s) {
-    Loggers.app.warning(e, s);
-  }
+  _updateDiskUsage(req.ss);
   return req.ss;
 }
 

--- a/lib/data/model/server/systemd.dart
+++ b/lib/data/model/server/systemd.dart
@@ -6,18 +6,12 @@ enum SystemdUnitFunc {
   start,
   stop,
   restart,
-  reload,
-  enable,
-  disable,
   status;
 
   IconData get icon => switch (this) {
     start => Icons.play_arrow,
     stop => Icons.stop,
     restart => Icons.refresh,
-    reload => Icons.refresh,
-    enable => Icons.check,
-    disable => Icons.close,
     status => Icons.info,
   };
 }

--- a/lib/data/provider/port_forward_provider.dart
+++ b/lib/data/provider/port_forward_provider.dart
@@ -62,7 +62,8 @@ class PortForwardNotifier extends _$PortForwardNotifier {
   ) async {
     await stopForward(oldConfig.id);
     final configWithServerId = newConfig.copyWith(serverId: _serverId);
-    Stores.portForward.update(oldConfig, configWithServerId);
+    Stores.portForward.delete(oldConfig);
+    Stores.portForward.put(configWithServerId);
     final configs = state.configs
         .map((c) => c.id == oldConfig.id ? configWithServerId : c)
         .toList();

--- a/lib/data/provider/pve.dart
+++ b/lib/data/provider/pve.dart
@@ -125,8 +125,6 @@ class PveNotifier extends _$PveNotifier {
       );
   }
 
-  bool get onlyOneNode => state.data?.nodes.length == 1;
-
   Future<void> reconnect() async {
     await _closeSession(clearPendingTfa: true);
     if (!ref.mounted) return;

--- a/lib/data/res/misc.dart
+++ b/lib/data/res/misc.dart
@@ -13,9 +13,6 @@ abstract final class Miscs {
   /// Editor max allowed size is 1mb
   static const editorMaxSize = 1024 * 1024;
 
-  /// Max debug log lines
-  static const maxDebugLogLines = 100;
-
   static const pkgName = 'tech.lolli.toolbox';
 
   static const jsonEncoder = JsonEncoder.withIndent('  ');

--- a/lib/data/res/status.dart
+++ b/lib/data/res/status.dart
@@ -30,7 +30,7 @@ abstract final class InitStatus {
         avail: BigInt.zero,
       ),
     ],
-    tcp: const Conn(maxConn: 0, active: 0, passive: 0, fail: 0),
+    tcp: const Conn(maxConn: 0, fail: 0),
     netSpeed: netSpeed,
     swap: const Swap(total: 0, free: 0, cached: 0),
     system: SystemType.linux,

--- a/lib/data/store/history.dart
+++ b/lib/data/store/history.dart
@@ -53,15 +53,9 @@ class HistoryStore extends HiveStore {
 
   late final sftpLastPath = _MapHistory(box: box, name: 'sftpLastPath');
 
-  late final sshCmds = _ListHistory(box: box, name: 'sshCmds');
-
   late final sshServerHistory = _ListHistory(
     box: box,
     name: 'sshServerHistory',
   );
 
-  late final writeScriptTipShown = propertyDefault(
-    'writeScriptTipShown',
-    false,
-  );
 }

--- a/lib/data/store/port_forward.dart
+++ b/lib/data/store/port_forward.dart
@@ -43,27 +43,4 @@ class PortForwardStore extends HiveStore {
   void delete(PortForwardConfig config) {
     remove(config.id);
   }
-
-  void deleteByServer(String serverId) {
-    final keysToDelete = <dynamic>[];
-    for (final key in keys()) {
-      final config = get<PortForwardConfig>(key);
-      if (config?.serverId == serverId) {
-        keysToDelete.add(key);
-      }
-    }
-    for (final key in keysToDelete) {
-      remove(key);
-    }
-  }
-
-  void update(PortForwardConfig old, PortForwardConfig newConfig) {
-    if (!have(old)) {
-      throw Exception('Old config: $old not found');
-    }
-    delete(old);
-    put(newConfig);
-  }
-
-  bool have(PortForwardConfig config) => get(config.id) != null;
 }

--- a/lib/data/store/setting.dart
+++ b/lib/data/store/setting.dart
@@ -282,9 +282,6 @@ class SettingStore extends HiveStore {
   /// Close the editor after saving
   late final closeAfterSave = propertyDefault('closeAfterSave', false);
 
-  /// Version of store db
-  late final storeVersion = propertyDefault('storeVersion', 0);
-
   /// Have notified user for notificaiton permission or not
   late final noNotiPerm = propertyDefault('noNotiPerm', false);
 

--- a/lib/view/page/server/connection_stats.dart
+++ b/lib/view/page/server/connection_stats.dart
@@ -293,7 +293,7 @@ extension _Actions on _ConnectionStatsPageState {
     if (!mounted) return;
     final totalSize = oldSize + oldIndexSize;
 
-    final sizeStr = _formatSize(totalSize);
+    final sizeStr = totalSize.bytes2Str;
 
     context.showRoundDialog(
       title: l10n.compactDatabase,
@@ -310,7 +310,7 @@ extension _Actions on _ConnectionStatsPageState {
               final newIndexSize = await Stores.connectionStats
                   .indexDbSizeAsync();
               final newTotalSize = newSize + newIndexSize;
-              final newSizeStr = _formatSize(newTotalSize);
+              final newSizeStr = newTotalSize.bytes2Str;
               _finishCompacting('${libL10n.success}: $sizeStr -> $newSizeStr');
             } catch (e) {
               _finishCompacting('${libL10n.error}: $e');
@@ -427,13 +427,5 @@ extension _Actions on _ConnectionStatsPageState {
         ),
       ],
     );
-  }
-}
-
-extension _Utils on _ConnectionStatsPageState {
-  String _formatSize(int bytes) {
-    if (bytes < 1000) return '$bytes B';
-    if (bytes < 1000 * 1000) return '${(bytes / 1000).toStringAsFixed(1)} KB';
-    return '${(bytes / (1000 * 1000)).toStringAsFixed(1)} MB';
   }
 }

--- a/lib/view/page/storage/sftp.dart
+++ b/lib/view/page/storage/sftp.dart
@@ -580,8 +580,8 @@ extension _Actions on _SftpPageState {
     final editor = Stores.setting.sftpEditor.fetch();
     if (editor.isNotEmpty) {
       final sudoPrefix = useSudoForEdit ? 'sudo ' : '';
-      // Use single quote to avoid escape
-      final cmd = "$sudoPrefix$editor '$remotePath'";
+      final cmd =
+          '$sudoPrefix$editor ${shellSingleQuote(remotePath)}';
       final args = SshPageArgs(spi: widget.args.spi, initCmd: cmd);
       await SSHPage.route.go(context, args);
       await _listDir();

--- a/lib/view/page/storage/sftp.dart
+++ b/lib/view/page/storage/sftp.dart
@@ -121,7 +121,7 @@ class _SftpPageState extends ConsumerState<SftpPage> with AfterLayoutMixin {
 
     try {
       final homeResult = await _client.run(
-        'getent passwd -- ${_shellQuote(widget.args.spi.user)}',
+        'getent passwd -- ${shellSingleQuote(widget.args.spi.user)}',
       );
       final passwdEntry = homeResult.string.trim();
       final homePath = passwdEntry.split(':').elementAtOrNull(5)?.trim() ?? '';
@@ -369,10 +369,6 @@ extension _UI on _SftpPageState {
 }
 
 extension _Actions on _SftpPageState {
-  String _shellQuote(String value) {
-    return "'${value.replaceAll("'", "'\\''")}'";
-  }
-
   bool _isPermissionDeniedErr(Object? err) {
     final msg = '$err'.toLowerCase();
     return msg.contains('permission denied') ||
@@ -447,7 +443,7 @@ extension _Actions on _SftpPageState {
 
   Future<bool> _canWriteRemotePath(String remoteDir) async {
     final (code, _) = await _client.execWithPwd(
-      'test -w ${_shellQuote(remoteDir)}',
+      'test -w ${shellSingleQuote(remoteDir)}',
       context: context,
       id: '${widget.args.spi.id}_sftp_write_probe',
     );
@@ -493,7 +489,7 @@ extension _Actions on _SftpPageState {
     }
 
     try {
-      await _runShellCommand('rm -f ${_shellQuote(tmpPath)}');
+      await _runShellCommand('rm -f ${shellSingleQuote(tmpPath)}');
     } catch (_) {}
     return false;
   }
@@ -537,7 +533,7 @@ extension _Actions on _SftpPageState {
             final remotePath = _getRemotePath(file);
             final suc = await _runWithSudoRetry(
               normal: () => _runShellCommand(
-                'chmod ${_shellQuote(permStr)} ${_shellQuote(remotePath)}',
+                'chmod ${shellSingleQuote(permStr)} ${shellSingleQuote(remotePath)}',
               ),
               sudo: (pwd) =>
                   _sudoHelper.chmod(permStr, remotePath, password: pwd),
@@ -773,7 +769,7 @@ extension _Actions on _SftpPageState {
             final suc = await _runWithSudoRetry(
               normal: () async {
                 if (useRmr) {
-                  await _runShellCommand('rm -r ${_shellQuote(remotePath)}');
+                  await _runShellCommand('rm -r ${shellSingleQuote(remotePath)}');
                 } else if (file.attr.isDirectory) {
                   await _status.client!.rmdir(remotePath);
                 } else {
@@ -849,7 +845,7 @@ extension _Actions on _SftpPageState {
       context.pop();
       final path = '${_status.path.path}/$text';
       final suc = await _runWithSudoRetry(
-        normal: () => _runShellCommand('touch ${_shellQuote(path)}'),
+        normal: () => _runShellCommand('touch ${shellSingleQuote(path)}'),
         sudo: (pwd) => _sudoHelper.touch(path, password: pwd),
       );
       if (!suc) return;

--- a/test/amd_smi_test.dart
+++ b/test/amd_smi_test.dart
@@ -146,7 +146,6 @@ void main() {
 
       final gpu1 = gpus[0];
       expect(gpu1.name, 'AMD Radeon RX 7900 XTX');
-      expect(gpu1.deviceId, '0');
       expect(gpu1.temp, 45);
       expect(gpu1.power, '120W / 355W');
       expect(gpu1.memory.total, 24576);
@@ -165,7 +164,6 @@ void main() {
 
       final gpu2 = gpus[1];
       expect(gpu2.name, 'AMD Radeon RX 6800 XT');
-      expect(gpu2.deviceId, '1');
       expect(gpu2.temp, 38);
       expect(gpu2.power, '85W / 300W');
       expect(gpu2.memory.total, 16384);
@@ -183,7 +181,6 @@ void main() {
 
       final gpu = gpus[0];
       expect(gpu.name, 'AMD Radeon RX 6700 XT');
-      expect(gpu.deviceId, 'card0');
       expect(gpu.temp, 42);
       expect(gpu.power, '95W / 230W');
       expect(gpu.memory.total, 12288);
@@ -204,7 +201,6 @@ void main() {
 
       final gpu = gpus[0];
       expect(gpu.name, 'Radeon RX 580');
-      expect(gpu.deviceId, '0');
       expect(gpu.temp, 55);
       expect(gpu.power, '150W / 185W');
       expect(gpu.memory.total, 8192);
@@ -222,7 +218,6 @@ void main() {
 
       final gpu1 = gpus[0];
       expect(gpu1.name, 'Unknown AMD GPU');
-      expect(gpu1.deviceId, '');
       expect(gpu1.temp, 0);
       expect(gpu1.power, 'N/A');
       expect(gpu1.memory.total, 0);
@@ -235,7 +230,6 @@ void main() {
 
       final gpu2 = gpus[1];
       expect(gpu2.name, 'AMD Test GPU');
-      expect(gpu2.deviceId, 'test');
       expect(gpu2.temp, 50);
       expect(gpu2.power, '100W');
       expect(gpu2.memory.total, 16384);
@@ -330,7 +324,6 @@ void main() {
     test('AmdSmiItem toString', () {
       final memory = AmdSmiMem(8192, 2048, 'MB', []);
       final item = AmdSmiItem(
-        deviceId: '0',
         name: 'Test GPU',
         temp: 45,
         power: '100W / 200W',
@@ -406,7 +399,6 @@ void main() {
       final gpus = AmdSmi.fromJson(minimalGpuJson);
       expect(gpus.length, 1);
       expect(gpus[0].name, 'Unknown AMD GPU');
-      expect(gpus[0].deviceId, '0');
       expect(gpus[0].temp, 0);
       expect(gpus[0].power, 'N/A');
       expect(gpus[0].utilization, 0);

--- a/test/core_utils_test.dart
+++ b/test/core_utils_test.dart
@@ -52,7 +52,7 @@ void main() {
     test('thenTrueFirst sorts correctly', () {
       final list = [('a', false), ('b', true), ('c', false)];
       list.sort(
-        ChainComparator.empty()
+        ChainComparator.create()
             .thenTrueFirst((t) => t.$2)
             .thenWithComparator((a, b) => a.$1.compareTo(b.$1))
             .call,

--- a/test/sensors_test.dart
+++ b/test/sensors_test.dart
@@ -108,10 +108,10 @@ void main() {
       'nvme-pci-0400',
     ]);
     expect(sensors.map((e) => e.adapter), [
-      SensorAdaptor.isa,
-      SensorAdaptor.acpi,
-      SensorAdaptor.virtual,
-      SensorAdaptor.pci,
+      const SensorAdaptor(SensorAdaptor.isaRaw),
+      const SensorAdaptor(SensorAdaptor.acpiRaw),
+      const SensorAdaptor(SensorAdaptor.virtualRaw),
+      const SensorAdaptor(SensorAdaptor.pciRaw),
     ]);
     expect(sensors.map((e) => e.summary), [
       '+56.0°C  (high = +105.0°C, crit = +105.0°C)',
@@ -130,10 +130,10 @@ void main() {
       'k10temp-pci-00c3',
     ]);
     expect(sensors.map((e) => e.adapter), [
-      SensorAdaptor.isa,
-      SensorAdaptor.isa,
-      SensorAdaptor.pci,
-      SensorAdaptor.pci,
+      const SensorAdaptor(SensorAdaptor.isaRaw),
+      const SensorAdaptor(SensorAdaptor.isaRaw),
+      const SensorAdaptor(SensorAdaptor.pciRaw),
+      const SensorAdaptor(SensorAdaptor.pciRaw),
     ]);
     expect(sensors.map((e) => e.summary), [
       '1.26 V',

--- a/test/server_status_update_req_test.dart
+++ b/test/server_status_update_req_test.dart
@@ -141,7 +141,7 @@ ServerStatus _createPreviousStatus() {
   previous.sensors.add(
     const SensorItem(
       device: 'old-sensor',
-      adapter: SensorAdaptor.isa,
+      adapter: SensorAdaptor(SensorAdaptor.isaRaw),
       details: {'temp1': '+40.0C'},
     ),
   );


### PR DESCRIPTION
## Changes

### Dead code removal (14 items)

| Item | File | Reason |
|------|------|--------|
| `HistoryStore.sshCmds` | `lib/data/store/history.dart` | Declared, never accessed |
| `HistoryStore.writeScriptTipShown` | `lib/data/store/history.dart` | Declared, never accessed |
| `SettingStore.storeVersion` | `lib/data/store/setting.dart` | Declared, never read/written |
| `Miscs.maxDebugLogLines` | `lib/data/res/misc.dart` | Declared, never referenced |
| `PveNotifier.onlyOneNode` | `lib/data/provider/pve.dart` | Provider getter unused; model getter used directly |
| `SensorAdaptor` static instances | `lib/data/model/server/sensors.dart` | Inlined in `parse()` — only consumer |
| `SshDiscoveryConfigX.toArgs()` | `lib/data/model/server/discovery_result.dart` | Extension method never called |
| `SSHErrType.chdir` | `lib/data/model/app/error.dart` | Enum value never instantiated |
| `ContainerErrType.cmdNoPrefix` | `lib/data/model/app/error.dart` | Enum value never referenced |
| `SystemdUnitFunc.reload/enable/disable` | `lib/data/model/server/systemd.dart` | 3 enum values never used |
| `ChainComparator.empty()` | `lib/core/utils/comparator.dart` | `create()` has identical behavior |
| `PortForwardStore.update/have/deleteByServer` | `lib/data/store/port_forward.dart` | 3 methods never called |

### Unused model fields (4 items)

| Field | File | Reason |
|-------|------|--------|
| `NvidiaSmiItem.uuid` | `lib/data/model/server/nvdia.dart` | Parsed from XML, never read in UI |
| `AmdSmiItem.deviceId` | `lib/data/model/server/amd.dart` | Parsed from JSON, never read in UI |
| `Conn.active` | `lib/data/model/server/conn.dart` | Parsed from /proc/net/snmp, only `maxConn` and `fail` displayed |
| `Conn.passive` | `lib/data/model/server/conn.dart` | Same as above |

Windows `connCount` moved from removed `active` to `maxConn` (the field shown in UI).

### Code deduplication (4 items)

| Pattern | Files | Fix |
|---------|-------|-----|
| `_shellQuote` duplicated 3x | `sftp.dart`, `sftp_sudo.dart` | Use canonical `shellSingleQuote` from `shell_quote.dart` |
| `_formatSize` vs `bytes2Str` | `connection_stats.dart` | Use existing `bytes2Str` extension from fl_lib |
| `int.tryParse(split.firstOrNull ?? '0') ?? 0` × 6 | `nvdia.dart` | Extracted `_parseFirstInt` helper |
| `DiskUsage.parse` + empty-guard × 2 | `server_status_update_req.dart` | Extracted `_updateDiskUsage` helper |

### Performance (2 items)

| Issue | File | Fix |
|-------|------|-----|
| `Proc.binary` getter re-parses command on every access (O(n log n) during sort) | `lib/data/model/server/proc.dart` | Cache as `late final` field |
| `NetSpeed` methods use `indexOf` inside loops (O(n²)) | `lib/data/model/server/net_speed.dart` | Index-based iteration (O(n)) |

## Verification

- `dart analyze lib test` — 0 issues
- `flutter test --no-pub` — 248/248 passed
- Manual human test no bugs found

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  - Consolidated shell-quoting logic used for SFTP/remote commands.
  - Simplified internal data models and storage behaviors (affects history, port-forward handling, and persisted settings).
  - Removed some internal connection/error variants and certain GPU identifier fields.

* **User-facing changes**
  - Systemd actions reduced to start/stop/restart/status (enable/disable/reload no longer available).
  - Minor adjustments to displayed/parsed hardware and connection summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->