### PR TITLE
Add manual tag trigger in workflow build file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,11 @@ name: Flutter Build
 
 on:
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g. v1.0.1426)'
+        required: true
+        type: string
   push:
     tags:
       - "v*"
@@ -11,7 +16,7 @@ permissions:
 
 env:
   APP_NAME: ServerBox
-  RELEASE_TAG: ${{ github.ref_name }}
+  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
   BUILD_TAG: test-build-${{ github.run_number }}-${{ github.sha }}
 
 jobs:
@@ -23,6 +28,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+          ref: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.ref }}
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
@@ -43,7 +49,7 @@ jobs:
       - name: Build
         run: dart run fl_build -p android
       - name: Rename for release
-        if: github.ref_type == 'tag'
+        if: github.ref_type == 'tag' || inputs.tag != ''
         shell: bash
         run: |
           APK_DIR="build/app/outputs/flutter-apk"
@@ -60,7 +66,7 @@ jobs:
             mv "${matches[0]}" "$APK_DIR/${APP_NAME}_${RELEASE_TAG}_${arch}.apk"
           done
       - name: Upload artifacts
-        if: github.ref_type != 'tag'
+        if: github.ref_type != 'tag' && inputs.tag == ''
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.APP_NAME }}-${{ env.BUILD_TAG }}-android
@@ -68,7 +74,7 @@ jobs:
           if-no-files-found: error
           retention-days: 14
       - name: Create Release
-        if: github.ref_type == 'tag'
+        if: github.ref_type == 'tag' || inputs.tag != ''
         uses: softprops/action-gh-release@v2
         with:
           files: |
@@ -96,6 +102,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+          ref: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.ref }}
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
@@ -108,7 +115,7 @@ jobs:
       - name: Build
         run: dart run fl_build -p linux
       - name: Rename for release
-        if: github.ref_type == 'tag'
+        if: github.ref_type == 'tag' || inputs.tag != ''
         shell: bash
         run: |
           shopt -s nullglob
@@ -120,7 +127,7 @@ jobs:
           fi
           mv "${matches[0]}" "${APP_NAME}_${RELEASE_TAG}${{ matrix.release_suffix }}_amd64.AppImage"
       - name: Upload artifacts
-        if: github.ref_type != 'tag'
+        if: github.ref_type != 'tag' && inputs.tag == ''
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.APP_NAME }}-${{ env.BUILD_TAG }}-linux${{ matrix.artifact_suffix }}
@@ -128,7 +135,7 @@ jobs:
           if-no-files-found: error
           retention-days: 14
       - name: Create Release
-        if: github.ref_type == 'tag'
+        if: github.ref_type == 'tag' || inputs.tag != ''
         uses: softprops/action-gh-release@v2
         with:
           files: |
@@ -144,6 +151,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+          ref: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.ref }}
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
@@ -151,7 +159,7 @@ jobs:
       - name: Build
         run: dart run fl_build -p windows
       - name: Rename for release
-        if: github.ref_type == 'tag'
+        if: github.ref_type == 'tag' || inputs.tag != ''
         shell: bash
         run: |
           shopt -s nullglob
@@ -163,7 +171,7 @@ jobs:
           fi
           mv "${matches[0]}" "${APP_NAME}_${RELEASE_TAG}_windows_amd64.zip"
       - name: Upload artifacts
-        if: github.ref_type != 'tag'
+        if: github.ref_type != 'tag' && inputs.tag == ''
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.APP_NAME }}-${{ env.BUILD_TAG }}-windows
@@ -171,7 +179,7 @@ jobs:
           if-no-files-found: error
           retention-days: 14
       - name: Create Release
-        if: github.ref_type == 'tag'
+        if: github.ref_type == 'tag' || inputs.tag != ''
         uses: softprops/action-gh-release@v2
         with:
           files: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       tag:
         description: 'Tag to build (e.g. v1.0.1426)'
-        required: true
+        required: false
         type: string
   push:
     tags:
@@ -29,6 +29,7 @@ jobs:
         with:
           submodules: recursive
           ref: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          persist-credentials: false
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
@@ -103,6 +104,7 @@ jobs:
         with:
           submodules: recursive
           ref: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          persist-credentials: false
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
@@ -152,6 +154,7 @@ jobs:
         with:
           submodules: recursive
           ref: ${{ inputs.tag && format('refs/tags/{0}', inputs.tag) || github.ref }}
+          persist-credentials: false
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build workflow to allow manual triggering with an optional tag input for flexible release timing and versioning.
  * Unified handling so builds use the provided tag or the current ref name for naming and checkout.
  * Broadened conditions so tagged/manual-tag runs create GitHub Releases, while other runs upload build artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->