### PR TITLE
feat(ssh): native tmux support for mobile vibe coding

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -125,6 +125,7 @@ class _MyAppState extends State<MyApp> {
 
     return MaterialApp(
       key: ValueKey(locale),
+      restorationScopeId: 'serverbox',
       navigatorKey: AppNavigator.key,
       builder: ResponsivePoints.builder,
       locale: locale,

--- a/lib/data/model/ssh/virtual_key.dart
+++ b/lib/data/model/ssh/virtual_key.dart
@@ -11,6 +11,7 @@ enum VirtualKeyFunc {
   snippet,
   file,
   sudoPassword,
+  tmuxSwitch,
 }
 
 enum VirtKey {
@@ -60,6 +61,7 @@ enum VirtKey {
   f11,
   f12,
   sudo,
+  tmux,
 }
 
 extension VirtKeyX on VirtKey {
@@ -91,6 +93,7 @@ extension VirtKeyX on VirtKey {
 
     if (this == VirtKey.pgdn) return 'PgDn';
     if (this == VirtKey.pgup) return 'PgUp';
+    if (this == VirtKey.tmux) return 'tmux';
 
     if (name.length > 1) {
       return name.substring(0, 1).toUpperCase() + name.substring(1);
@@ -116,6 +119,7 @@ extension VirtKeyX on VirtKey {
     VirtKey.sudo,
     VirtKey.ime,
     VirtKey.shift,
+    VirtKey.tmux,
   ];
 
   /// Corresponding [TerminalKey]
@@ -158,6 +162,7 @@ extension VirtKeyX on VirtKey {
     VirtKey.snippet => Icons.code,
     VirtKey.clipboard => Icons.paste,
     VirtKey.sudo => Icons.password,
+    VirtKey.tmux => Icons.window,
     VirtKey.ime => Icons.keyboard,
     _ => null,
   };
@@ -170,6 +175,7 @@ extension VirtKeyX on VirtKey {
     VirtKey.snippet => VirtualKeyFunc.snippet,
     VirtKey.clipboard => VirtualKeyFunc.clipboard,
     VirtKey.sudo => VirtualKeyFunc.sudoPassword,
+    VirtKey.tmux => VirtualKeyFunc.tmuxSwitch,
     VirtKey.ime => VirtualKeyFunc.toggleIME,
     _ => null,
   };

--- a/lib/data/provider/systemd.g.dart
+++ b/lib/data/provider/systemd.g.dart
@@ -58,7 +58,7 @@ final class SystemdNotifierProvider
   }
 }
 
-String _$systemdNotifierHash() => r'd8b36c60dff036e98196ad4d084e4b2ae3a65e32';
+String _$systemdNotifierHash() => r'59470f15580fd1e0366e4981e013643fa8f60c11';
 
 final class SystemdNotifierFamily extends $Family
     with

--- a/lib/data/ssh/tmux/tmux_command_builder.dart
+++ b/lib/data/ssh/tmux/tmux_command_builder.dart
@@ -1,0 +1,134 @@
+/// Pure utility for building tmux commands.
+///
+/// Extracted from TmuxSession for testability without flutter dependencies.
+abstract final class TmuxCommandBuilder {
+  static const defaultLang = 'en_US.UTF-8';
+
+  /// Escape a shell argument for use in tmux commands.
+  static String escapeArg(String arg) {
+    return "'${arg.replaceAll("'", "'\\''")}'";
+  }
+
+  static String tmuxPrefix({
+    String tmuxBin = 'tmux',
+    String lang = defaultLang,
+  }) {
+    final escapedLang = escapeArg(lang);
+    return 'env LANG=$escapedLang LC_CTYPE=$escapedLang LC_ALL=$escapedLang $tmuxBin';
+  }
+
+  /// Build the attach command for an existing session.
+  static String attachSession(
+    String sessionName, {
+    String tmuxBin = 'tmux',
+    String lang = defaultLang,
+  }) {
+    return '${tmuxPrefix(tmuxBin: tmuxBin, lang: lang)} attach-session -t ${escapeArg(sessionName)}';
+  }
+
+  /// Build the attach command targeting a specific window.
+  static String attachSessionWindow(
+    String sessionName,
+    int windowIndex, {
+    String tmuxBin = 'tmux',
+    String lang = defaultLang,
+  }) {
+    return '${tmuxPrefix(tmuxBin: tmuxBin, lang: lang)} attach-session -t ${escapeArg('$sessionName:$windowIndex')}';
+  }
+
+  /// Build the new-session command.
+  static String newSession(
+    String sessionName, {
+    String tmuxBin = 'tmux',
+    String lang = defaultLang,
+  }) {
+    return '${tmuxPrefix(tmuxBin: tmuxBin, lang: lang)} new-session -s ${escapeArg(sessionName)}';
+  }
+
+  /// Build the new-session -A command (attach or create).
+  static String newSessionOrAttach(
+    String sessionName, {
+    String tmuxBin = 'tmux',
+    String lang = defaultLang,
+  }) {
+    return '${tmuxPrefix(tmuxBin: tmuxBin, lang: lang)} new-session -A -s ${escapeArg(sessionName)}';
+  }
+
+  /// Build the kill-session command.
+  static String killSession(
+    String sessionName, {
+    String tmuxBin = 'tmux',
+    String lang = defaultLang,
+  }) {
+    return '${tmuxPrefix(tmuxBin: tmuxBin, lang: lang)} kill-session -t ${escapeArg(sessionName)}';
+  }
+
+  /// Build the list-sessions command with format string.
+  static String listSessionsCmd({
+    String tmuxBin = 'tmux',
+    String lang = defaultLang,
+  }) =>
+      '${tmuxPrefix(tmuxBin: tmuxBin, lang: lang)} list-sessions -F '
+      '"#{session_name}|#{session_windows}|#{session_attached}'
+      '|#{session_created_string}|#{session_last_attached_string}'
+      '|#{session_activity_string}"';
+
+  /// Build the list-windows command for a session.
+  static String listWindows(
+    String sessionName, {
+    String tmuxBin = 'tmux',
+    String lang = defaultLang,
+  }) =>
+      '${tmuxPrefix(tmuxBin: tmuxBin, lang: lang)} list-windows -t ${escapeArg(sessionName)} -F '
+      '"#{window_index}|#{window_name}|#{window_active}|#{window_panes}|#{window_activity_string}"';
+
+  /// Build the list-clients command with identity and disambiguation fields.
+  static String listClients({
+    String tmuxBin = 'tmux',
+    String lang = defaultLang,
+  }) =>
+      '${tmuxPrefix(tmuxBin: tmuxBin, lang: lang)} list-clients -F '
+      '"#{client_tty}|#{client_session}|#{window_index}|#{client_activity}"';
+
+  /// Build the switch-client command for a specific client tty.
+  static String switchClient(
+    String clientTty,
+    String target, {
+    String tmuxBin = 'tmux',
+    String lang = defaultLang,
+  }) =>
+      '${tmuxPrefix(tmuxBin: tmuxBin, lang: lang)} switch-client -c ${escapeArg(clientTty)} -t ${escapeArg(target)}';
+
+  /// Build the kill-window command.
+  static String killWindow(
+    String sessionName,
+    int windowIndex, {
+    String tmuxBin = 'tmux',
+    String lang = defaultLang,
+  }) =>
+      '${tmuxPrefix(tmuxBin: tmuxBin, lang: lang)} kill-window -t ${escapeArg('$sessionName:$windowIndex')}';
+
+  /// Build the select-window command.
+  static String selectWindow(
+    String sessionName,
+    int windowIndex, {
+    String tmuxBin = 'tmux',
+    String lang = defaultLang,
+  }) =>
+      '${tmuxPrefix(tmuxBin: tmuxBin, lang: lang)} select-window -t ${escapeArg('$sessionName:$windowIndex')}';
+
+  /// Build the new-window command.
+  static String newWindow(
+    String sessionName, {
+    String tmuxBin = 'tmux',
+    String lang = defaultLang,
+  }) =>
+      '${tmuxPrefix(tmuxBin: tmuxBin, lang: lang)} new-window -t ${escapeArg(sessionName)}';
+
+  /// Find tmux binary path.
+  /// Uses `bash -i -c` to start an interactive shell that sources ~/.bashrc,
+  /// ensuring PATH includes homebrew/linuxbrew etc.
+  static String get findTmux =>
+      "bash -i -c 'command -v tmux' 2>/dev/null || "
+      'command -v tmux 2>/dev/null || which tmux 2>/dev/null';
+}

--- a/lib/data/ssh/tmux/tmux_export.dart
+++ b/lib/data/ssh/tmux/tmux_export.dart
@@ -1,0 +1,6 @@
+export 'tmux_command_builder.dart';
+export 'tmux_launch_plan.dart';
+export 'tmux_restore_state.dart';
+export 'tmux_session.dart';
+export 'tmux_session_info.dart';
+export 'tmux_session_scanner.dart';

--- a/lib/data/ssh/tmux/tmux_launch_plan.dart
+++ b/lib/data/ssh/tmux/tmux_launch_plan.dart
@@ -1,0 +1,99 @@
+import 'package:server_box/data/ssh/tmux/tmux_command_builder.dart';
+import 'package:server_box/data/ssh/tmux/tmux_restore_state.dart';
+import 'package:server_box/data/ssh/tmux/tmux_session.dart';
+import 'package:server_box/data/ssh/tmux/tmux_session_info.dart';
+
+final class TmuxLaunchPlan {
+  final String? command;
+  final String? sessionName;
+  final int? windowIndex;
+
+  const TmuxLaunchPlan._({
+    required this.command,
+    required this.sessionName,
+    required this.windowIndex,
+  });
+
+  const TmuxLaunchPlan.none() : this._(command: null, sessionName: null, windowIndex: null);
+
+  const TmuxLaunchPlan.tmux({
+    required String command,
+    required String sessionName,
+    int? windowIndex,
+  }) : this._(
+         command: command,
+         sessionName: sessionName,
+         windowIndex: windowIndex,
+       );
+
+  bool get shouldLaunchTmux => command != null && sessionName != null;
+}
+
+TmuxLaunchPlan buildRestoredTmuxLaunchPlan(
+  TmuxRestoreState restoreState,
+  List<TmuxSessionInfo> sessions,
+  {
+    String tmuxBin = 'tmux',
+    String lang = TmuxCommandBuilder.defaultLang,
+  }
+) {
+  if (!restoreState.hasSession) return const TmuxLaunchPlan.none();
+
+  final sessionName = restoreState.sessionName!;
+  final exists = sessions.any((session) => session.name == sessionName);
+  if (!exists) return const TmuxLaunchPlan.none();
+
+  final command = restoreState.windowIndex != null
+      ? TmuxCommandBuilder.attachSessionWindow(
+          sessionName,
+          restoreState.windowIndex!,
+          tmuxBin: tmuxBin,
+          lang: lang,
+        )
+      : TmuxCommandBuilder.attachSession(
+          sessionName,
+          tmuxBin: tmuxBin,
+          lang: lang,
+        );
+
+  return TmuxLaunchPlan.tmux(
+    command: command,
+    sessionName: sessionName,
+    windowIndex: restoreState.windowIndex,
+  );
+}
+
+TmuxLaunchPlan buildChosenTmuxLaunchPlan(
+  TmuxAttachChoice choice, {
+  String tmuxBin = 'tmux',
+  String lang = TmuxCommandBuilder.defaultLang,
+}) {
+  return switch (choice) {
+    TmuxAttachExisting(sessionName: final sessionName, windowIndex: final windowIndex) =>
+      TmuxLaunchPlan.tmux(
+        command: windowIndex != null
+            ? TmuxCommandBuilder.attachSessionWindow(
+                sessionName,
+                windowIndex,
+                tmuxBin: tmuxBin,
+                lang: lang,
+              )
+            : TmuxCommandBuilder.attachSession(
+                sessionName,
+                tmuxBin: tmuxBin,
+                lang: lang,
+              ),
+        sessionName: sessionName,
+        windowIndex: windowIndex,
+      ),
+    TmuxAttachNew(sessionName: final sessionName) => TmuxLaunchPlan.tmux(
+      command: TmuxCommandBuilder.newSessionOrAttach(
+        sessionName,
+        tmuxBin: tmuxBin,
+        lang: lang,
+      ),
+      sessionName: sessionName,
+    ),
+    _ => const TmuxLaunchPlan.none(),
+  };
+}

--- a/lib/data/ssh/tmux/tmux_restore_state.dart
+++ b/lib/data/ssh/tmux/tmux_restore_state.dart
@@ -1,0 +1,31 @@
+final class TmuxRestoreState {
+  final String? sessionName;
+  final int? windowIndex;
+
+  const TmuxRestoreState({this.sessionName, this.windowIndex});
+
+  bool get hasSession => sessionName != null && sessionName!.isNotEmpty;
+}
+
+TmuxRestoreState resolveTmuxRestoreState({
+  String? argsSession,
+  int? argsWindow,
+  String? restorableSession,
+  int? restorableWindow,
+}) {
+  if (argsSession != null) {
+    return TmuxRestoreState(
+      sessionName: argsSession,
+      windowIndex: argsWindow,
+    );
+  }
+
+  if (restorableSession != null) {
+    return TmuxRestoreState(
+      sessionName: restorableSession,
+      windowIndex: restorableWindow,
+    );
+  }
+
+  return const TmuxRestoreState();
+}

--- a/lib/data/ssh/tmux/tmux_session.dart
+++ b/lib/data/ssh/tmux/tmux_session.dart
@@ -1,0 +1,147 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:server_box/data/ssh/persistent_shell.dart';
+import 'package:server_box/data/ssh/tmux/tmux_command_builder.dart';
+import 'package:server_box/data/ssh/tmux/tmux_session_info.dart';
+import 'package:server_box/data/ssh/tmux/tmux_session_scanner.dart';
+import 'package:server_box/data/ssh/tmux/tmux_window_info.dart';
+
+/// Represents the user's choice when connecting to tmux.
+sealed class TmuxAttachChoice {
+  const TmuxAttachChoice();
+}
+
+/// Attach to an existing tmux session, optionally at a specific window.
+final class TmuxAttachExisting extends TmuxAttachChoice {
+  final String sessionName;
+  final int? windowIndex;
+  const TmuxAttachExisting({required this.sessionName, this.windowIndex});
+}
+
+/// Create a new tmux session with the given name.
+final class TmuxAttachNew extends TmuxAttachChoice {
+  final String sessionName;
+  const TmuxAttachNew({required this.sessionName});
+}
+
+/// Skip tmux entirely (use raw shell).
+final class TmuxAttachSkip extends TmuxAttachChoice {
+  const TmuxAttachSkip();
+}
+
+/// Manages tmux session lifecycle for an SSH connection.
+///
+/// Uses `tmux -CC` protocol for session discovery on a background channel,
+/// and generates the appropriate attach command for the main terminal.
+final class TmuxSession {
+  final PersistentShell _shell;
+  final TmuxSessionScanner _scanner;
+  final ValueNotifier<TmuxAttachChoice?> choiceNotifier = ValueNotifier(null);
+  final String _lang;
+
+  TmuxSession(
+    PersistentShell shell, {
+    String lang = TmuxCommandBuilder.defaultLang,
+  }) : _shell = shell,
+       _lang = lang,
+       _scanner = TmuxSessionScanner(shell, lang: lang);
+
+  TmuxSessionScanner get scanner => _scanner;
+
+  String? _lastSessionName;
+  String? get lastSessionName => _lastSessionName;
+
+  /// Check if tmux is available on the remote server.
+  Future<bool> get isAvailable => _scanner.isTmuxAvailable();
+
+  /// Discover available sessions.
+  Future<List<TmuxSessionInfo>> get sessions => _scanner.listSessions();
+
+  /// List windows in a session.
+  Future<List<TmuxWindowInfo>> listWindows(String sessionName) =>
+      _scanner.listWindows(sessionName);
+
+  /// Set the user's choice and remember the session name for reconnection.
+  void setChoice(TmuxAttachChoice choice) {
+    choiceNotifier.value = choice;
+    if (choice is TmuxAttachExisting) {
+      _lastSessionName = choice.sessionName;
+    } else if (choice is TmuxAttachNew) {
+      _lastSessionName = choice.sessionName;
+    }
+  }
+
+  /// Generate the shell command to execute for tmux attachment.
+  ///
+  /// Returns the command string to prepend to the terminal session.
+  /// For existing sessions: `tmux attach-session -t <name>`
+  /// For new sessions: `tmux new-session -s <name>`
+  /// For skip: returns null (no tmux command).
+  String? buildAttachCommand(
+    TmuxAttachChoice choice, {
+    String tmuxBin = 'tmux',
+  }) {
+    return switch (choice) {
+      TmuxAttachExisting(sessionName: final name, windowIndex: final win) =>
+        win != null
+            ? TmuxCommandBuilder.attachSessionWindow(
+                name,
+                win,
+                tmuxBin: tmuxBin,
+                lang: _lang,
+              )
+            : TmuxCommandBuilder.attachSession(
+                name,
+                tmuxBin: tmuxBin,
+                lang: _lang,
+              ),
+      TmuxAttachNew(sessionName: final name) => TmuxCommandBuilder.newSession(
+        name,
+        tmuxBin: tmuxBin,
+        lang: _lang,
+      ),
+      TmuxAttachSkip() => null,
+    };
+  }
+
+  /// Build the command for auto-reconnection.
+  ///
+  /// If a previous session was active, try to reattach.
+  /// Otherwise, fall back to creating a new session.
+  String buildReconnectCommand() {
+    if (_lastSessionName != null) {
+      return TmuxCommandBuilder.newSessionOrAttach(
+        _lastSessionName!,
+        lang: _lang,
+      );
+    }
+    return 'tmux new-session';
+  }
+
+  /// Generate the initial auto-tmux command.
+  ///
+  /// Uses `tmux new-session -A` which attaches to an existing session
+  /// with the given name or creates a new one.
+  String buildAutoCommand({String? sessionName}) {
+    final name = sessionName ?? 'server_box';
+    return TmuxCommandBuilder.newSessionOrAttach(name, lang: _lang);
+  }
+
+  /// Kill a tmux session.
+  Future<bool> killSession(String name) => _scanner.killSession(name);
+
+  /// Close the underlying PersistentShell SSH channel.
+  Future<void> dispose() async {
+    try {
+      await _shell.close();
+    } catch (_) {}
+  }
+
+  /// Run an arbitrary command on the remote server.
+  Future<bool> runCommand(String command) => _scanner.runCommand(command);
+
+  /// Run a command and capture its output.
+  Future<String?> runCommandAndCapture(String command) =>
+      _scanner.runCommandAndCapture(command);
+}

--- a/lib/data/ssh/tmux/tmux_session_info.dart
+++ b/lib/data/ssh/tmux/tmux_session_info.dart
@@ -1,0 +1,46 @@
+/// Represents a tmux session discovered on the remote server.
+final class TmuxSessionInfo {
+  final String name;
+  final int windows;
+  final bool attached;
+  final String? createdAt;
+  final String? lastAttached;
+  final String? activity;
+
+  const TmuxSessionInfo({
+    required this.name,
+    required this.windows,
+    required this.attached,
+    this.createdAt,
+    this.lastAttached,
+    this.activity,
+  });
+  /// Parse a line from `tmux list-sessions -F "#{session_name}|#{session_windows}|#{session_attached}|#{session_created_string}|#{session_last_attached_string}|#{session_activity_string}"`
+  static TmuxSessionInfo? tryParse(String line) {
+    final parts = line.split('|');
+    if (parts.isEmpty || parts[0].isEmpty) return null;
+    return TmuxSessionInfo(
+      name: parts[0],
+      windows: parts.length > 1 ? (int.tryParse(parts[1]) ?? 0) : 0,
+      attached: parts.length > 2 && (int.tryParse(parts[2]) ?? 0) > 0,
+      createdAt: parts.length > 3 ? parts[3] : null,
+      lastAttached: parts.length > 4 ? parts[4] : null,
+      activity: parts.length > 5 ? parts[5] : null,
+    );
+  }
+
+  /// Format for display in session selector.
+  String get displayName {
+    final parts = <String>[name];
+    if (windows > 0) {
+      parts.add('$windows window${windows == 1 ? '' : 's'}');
+    }
+    if (attached) {
+      parts.add('(attached)');
+    }
+    return parts.join(' · ');
+  }
+
+  @override
+  String toString() => 'TmuxSession($name, $windows windows, attached=$attached)';
+}

--- a/lib/data/ssh/tmux/tmux_session_scanner.dart
+++ b/lib/data/ssh/tmux/tmux_session_scanner.dart
@@ -1,0 +1,143 @@
+import 'dart:async';
+
+import 'package:fl_lib/fl_lib.dart';
+import 'package:server_box/data/ssh/persistent_shell.dart';
+import 'package:server_box/data/ssh/tmux/tmux_command_builder.dart';
+import 'package:server_box/data/ssh/tmux/tmux_session_info.dart';
+import 'package:server_box/data/ssh/tmux/tmux_window_info.dart';
+
+/// Scans for available tmux sessions on the remote server and manages
+/// tmux -CC connections.
+final class TmuxSessionScanner {
+  final PersistentShell _shell;
+  final String _lang;
+  String? _tmuxBin;
+  String? get tmuxBin => _tmuxBin;
+
+  TmuxSessionScanner(
+    this._shell, {
+    String lang = TmuxCommandBuilder.defaultLang,
+  }) : _lang = lang;
+
+  Future<String?> _findTmuxBin() async {
+    final result = await _shell.run(
+      TmuxCommandBuilder.findTmux,
+      timeout: const Duration(seconds: 5),
+    );
+    if (result.exitCode != 0) return null;
+
+    final tmuxBin = result.output.trim();
+    if (tmuxBin.isEmpty) return null;
+    return tmuxBin;
+  }
+
+  Future<bool> _ensureTmuxResolved() async {
+    if (_tmuxBin != null) return true;
+    return isTmuxAvailable();
+  }
+
+  /// Find tmux binary and check availability. Stores the path for later use.
+  Future<bool> isTmuxAvailable() async {
+    try {
+      final tmuxBin = await _findTmuxBin();
+      if (tmuxBin == null) return false;
+      _tmuxBin = tmuxBin;
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /// List all tmux sessions on the remote server.
+  Future<List<TmuxSessionInfo>> listSessions() async {
+    try {
+      if (!await _ensureTmuxResolved()) return [];
+      final result = await _shell.run(
+        TmuxCommandBuilder.listSessionsCmd(tmuxBin: _tmuxBin!, lang: _lang),
+        timeout: const Duration(seconds: 5),
+      );
+      if (result.exitCode != 0) return [];
+      return result.output
+          .split('\n')
+          .where((line) => line.trim().isNotEmpty)
+          .map(TmuxSessionInfo.tryParse)
+          .whereType<TmuxSessionInfo>()
+          .toList();
+    } catch (e, st) {
+      Loggers.app.warning('Failed to list tmux sessions', e, st);
+      return [];
+    }
+  }
+
+  /// List windows in a tmux session.
+  Future<List<TmuxWindowInfo>> listWindows(String sessionName) async {
+    try {
+      if (!await _ensureTmuxResolved()) return [];
+      final result = await _shell.run(
+        TmuxCommandBuilder.listWindows(
+          sessionName,
+          tmuxBin: _tmuxBin!,
+          lang: _lang,
+        ),
+        timeout: const Duration(seconds: 5),
+      );
+      if (result.exitCode != 0) return [];
+      return result.output
+          .split('\n')
+          .where((line) => line.trim().isNotEmpty)
+          .map(TmuxWindowInfo.tryParse)
+          .whereType<TmuxWindowInfo>()
+          .toList();
+    } catch (e, st) {
+      Loggers.app.warning('Failed to list tmux windows', e, st);
+      return [];
+    }
+  }
+
+  /// Run a command and capture its output.
+  Future<String?> runCommandAndCapture(String command) async {
+    try {
+      final result = await _shell.run(
+        command,
+        timeout: const Duration(seconds: 5),
+      );
+      if (result.exitCode == 0) return result.output;
+      return null;
+    } catch (e, st) {
+      Loggers.app.warning('Failed to run command: $command', e, st);
+      return null;
+    }
+  }
+
+  /// Run an arbitrary command on the remote server.
+  Future<bool> runCommand(String command) async {
+    try {
+      final result = await _shell.run(
+        command,
+        timeout: const Duration(seconds: 5),
+      );
+      return result.exitCode == 0;
+    } catch (e, st) {
+      Loggers.app.warning('Failed to run command: $command', e, st);
+      return false;
+    }
+  }
+
+  /// Kill a tmux session by name.
+  Future<bool> killSession(String sessionName) async {
+    try {
+      final result = await _shell.run(
+        TmuxCommandBuilder.killSession(
+          sessionName,
+          tmuxBin: _tmuxBin ?? 'tmux',
+          lang: _lang,
+        ),
+        timeout: const Duration(seconds: 5),
+      );
+      return result.exitCode == 0;
+    } catch (e, st) {
+      Loggers.app.warning('Failed to kill tmux session', e, st);
+      return false;
+    }
+  }
+}

--- a/lib/data/ssh/tmux/tmux_window_info.dart
+++ b/lib/data/ssh/tmux/tmux_window_info.dart
@@ -1,0 +1,41 @@
+/// Represents a tmux window within a session.
+final class TmuxWindowInfo {
+  final int index;
+  final String name;
+  final bool active;
+  final int panes;
+  final String? activity;
+
+  const TmuxWindowInfo({
+    required this.index,
+    required this.name,
+    required this.active,
+    required this.panes,
+    this.activity,
+  });
+
+  /// Parse a line from `tmux list-windows -t <session> -F "#{window_index}|#{window_name}|#{window_active}|#{window_panes}|#{window_activity_string}"`
+  static TmuxWindowInfo? tryParse(String line) {
+    final parts = line.split('|');
+    if (parts.isEmpty) return null;
+    final index = int.tryParse(parts[0]);
+    if (index == null) return null;
+    return TmuxWindowInfo(
+      index: index,
+      name: parts.length > 1 ? parts[1] : '',
+      active: parts.length > 2 && parts[2] == '1',
+      panes: parts.length > 3 ? (int.tryParse(parts[3]) ?? 1) : 1,
+      activity: parts.length > 4 ? parts[4] : null,
+    );
+  }
+
+  String get displayName {
+    final parts = <String>['$index: $name'];
+    if (active) parts.add('(active)');
+    if (panes > 1) parts.add('$panes panes');
+    return parts.join(' · ');
+  }
+
+  @override
+  String toString() => 'TmuxWindow($index: $name, active=$active, panes=$panes)';
+}

--- a/lib/data/store/setting.dart
+++ b/lib/data/store/setting.dart
@@ -309,4 +309,13 @@ class SettingStore extends HiveStore {
 
   late final sshPageSortBy = propertyDefault('sshPageSortBy', 0);
   late final sshPageSortAsc = propertyDefault('sshPageSortAsc', true);
+
+  /// Whether to automatically start/attach tmux on SSH connect.
+  late final tmuxAuto = propertyDefault('tmuxAuto', false);
+
+  /// Whether to show the tmux session selector dialog on connect.
+  late final tmuxShowSelector = propertyDefault('tmuxShowSelector', true);
+
+  /// Default tmux session name. Empty string means use 'server_box'.
+  late final tmuxSessionName = propertyDefault('tmuxSessionName', '');
 }

--- a/lib/hive/hive_adapters.g.dart
+++ b/lib/hive/hive_adapters.g.dart
@@ -270,6 +270,8 @@ class VirtKeyAdapter extends TypeAdapter<VirtKey> {
         return VirtKey.shift;
       case 45:
         return VirtKey.sudo;
+      case 46:
+        return VirtKey.tmux;
       default:
         return VirtKey.esc;
     }
@@ -370,6 +372,8 @@ class VirtKeyAdapter extends TypeAdapter<VirtKey> {
         writer.writeByte(44);
       case VirtKey.sudo:
         writer.writeByte(45);
+      case VirtKey.tmux:
+        writer.writeByte(46);
     }
   }
 

--- a/lib/hive/hive_adapters.g.yaml
+++ b/lib/hive/hive_adapters.g.yaml
@@ -67,7 +67,7 @@ types:
         index: 17
   VirtKey:
     typeId: 4
-    nextIndex: 46
+    nextIndex: 47
     fields:
       esc:
         index: 0
@@ -161,6 +161,8 @@ types:
         index: 44
       sudo:
         index: 45
+      tmux:
+        index: 46
   NetViewType:
     typeId: 5
     nextIndex: 3

--- a/lib/view/page/home.dart
+++ b/lib/view/page/home.dart
@@ -32,7 +32,19 @@ class _HomePageState extends ConsumerState<HomePage>
         AutomaticKeepAliveClientMixin,
         AfterLayoutMixin,
         WidgetsBindingObserver,
-        GlobalRef {
+        GlobalRef,
+        RestorationMixin {
+  // Restorable state for current tab index
+  final RestorableInt _restorableTabIndex = RestorableInt(0);
+
+  @override
+  String get restorationId => 'home_page';
+
+  @override
+  void restoreState(RestorationBucket? oldBucket, bool initialRestore) {
+    registerForRestoration(_restorableTabIndex, 'tab_index');
+  }
+
   late final PageController _pageController;
 
   final _selectIndex = ValueNotifier(0);
@@ -47,6 +59,7 @@ class _HomePageState extends ConsumerState<HomePage>
 
   @override
   void dispose() {
+    _restorableTabIndex.dispose();
     if (isMobile) {
       SystemUIs.switchStatusBar(hide: false);
     }
@@ -150,6 +163,7 @@ class _HomePageState extends ConsumerState<HomePage>
                 FocusScope.of(context).unfocus();
                 if (!_switchingPage) {
                   _selectIndex.value = value;
+                  _restorableTabIndex.value = value;
                 }
                 _syncFullscreenSystemUi();
               },
@@ -243,6 +257,13 @@ class _HomePageState extends ConsumerState<HomePage>
   @override
   Future<void> afterFirstLayout(BuildContext context) async {
     // Auth required for first launch
+    // Restore tab index from restoration if available
+    if (_restorableTabIndex.value >= 0 && _restorableTabIndex.value < _tabs.length) {
+      _selectIndex.value = _restorableTabIndex.value;
+      if (_pageController.hasClients) {
+        _pageController.jumpToPage(_restorableTabIndex.value);
+      }
+    }
     _goAuth();
 
     //_reqNotiPerm();
@@ -274,6 +295,7 @@ class _HomePageState extends ConsumerState<HomePage>
     if (_selectIndex.value == index) return;
     if (index < 0 || index >= _tabs.length) return;
     _selectIndex.value = index;
+    _restorableTabIndex.value = index;
     _switchingPage = true;
     _pageController.animateToPage(
       index,
@@ -337,6 +359,7 @@ extension _HomePageStateActions on _HomePageState {
     setState(() {
       _tabs = newTabs;
       _selectIndex.value = clampedIndex;
+      _restorableTabIndex.value = clampedIndex;
     });
 
     if (clampedIndex != previousIndex && _pageController.hasClients) {

--- a/lib/view/page/setting/entries/ssh.dart
+++ b/lib/view/page/setting/entries/ssh.dart
@@ -24,6 +24,7 @@ extension _SSH on _AppSettingsPageState {
         if (isDesktop) _buildDesktopSshAutoCopyPassword(),
         _buildSSHVirtualKeyAutoOff(),
         if (isMobile) _buildSSHVirtKeys(),
+        _buildTmuxAuto(),
       ].map((e) => CardX(child: e)).toList(),
     );
   }
@@ -589,5 +590,88 @@ extension _SSH on _AppSettingsPageState {
         actions: Btn.ok(onTap: () => onSave(_sshBlurCtrl.text)).toList,
       ),
     );
+  }
+
+  Widget _buildTmuxAuto() {
+    return ExpandTile(
+      leading: const Icon(Icons.terminal),
+      title: const Text('tmux auto-attach'),
+      children: [
+        _buildTmuxAutoToggle(),
+        _buildTmuxShowSelector(),
+        _buildTmuxSessionName(),
+      ],
+    );
+  }
+
+  Widget _buildTmuxAutoToggle() {
+    return ListTile(
+      title: const Text('Auto tmux'),
+      subtitle: Text(
+        'Automatically start/attach tmux on SSH connect',
+        style: UIs.textGrey,
+      ),
+      trailing: StoreSwitch(prop: _setting.tmuxAuto),
+    );
+  }
+
+  Widget _buildTmuxShowSelector() {
+    return _setting.tmuxAuto.listenable().listenVal((autoEnabled) {
+      return IgnorePointer(
+        ignoring: !autoEnabled,
+        child: Opacity(
+          opacity: autoEnabled ? 1.0 : 0.5,
+          child: ListTile(
+            title: const Text('Session selector'),
+            subtitle: Text(
+              'Show session picker dialog on connect',
+              style: UIs.textGrey,
+            ),
+            trailing: StoreSwitch(prop: _setting.tmuxShowSelector),
+          ),
+        ),
+      );
+    });
+  }
+
+  Widget _buildTmuxSessionName() {
+    return _setting.tmuxAuto.listenable().listenVal((autoEnabled) {
+      return _setting.tmuxSessionName.listenable().listenVal((name) {
+        final displayName = name.isEmpty ? 'server_box' : name;
+        return IgnorePointer(
+          ignoring: !autoEnabled,
+          child: Opacity(
+            opacity: autoEnabled ? 1.0 : 0.5,
+            child: ListTile(
+              title: const Text('Default session name'),
+              trailing: Text(displayName, style: UIs.text15),
+              onTap: () => _showTmuxSessionNameDialog(name),
+            ),
+          ),
+        );
+      });
+    });
+  }
+
+  Future<void> _showTmuxSessionNameDialog(String current) async {
+    withTextFieldController((ctrl) async {
+      ctrl.text = current;
+      void onSave() {
+        _setting.tmuxSessionName.put(ctrl.text.trim());
+        context.pop();
+      }
+
+      await context.showRoundDialog<bool>(
+        title: 'Session name',
+        child: Input(
+          controller: ctrl,
+          autoFocus: true,
+          hint: 'server_box',
+          suggestion: false,
+          onSubmitted: (_) => onSave(),
+        ),
+        actions: Btn.ok(onTap: onSave).toList,
+      );
+    });
   }
 }

--- a/lib/view/page/ssh/page/init.dart
+++ b/lib/view/page/ssh/page/init.dart
@@ -1,6 +1,132 @@
 part of 'page.dart';
 
 extension _Init on SSHPageState {
+  void _logTmuxInfo(String message) {
+    Loggers.app.info('[TMUX] $message');
+  }
+
+  Map<String, String> get _sshEnvironment {
+    final env = <String, String>{...?widget.args.spi.envs};
+    final lang = (env['LANG']?.trim().isNotEmpty ?? false)
+        ? env['LANG']!
+        : TmuxCommandBuilder.defaultLang;
+    env['LANG'] = lang;
+    env.putIfAbsent('LC_CTYPE', () => lang);
+    env.putIfAbsent('LC_ALL', () => lang);
+    return env;
+  }
+
+  String get _tmuxLang {
+    final env = _sshEnvironment;
+    return (env['LC_CTYPE']?.trim().isNotEmpty ?? false)
+        ? env['LC_CTYPE']!
+        : env['LANG']!;
+  }
+
+  void _resetForegroundTerminal() {
+    _terminal.buffer.clear();
+    _terminal.buffer.setCursor(0, 0);
+  }
+
+  void _cancelTerminalOutputSubscriptions() {
+    for (final subscription in _terminalOutputSubscriptions) {
+      subscription.cancel();
+    }
+    _terminalOutputSubscriptions.clear();
+  }
+
+  void _bindForegroundSession(SSHSession session) {
+    _resetForegroundTerminal();
+    _cancelTerminalOutputSubscriptions();
+    _terminal.onOutput = (data) {
+      session.write(utf8.encode(data));
+    };
+    _terminal.onResize = (width, height, pixelWidth, pixelHeight) {
+      session.resizeTerminal(width, height);
+    };
+
+    _listen(session.stdout, name: 'stdout');
+    _listen(session.stderr, name: 'stderr');
+
+    _session = session;
+    TermSessionManager.updateStatus(_sessionId, TermSessionStatus.connected);
+    unawaited(_waitForegroundSessionDone(session));
+  }
+
+  Future<void> _waitForegroundSessionDone(SSHSession session) async {
+    await session.done;
+    if (!identical(_session, session)) {
+      return;
+    }
+
+    _session = null;
+    _drainPendingTerminalOutput();
+    if (mounted && widget.args.notFromTab) {
+      context.pop();
+    }
+    widget.args.onSessionEnd?.call();
+    TermSessionManager.remove(_sessionId);
+  }
+
+  Future<bool> _replaceForegroundWithLaunchPlan(TmuxLaunchPlan plan) async {
+    if (_client == null || !plan.shouldLaunchTmux) return false;
+
+    final oldSession = _session;
+    _session = null;
+    _cancelTerminalOutputSubscriptions();
+
+    try {
+      oldSession?.close();
+    } catch (e, st) {
+      Loggers.app.warning('Failed to close old foreground session', e, st);
+    }
+
+    final pty = SSHPtyConfig(
+      width: _terminal.viewWidth,
+      height: _terminal.viewHeight,
+    );
+    final session = await _client?.execute(
+      plan.command!,
+      pty: pty,
+      environment: _sshEnvironment,
+    );
+
+    if (session == null) {
+      Loggers.app.warning('Failed to replace foreground session with tmux');
+      return false;
+    }
+
+    _saveTmuxState(
+      sessionName: plan.sessionName!,
+      windowIndex: plan.windowIndex,
+    );
+    _bindForegroundSession(session);
+    widget.args.focusNode?.requestFocus();
+    return true;
+  }
+
+  Future<SSHSession?> _openForegroundSession() async {
+    final plan = await _resolveForegroundLaunchPlan();
+    final pty = SSHPtyConfig(
+      width: _terminal.viewWidth,
+      height: _terminal.viewHeight,
+    );
+
+    if (plan.shouldLaunchTmux) {
+      _saveTmuxState(
+        sessionName: plan.sessionName!,
+        windowIndex: plan.windowIndex,
+      );
+      return _client?.execute(
+        plan.command!,
+        pty: pty,
+        environment: _sshEnvironment,
+      );
+    }
+
+    return _client?.shell(pty: pty, environment: _sshEnvironment);
+  }
+
   void _initStoredCfg() {
     final fontFamilly = Stores.setting.fontPath.fetch().getFileName();
     final textSize = Stores.setting.termFontSize.fetch();
@@ -39,67 +165,39 @@ extension _Init on SSHPageState {
     );
 
     _writeLn('${libL10n.execute}: Shell');
-    final session = await _client?.shell(
-      pty: SSHPtyConfig(
-        width: _terminal.viewWidth,
-        height: _terminal.viewHeight,
-      ),
-      environment: widget.args.spi.envs,
-    );
+    final session = await _openForegroundSession();
 
     if (session == null) {
       _writeLn(libL10n.fail);
       return;
     }
 
-    _terminal.buffer.clear();
-    _terminal.buffer.setCursor(0, 0);
-
-    _terminal.onOutput = (data) {
-      session.write(utf8.encode(data));
-    };
-    _terminal.onResize = (width, height, pixelWidth, pixelHeight) {
-      session.resizeTerminal(width, height);
-    };
-
-    _listen(session.stdout);
-    _listen(session.stderr);
-
-    // Hold the session for external control (disconnect)
-    _session = session;
-    // Mark status connected for notifications / live activities
-    TermSessionManager.updateStatus(_sessionId, TermSessionStatus.connected);
+    _bindForegroundSession(session);
 
     final snippets = ref.read(snippetProvider.select((p) => p.snippets));
-    for (final snippet in snippets) {
-      if (snippet.autoRunOn?.contains(widget.args.spi.id) == true) {
-        snippet.runInTerm(_terminal, widget.args.spi);
+    if (_tmuxCurrentSession == null) {
+      for (final snippet in snippets) {
+        if (snippet.autoRunOn?.contains(widget.args.spi.id) == true) {
+          snippet.runInTerm(_terminal, widget.args.spi);
+        }
       }
     }
 
     final initCmd = widget.args.initCmd;
-    if (initCmd != null) {
+    if (initCmd != null && _tmuxCurrentSession == null) {
       _terminal.textInput(initCmd);
       _terminal.keyInput(TerminalKey.enter);
     }
 
     final initSnippet = widget.args.initSnippet;
-    if (initSnippet != null) {
+    if (initSnippet != null && _tmuxCurrentSession == null) {
       initSnippet.runInTerm(_terminal, widget.args.spi);
     }
 
     widget.args.focusNode?.requestFocus();
-
-    await session.done;
-    _drainPendingTerminalOutput();
-    if (mounted && widget.args.notFromTab) {
-      context.pop();
-    }
-    widget.args.onSessionEnd?.call();
-    TermSessionManager.remove(_sessionId);
   }
 
-  void _listen(Stream<Uint8List>? stream) {
+  void _listen(Stream<Uint8List>? stream, {required String name}) {
     if (stream == null) {
       return;
     }
@@ -242,6 +340,376 @@ extension _Init on SSHPageState {
   void _writeLn(String p0) {
     _terminal.write('$p0\r\n');
   }
+
+  TmuxRestoreState get _restoreTmuxState {
+    return resolveTmuxRestoreState(
+      argsSession: widget.args.tmuxSession,
+      argsWindow: widget.args.tmuxWindow,
+      restorableSession: _restorableTmuxSession.value,
+      restorableWindow: _restorableTmuxWindow.value,
+    );
+  }
+
+  void _saveTmuxState({required String sessionName, int? windowIndex}) {
+    _tmuxCurrentSession = sessionName;
+    _tmuxCurrentWindow = windowIndex;
+    _restorableServerId.value = widget.args.spi.id;
+    _restorableTmuxSession.value = sessionName;
+    _restorableTmuxWindow.value = windowIndex;
+    widget.args.onTmuxStateChanged?.call();
+  }
+
+  Future<TmuxSession> _createTmuxControlSession() async {
+    return TmuxSession(
+      PersistentShell(
+        _client,
+        sessionFactory: () async {
+          final sh = await _client!.execute(
+            'bash --login',
+            environment: _sshEnvironment,
+          );
+          return SshPersistentShellSession(sh);
+        },
+      ),
+      lang: _tmuxLang,
+    );
+  }
+
+  Future<TmuxLaunchPlan> _resolveForegroundLaunchPlan() async {
+    if (!Stores.setting.tmuxAuto.fetch() || _client == null) {
+      return const TmuxLaunchPlan.none();
+    }
+
+    final tmuxSession = await _createTmuxControlSession();
+    try {
+      bool available;
+      try {
+        available = await tmuxSession.isAvailable;
+      } catch (e, st) {
+        Loggers.app.warning('tmux availability check failed', e, st);
+        return const TmuxLaunchPlan.none();
+      }
+
+      if (!available) {
+        return const TmuxLaunchPlan.none();
+      }
+      final tmuxBin = tmuxSession.scanner.tmuxBin ?? 'tmux';
+
+      final showSelector = Stores.setting.tmuxShowSelector.fetch();
+      final restoredState = _restoreTmuxState;
+      final shouldPreloadSessions = restoredState.hasSession || showSelector;
+      final sessions = shouldPreloadSessions
+          ? await _loadTmuxSessions(tmuxSession)
+          : const <TmuxSessionInfo>[];
+
+      final restoredPlan = await _buildRestoredForegroundLaunchPlan(
+        sessions,
+        tmuxBin: tmuxBin,
+        lang: _tmuxLang,
+      );
+      if (restoredPlan.shouldLaunchTmux) return restoredPlan;
+
+      final plan = await _buildInitialForegroundLaunchPlan(
+        tmuxSession,
+        preloadedSessions: sessions,
+        tmuxBin: tmuxBin,
+        lang: _tmuxLang,
+      );
+      return plan;
+    } finally {
+      await tmuxSession.dispose();
+    }
+  }
+
+  Future<List<TmuxSessionInfo>> _loadTmuxSessions(
+    TmuxSession tmuxSession,
+  ) async {
+    try {
+      return await tmuxSession.sessions;
+    } catch (e, st) {
+      Loggers.app.warning('tmux list sessions failed', e, st);
+      return const [];
+    }
+  }
+
+  Future<TmuxLaunchPlan> _buildRestoredForegroundLaunchPlan(
+    List<TmuxSessionInfo> sessions, {
+    required String tmuxBin,
+    required String lang,
+  }) async {
+    final restoredState = _restoreTmuxState;
+    if (!restoredState.hasSession) return const TmuxLaunchPlan.none();
+
+    final restoredPlan = buildRestoredTmuxLaunchPlan(
+      restoredState,
+      sessions,
+      tmuxBin: tmuxBin,
+      lang: lang,
+    );
+    if (restoredPlan.shouldLaunchTmux) {
+      _logTmuxInfo(
+        'Restoring tmux session "${restoredState.sessionName}"'
+        '${restoredState.windowIndex != null ? ' window ${restoredState.windowIndex}' : ''}',
+      );
+      return restoredPlan;
+    }
+
+    Loggers.app.info(
+      'Restored tmux session "${restoredState.sessionName}" not found, falling back to picker',
+    );
+    return const TmuxLaunchPlan.none();
+  }
+
+  Future<TmuxLaunchPlan> _buildInitialForegroundLaunchPlan(
+    TmuxSession tmuxSession, {
+    List<TmuxSessionInfo>? preloadedSessions,
+    required String tmuxBin,
+    required String lang,
+  }) async {
+    final showSelector = Stores.setting.tmuxShowSelector.fetch();
+    final defaultName = Stores.setting.tmuxSessionName.fetch();
+    final sessionName = defaultName.isEmpty ? 'server_box' : defaultName;
+
+    TmuxAttachChoice? choice;
+
+    if (showSelector) {
+      final sessions =
+          preloadedSessions ?? await _loadTmuxSessions(tmuxSession);
+      if (!mounted) return const TmuxLaunchPlan.none();
+
+      choice = await showTmuxSessionSelectorWithSkip(
+        context,
+        sessions: sessions,
+        tmuxSessionFactory: _createTmuxControlSession,
+        defaultSessionName: sessionName,
+      );
+    } else {
+      choice = TmuxAttachNew(sessionName: sessionName);
+    }
+
+    if (choice == null || choice is TmuxAttachSkip) {
+      return const TmuxLaunchPlan.none();
+    }
+
+    return buildChosenTmuxLaunchPlan(choice, tmuxBin: tmuxBin, lang: lang);
+  }
+
+  Future<void> _showTmuxSwitcher() async {
+    if (_client == null || !mounted) return;
+
+    final tmuxSession = await _createTmuxControlSession();
+    try {
+      final available = await tmuxSession.isAvailable;
+      if (!available || !mounted) {
+        if (mounted) context.showSnackBar('tmux not available');
+        return;
+      }
+      final tmuxBin = tmuxSession.scanner.tmuxBin ?? 'tmux';
+
+      final sessions = await tmuxSession.sessions;
+      if (!mounted) return;
+
+      final defaultName = Stores.setting.tmuxSessionName.fetch();
+      final sessionName = defaultName.isEmpty ? 'server_box' : defaultName;
+
+      final choice = await showTmuxSessionSelectorWithSkip(
+        context,
+        sessions: sessions,
+        tmuxSessionFactory: _createTmuxControlSession,
+        defaultSessionName: sessionName,
+        initialSessionName: _tmuxCurrentSession,
+      );
+
+      if (choice == null || choice is TmuxAttachSkip) return;
+
+      if (choice is TmuxAttachExisting) {
+        if (_tmuxCurrentSession == null) {
+          final plan = buildChosenTmuxLaunchPlan(
+            choice,
+            tmuxBin: tmuxBin,
+            lang: _tmuxLang,
+          );
+          await _replaceForegroundWithLaunchPlan(plan);
+          return;
+        }
+        final target = choice.windowIndex != null
+            ? '${choice.sessionName}:${choice.windowIndex}'
+            : choice.sessionName;
+        await _switchTmuxClient(
+          tmuxSession,
+          target,
+          nextSessionName: choice.sessionName,
+          nextWindowIndex: choice.windowIndex,
+        );
+        widget.args.focusNode?.requestFocus();
+        return;
+      }
+
+      if (choice is TmuxAttachNew) {
+        if (_tmuxCurrentSession == null) {
+          final plan = buildChosenTmuxLaunchPlan(
+            choice,
+            tmuxBin: tmuxBin,
+            lang: _tmuxLang,
+          );
+          await _replaceForegroundWithLaunchPlan(plan);
+          return;
+        }
+        await tmuxSession.runCommand(
+          '${TmuxCommandBuilder.tmuxPrefix(tmuxBin: tmuxBin, lang: _tmuxLang)} new-session -d -s ${TmuxCommandBuilder.escapeArg(choice.sessionName)}',
+        );
+        await _switchTmuxClient(
+          tmuxSession,
+          choice.sessionName,
+          nextSessionName: choice.sessionName,
+        );
+        widget.args.focusNode?.requestFocus();
+        return;
+      }
+    } finally {
+      await tmuxSession.dispose();
+    }
+  }
+
+  /// Switch the terminal's tmux client to a different session/window.
+  /// Dynamically finds this terminal's tmux client by session/window.
+  Future<void> _switchTmuxClient(
+    TmuxSession tmuxSession,
+    String target, {
+    required String nextSessionName,
+    int? nextWindowIndex,
+  }) async {
+    final tmuxBin = tmuxSession.scanner.tmuxBin ?? 'tmux';
+    final tty = await _resolveTmuxClientTty(
+      tmuxSession,
+      tmuxBin: tmuxBin,
+      lang: _tmuxLang,
+    );
+    if (tty == null) {
+      Loggers.app.warning('Failed to find tmux client tty for session switch');
+      return;
+    }
+    final switchCmd = TmuxCommandBuilder.switchClient(
+      tty,
+      target,
+      tmuxBin: tmuxBin,
+      lang: _tmuxLang,
+    );
+    final ok = await tmuxSession.runCommand(switchCmd);
+    if (!ok) {
+      Loggers.app.warning('Failed to switch tmux client to target: $target');
+    }
+    if (ok) {
+      _saveTmuxState(
+        sessionName: nextSessionName,
+        windowIndex: nextWindowIndex,
+      );
+    }
+  }
+
+  Future<String?> _resolveTmuxClientTty(
+    TmuxSession tmuxSession, {
+    required String tmuxBin,
+    required String lang,
+  }) async {
+    final clients = await _listTmuxClients(
+      tmuxSession,
+      tmuxBin: tmuxBin,
+      lang: lang,
+    );
+
+    final currentSession = _tmuxCurrentSession;
+    if (currentSession == null) return null;
+
+    var candidates = clients
+        .where((client) => client.sessionName == currentSession)
+        .toList(growable: false);
+
+    final currentWindow = _tmuxCurrentWindow;
+    if (currentWindow != null) {
+      candidates = candidates
+          .where((client) => client.windowIndex == currentWindow)
+          .toList(growable: false);
+    }
+
+    if (candidates.length == 1) {
+      return candidates.single.tty;
+    }
+
+    final sorted = [...candidates]
+      ..sort((a, b) => b.activity.compareTo(a.activity));
+    if (sorted.isNotEmpty) {
+      final latest = sorted.first;
+      final latestCount = sorted
+          .where((client) => client.activity == latest.activity)
+          .length;
+      if (latestCount == 1) {
+        Loggers.app.info(
+          '[TMUX] Resolved ambiguous client by activity: $latest',
+        );
+        return latest.tty;
+      }
+    }
+
+    Loggers.app.warning(
+      'Ambiguous tmux client for switch: clients=$clients '
+      'currentSession=$currentSession currentWindow=$currentWindow',
+    );
+    return null;
+  }
+
+  Future<List<_TmuxClientCandidate>> _listTmuxClients(
+    TmuxSession tmuxSession, {
+    required String tmuxBin,
+    required String lang,
+  }) async {
+    final result = await tmuxSession.scanner.runCommandAndCapture(
+      TmuxCommandBuilder.listClients(tmuxBin: tmuxBin, lang: lang),
+    );
+    if (result == null) return const [];
+
+    return result
+        .split('\n')
+        .map(_TmuxClientCandidate.tryParse)
+        .whereType<_TmuxClientCandidate>()
+        .toList(growable: false);
+  }
+}
+
+final class _TmuxClientCandidate {
+  final String tty;
+  final String sessionName;
+  final int? windowIndex;
+  final int activity;
+
+  const _TmuxClientCandidate({
+    required this.tty,
+    required this.sessionName,
+    required this.windowIndex,
+    required this.activity,
+  });
+
+  static _TmuxClientCandidate? tryParse(String line) {
+    final parts = line.trim().split('|');
+    if (parts.length < 4) return null;
+
+    final tty = parts[0].trim();
+    final sessionName = parts[1].trim();
+    final windowIndex = int.tryParse(parts[2].trim());
+    final activity = int.tryParse(parts[3].trim());
+    if (tty.isEmpty || sessionName.isEmpty || activity == null) return null;
+
+    return _TmuxClientCandidate(
+      tty: tty,
+      sessionName: sessionName,
+      windowIndex: windowIndex,
+      activity: activity,
+    );
+  }
+
+  @override
+  String toString() =>
+      '$tty $sessionName:${windowIndex ?? '?'} activity=$activity';
 }
 
 extension on SSHPageState {

--- a/lib/view/page/ssh/page/page.dart
+++ b/lib/view/page/ssh/page/page.dart
@@ -25,9 +25,12 @@ import 'package:server_box/data/provider/virtual_keyboard.dart';
 import 'package:server_box/data/res/misc.dart';
 import 'package:server_box/data/res/store.dart';
 import 'package:server_box/data/res/terminal.dart';
+import 'package:server_box/data/ssh/persistent_shell.dart';
 import 'package:server_box/data/ssh/session_manager.dart';
 import 'package:server_box/data/ssh/terminal_output_buffer.dart';
+import 'package:server_box/data/ssh/tmux/tmux_export.dart';
 import 'package:server_box/view/page/storage/sftp.dart';
+import 'package:server_box/view/widget/tmux_session_selector.dart';
 import 'package:wakelock_plus/wakelock_plus.dart';
 import 'package:xterm/core.dart';
 import 'package:xterm/ui.dart' hide TerminalThemes;
@@ -46,6 +49,9 @@ final class SshPageArgs {
   final GlobalKey<TerminalViewState>? terminalKey;
   final FocusNode? focusNode;
   final ValueListenable<bool>? visibleListenable;
+  final String? tmuxSession;
+  final int? tmuxWindow;
+  final VoidCallback? onTmuxStateChanged;
 
   const SshPageArgs({
     required this.spi,
@@ -56,6 +62,9 @@ final class SshPageArgs {
     this.terminalKey,
     this.focusNode,
     this.visibleListenable,
+    this.tmuxSession,
+    this.tmuxWindow,
+    this.onTmuxStateChanged,
   }) : assert(
          notFromTab || visibleListenable != null,
          'visibleListenable is required when notFromTab is false',
@@ -83,7 +92,23 @@ class SSHPageState extends ConsumerState<SSHPage>
         AutomaticKeepAliveClientMixin,
         AfterLayoutMixin,
         TickerProviderStateMixin,
-        WidgetsBindingObserver {
+        WidgetsBindingObserver,
+        RestorationMixin {
+  // Restorable state for this SSH page
+  final RestorableString _restorableServerId = RestorableString('');
+  final RestorableStringN _restorableTmuxSession = RestorableStringN(null);
+  final RestorableIntN _restorableTmuxWindow = RestorableIntN(null);
+
+  @override
+  String get restorationId => 'ssh_page_${widget.args.spi.id}';
+
+  @override
+  void restoreState(RestorationBucket? oldBucket, bool initialRestore) {
+    registerForRestoration(_restorableServerId, 'server_id');
+    registerForRestoration(_restorableTmuxSession, 'tmux_session');
+    registerForRestoration(_restorableTmuxWindow, 'tmux_window');
+  }
+
   late final _terminal = Terminal();
   late final TerminalController _terminalController = TerminalController(
     vsync: this,
@@ -117,6 +142,14 @@ class SSHPageState extends ConsumerState<SSHPage>
   bool _reportedDisconnected = false;
   VoidCallback? _visibilityListener;
   bool _isPickingSnippet = false;
+  String? _tmuxCurrentSession;
+  int? _tmuxCurrentWindow;
+
+  /// Current tmux session name (for state restoration)
+  String? get tmuxCurrentSession => _tmuxCurrentSession;
+
+  /// Current tmux window index (for state restoration)
+  int? get tmuxCurrentWindow => _tmuxCurrentWindow;
 
   /// Used for (de)activate the wake lock and forground service
   static var _sshConnCount = 0;
@@ -127,6 +160,9 @@ class SSHPageState extends ConsumerState<SSHPage>
 
   @override
   void dispose() {
+    _restorableServerId.dispose();
+    _restorableTmuxSession.dispose();
+    _restorableTmuxWindow.dispose();
     WidgetsBinding.instance.removeObserver(this);
     _virtKeyLongPressTimer?.cancel();
     _terminalController.dispose();
@@ -256,8 +292,6 @@ class SSHPageState extends ConsumerState<SSHPage>
   @override
   Widget build(BuildContext context) {
     super.build(context);
-    final bgImage = Stores.setting.sshBgImage.fetch();
-    final hasBg = bgImage.isNotEmpty;
     Widget child = PopScope(
       canPop: false,
       onPopInvokedWithResult: (didPop, _) {
@@ -273,7 +307,6 @@ class SSHPageState extends ConsumerState<SSHPage>
                 actions: _buildAppBarActions(),
               )
             : null,
-        backgroundColor: hasBg ? Colors.transparent : _terminalTheme.background,
         body: _buildBody(),
         bottomNavigationBar: isDesktop ? null : _buildBottom(),
       ),

--- a/lib/view/page/ssh/page/page.dart
+++ b/lib/view/page/ssh/page/page.dart
@@ -83,6 +83,28 @@ class SSHPage extends ConsumerStatefulWidget {
     page: SSHPage.new,
     path: '/ssh/page',
   );
+
+  /// Restorable route builder for navigation from server list.
+  /// Takes a server ID as argument and looks up the Spi from the store.
+  /// Note: tmux state restoration is handled at SSHTabPage level for tab-based navigation.
+  static Route<void> restorableRouteBuilder(
+    BuildContext context,
+    Object? arguments,
+  ) {
+    if (arguments is! String) {
+      return MaterialPageRoute(builder: (_) => const SizedBox.shrink());
+    }
+    final serverId = arguments;
+    final servers = Stores.server.fetch();
+    final spi = servers.where((s) => s.id == serverId).firstOrNull;
+    if (spi == null) {
+      // Server not found, return empty route
+      return MaterialPageRoute(builder: (_) => const SizedBox.shrink());
+    }
+    return MaterialPageRoute(
+      builder: (_) => SSHPage(args: SshPageArgs(spi: spi)),
+    );
+  }
 }
 
 const _horizonPadding = 7.0;

--- a/lib/view/page/ssh/page/virt_key.dart
+++ b/lib/view/page/ssh/page/virt_key.dart
@@ -135,6 +135,9 @@ extension _VirtKey on SSHPageState {
       case VirtualKeyFunc.sudoPassword:
         await _insertSudoPassword();
         break;
+      case VirtualKeyFunc.tmuxSwitch:
+        await _showTmuxSwitcher();
+        break;
     }
   }
 

--- a/lib/view/page/ssh/tab.dart
+++ b/lib/view/page/ssh/tab.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:math';
 
 import 'package:fl_lib/fl_lib.dart';
@@ -35,7 +36,70 @@ typedef _TabMap =
     >;
 
 class _SSHTabPageState extends ConsumerState<SSHTabPage>
-    with TickerProviderStateMixin, AutomaticKeepAliveClientMixin {
+    with TickerProviderStateMixin, AutomaticKeepAliveClientMixin, RestorationMixin {
+  // Restorable state for tab restoration
+  final RestorableString _restorableTabsState = RestorableString('');
+
+  @override
+  String get restorationId => 'ssh_tab_page';
+
+  @override
+  void restoreState(RestorationBucket? oldBucket, bool initialRestore) {
+    registerForRestoration(_restorableTabsState, 'tabs_state');
+
+    // Restore tabs after the first frame
+    if (initialRestore && _restorableTabsState.value.isNotEmpty) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _restoreTabs();
+      });
+    }
+  }
+
+  void _saveTabsState() {
+    final tabsData = <Map<String, dynamic>>[];
+    for (final entry in _tabMap.entries) {
+      if (entry.key == libL10n.add) continue; // Skip the add button
+
+      final sshPageState = entry.value.sshPageKey?.currentState;
+      final sshPage = entry.value.page as SSHPage;
+      final serverId = sshPageState?.widget.args.spi.id ?? sshPage.args.spi.id;
+      final tmuxSession =
+          sshPageState?.tmuxCurrentSession ?? sshPage.args.tmuxSession;
+      final tmuxWindow =
+          sshPageState?.tmuxCurrentWindow ?? sshPage.args.tmuxWindow;
+
+      tabsData.add({
+        'serverId': serverId,
+        'tmuxSession': tmuxSession,
+        'tmuxWindow': tmuxWindow,
+      });
+    }
+    _restorableTabsState.value = jsonEncode(tabsData);
+  }
+
+  void _restoreTabs() {
+    try {
+      final tabsData = jsonDecode(_restorableTabsState.value) as List;
+      for (final tabData in tabsData) {
+        final serverId = tabData['serverId'] as String;
+        final tmuxSession = tabData['tmuxSession'] as String?;
+        final tmuxWindow = tabData['tmuxWindow'] as int?;
+
+        // Find the server
+        final servers = Stores.server.fetch();
+        final spi = servers.where((s) => s.id == serverId).firstOrNull;
+        if (spi == null) {
+          continue;
+        }
+
+        // Add the tab with tmux state
+        _addTab(spi, tmuxSession: tmuxSession, tmuxWindow: tmuxWindow);
+      }
+    } catch (e, st) {
+      Loggers.app.warning('Failed to restore SSH tabs', e, st);
+    }
+  }
+
   late final _TabMap _tabMap = {
     libL10n.add: (
       page: _AddPage(
@@ -55,6 +119,7 @@ class _SSHTabPageState extends ConsumerState<SSHTabPage>
 
   @override
   void dispose() {
+    _restorableTabsState.dispose();
     final entries = _tabMap.values.toList(growable: false);
     _tabMap.clear();
     for (final entry in entries) {
@@ -190,6 +255,7 @@ extension on _SSHTabPageState {
 
     _tabRN.notify();
     _disposeTabEntryAfterFrame(removed);
+    _saveTabsState();
     if (_tabMap.isEmpty) {
       _fabVN.value = 0;
       return;
@@ -219,23 +285,8 @@ extension on _SSHTabPageState {
     }
   }
 
-  void _onTapInitCard(Spi spi) async {
-    final name = () {
-      final reg = RegExp('${spi.name}\\((\\d+)\\)');
-      final idxs = _tabMap.keys
-          .map((e) => reg.firstMatch(e))
-          .map((e) => e?.group(1))
-          .whereType<String>();
-      if (idxs.isEmpty) {
-        return _tabMap.keys.contains(spi.name) ? '${spi.name}(1)' : spi.name;
-      }
-      final biggest = idxs.reduce((a, b) => a.length > b.length ? a : b);
-      final biggestInt = int.tryParse(biggest);
-      if (biggestInt != null && biggestInt > 0) {
-        return '${spi.name}(${biggestInt + 1})';
-      }
-      return spi.name;
-    }();
+  Future<void> _addTab(Spi spi, {String? tmuxSession, int? tmuxWindow}) async {
+    final name = _generateTabName(spi);
     final key = GlobalKey<SSHPageState>(debugLabel: name);
     final focusNode = FocusNode();
     final visibleVN = ValueNotifier(false);
@@ -247,10 +298,13 @@ extension on _SSHTabPageState {
       },
       focusNode: focusNode,
       visibleListenable: visibleVN,
+      tmuxSession: tmuxSession,
+      tmuxWindow: tmuxWindow,
+      onTmuxStateChanged: _saveTabsState,
     );
     _tabMap[name] = (
       page: SSHPage(
-        key: key, // Keep it, or the Flutter will works unexpectedly
+        key: key,
         args: args,
       ),
       focus: focusNode,
@@ -259,10 +313,32 @@ extension on _SSHTabPageState {
     );
     _tabRN.notify();
     Stores.history.sshServerHistory.add(spi.id);
+    _saveTabsState();
     // Wait for the page to be built
     await Future.delayed(Durations.short3);
     final idx = _tabMap.keys.toList().indexOf(name);
     await _toPage(idx);
+  }
+
+  String _generateTabName(Spi spi) {
+      final reg = RegExp('${spi.name}\\((\\d+)\\)');
+      final idxs = _tabMap.keys
+          .map((e) => reg.firstMatch(e))
+          .map((e) => e?.group(1))
+          .whereType<String>();
+      if (idxs.isEmpty) {
+      return _tabMap.keys.contains(spi.name) ? '${spi.name}(1)' : spi.name;
+      }
+      final biggest = idxs.reduce((a, b) => a.length > b.length ? a : b);
+      final biggestInt = int.tryParse(biggest);
+      if (biggestInt != null && biggestInt > 0) {
+      return '${spi.name}(${biggestInt + 1})';
+      }
+      return spi.name;
+  }
+
+  void _onTapInitCard(Spi spi) async {
+    await _addTab(spi);
   }
 
   void _onLongPressInitCard(Spi spi) {

--- a/lib/view/widget/server_func_btns.dart
+++ b/lib/view/widget/server_func_btns.dart
@@ -184,8 +184,11 @@ extension ServerFuncBtnsActions on ServerFuncBtns {
 void _gotoSSH(Spi spi, BuildContext context) async {
   // run built-in ssh on macOS due to incompatibility
   if (isMobile || isMacOS) {
-    final args = SshPageArgs(spi: spi);
-    SSHPage.route.go(context, args);
+    Navigator.restorablePush(
+      context,
+      SSHPage.restorableRouteBuilder,
+      arguments: spi.id,
+    );
     return;
   }
 

--- a/lib/view/widget/tmux_session_selector.dart
+++ b/lib/view/widget/tmux_session_selector.dart
@@ -1,0 +1,376 @@
+import 'package:fl_lib/fl_lib.dart';
+import 'package:flutter/material.dart';
+import 'package:server_box/data/ssh/tmux/tmux_command_builder.dart';
+import 'package:server_box/data/ssh/tmux/tmux_session.dart';
+import 'package:server_box/data/ssh/tmux/tmux_session_info.dart';
+import 'package:server_box/data/ssh/tmux/tmux_window_info.dart';
+
+/// Dialog that allows the user to select a tmux session and window.
+final class TmuxSessionSelector extends StatefulWidget {
+  final List<TmuxSessionInfo> sessions;
+  final Future<TmuxSession> Function() tmuxSessionFactory;
+  final String defaultSessionName;
+  final String? initialSessionName;
+
+  const TmuxSessionSelector({
+    super.key,
+    required this.sessions,
+    required this.tmuxSessionFactory,
+    this.defaultSessionName = 'server_box',
+    this.initialSessionName,
+  });
+
+  @override
+  State<TmuxSessionSelector> createState() => _TmuxSessionSelectorState();
+}
+
+final class _TmuxSessionSelectorState extends State<TmuxSessionSelector> {
+  late final TextEditingController _newSessionCtrl;
+  TmuxSessionInfo? _selectedSession;
+  List<TmuxWindowInfo>? _windows;
+  bool _loadingWindows = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _newSessionCtrl = TextEditingController(text: widget.defaultSessionName);
+    final initialSessionName = widget.initialSessionName;
+    if (initialSessionName == null) {
+      return;
+    }
+
+    final initialSession = widget.sessions
+        .where((session) => session.name == initialSessionName)
+        .firstOrNull;
+    if (initialSession == null) return;
+
+    _selectedSession = initialSession;
+    _loadingWindows = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _loadWindowsForSession(initialSession);
+    });
+  }
+
+  @override
+  void dispose() {
+    _newSessionCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_selectedSession != null) {
+      return _buildWindowView();
+    }
+    return _buildSessionView();
+  }
+
+  Widget _buildSessionView() {
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxHeight: 400, maxWidth: 400),
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (widget.sessions.isNotEmpty) ...[
+              _buildSectionHeader('Existing Sessions'),
+              const SizedBox(height: 4),
+              ...widget.sessions.map(_buildSessionTile),
+              const Divider(height: 24),
+            ],
+            _buildSectionHeader('New Session'),
+            const SizedBox(height: 4),
+            _buildNewSessionInput(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildWindowView() {
+    final session = _selectedSession!;
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxHeight: 400, maxWidth: 400),
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4),
+              child: Row(
+                children: [
+                  IconButton(
+                    onPressed: () => setState(() {
+                      _selectedSession = null;
+                      _windows = null;
+                    }),
+                    icon: const Icon(Icons.arrow_back, size: 20),
+                    padding: EdgeInsets.zero,
+                    constraints: const BoxConstraints(),
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    session.name,
+                    style: const TextStyle(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Expanded(child: _buildSectionHeader('Windows')),
+                IconButton(
+                  onPressed: () => _createWindow(session.name),
+                  icon: const Icon(Icons.add, size: 20),
+                  padding: EdgeInsets.zero,
+                  constraints: const BoxConstraints(),
+                  tooltip: 'New window',
+                ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            if (_loadingWindows)
+              const Padding(
+                padding: EdgeInsets.all(16),
+                child: Center(child: CircularProgressIndicator(strokeWidth: 2)),
+              )
+            else if (_windows != null && _windows!.isNotEmpty)
+              ..._windows!.map((w) => _buildWindowTile(session.name, w))
+            else if (_windows != null)
+              const Padding(
+                padding: EdgeInsets.all(12),
+                child: Text('No windows found', style: TextStyle(fontSize: 13)),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSectionHeader(String title) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4),
+      child: Text(
+        title,
+        style: const TextStyle(fontSize: 13, fontWeight: FontWeight.w600),
+      ),
+    );
+  }
+
+  Widget _buildSessionTile(TmuxSessionInfo session) {
+    final timeParts = <String>[];
+    if (session.activity != null && session.activity!.isNotEmpty) {
+      timeParts.add('active: ${session.activity}');
+    }
+    if (session.lastAttached != null && session.lastAttached!.isNotEmpty) {
+      timeParts.add('attached: ${session.lastAttached}');
+    }
+    final timeLine = timeParts.isNotEmpty ? '\n${timeParts.join(' · ')}' : '';
+
+    return ListTile(
+      dense: true,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 8),
+      leading: Icon(
+        session.attached ? Icons.link : Icons.link_off,
+        size: 20,
+        color: session.attached ? Colors.green : null,
+      ),
+      title: Text(session.name),
+      subtitle: Text(
+        '${session.windows} window${session.windows == 1 ? '' : 's'}'
+        '${session.attached ? ' · attached' : ''}'
+        '$timeLine',
+        style: const TextStyle(fontSize: 12),
+      ),
+      trailing: const Icon(Icons.arrow_forward_ios, size: 14),
+      onTap: () => _onSessionTapped(session),
+    );
+  }
+
+  Future<void> _onSessionTapped(TmuxSessionInfo session) async {
+    setState(() {
+      _selectedSession = session;
+      _loadingWindows = true;
+      _windows = null;
+    });
+    await _loadWindowsForSession(session);
+  }
+
+  Future<void> _loadWindowsForSession(TmuxSessionInfo session) async {
+    try {
+      final windows = await _withTmuxSession(
+        (tmuxSession) => tmuxSession.listWindows(session.name),
+      );
+      if (!mounted) return;
+      setState(() {
+        _windows = windows;
+        _loadingWindows = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _windows = [];
+        _loadingWindows = false;
+      });
+    }
+  }
+  Widget _buildWindowTile(String sessionName, TmuxWindowInfo window) {
+    final subtitle = '${window.panes} pane${window.panes == 1 ? '' : 's'}'
+        '${window.active ? ' · active' : ''}'
+        '${window.activity != null && window.activity!.isNotEmpty ? '\n${window.activity}' : ''}';
+
+    final tile = ListTile(
+      dense: true,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 8),
+      leading: Icon(
+        window.active ? Icons.circle : Icons.circle_outlined,
+        size: 16,
+        color: window.active ? Colors.green : null,
+      ),
+      title: Text('${window.index}: ${window.name}'),
+      subtitle: Text(subtitle, style: const TextStyle(fontSize: 12)),
+      onTap: () {
+        context.pop(
+          TmuxAttachExisting(
+            sessionName: sessionName,
+            windowIndex: window.index,
+          ),
+        );
+      },
+    );
+
+    return Dismissible(
+      key: ValueKey('window_${sessionName}_${window.index}'),
+      direction: DismissDirection.endToStart,
+      background: Container(
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.only(right: 16),
+        color: Colors.red.withValues(alpha: 0.15),
+        child: const Icon(Icons.delete, color: Colors.red, size: 20),
+      ),
+      onDismissed: (_) => _killWindow(sessionName, window.index),
+      child: tile,
+    );
+  }
+
+  Future<T> _withTmuxSession<T>(
+    Future<T> Function(TmuxSession tmuxSession) action,
+  ) async {
+    final tmuxSession = await widget.tmuxSessionFactory();
+    try {
+      return await action(tmuxSession);
+    } finally {
+      await tmuxSession.dispose();
+    }
+  }
+
+  Future<void> _killWindow(String sessionName, int windowIndex) async {
+    if (!mounted) return;
+    setState(() {
+      _loadingWindows = true;
+    });
+    try {
+      final windows = await _withTmuxSession((tmuxSession) async {
+        final cmd = TmuxCommandBuilder.killWindow(sessionName, windowIndex);
+        await tmuxSession.runCommand(cmd);
+        return tmuxSession.listWindows(sessionName);
+      });
+      if (!mounted) return;
+      setState(() {
+        _windows = windows;
+        _loadingWindows = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _windows = [];
+        _loadingWindows = false;
+      });
+    }
+  }
+
+  Widget _buildNewSessionInput() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      child: Row(
+        children: [
+          Expanded(
+            child: Input(
+              controller: _newSessionCtrl,
+              hint: 'session name',
+              suggestion: false,
+              onSubmitted: (_) => _createNewSession(),
+            ),
+          ),
+          const SizedBox(width: 8),
+          IconButton.filled(
+            onPressed: _createNewSession,
+            icon: const Icon(Icons.add, size: 20),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _createNewSession() {
+    final name = _newSessionCtrl.text.trim();
+    if (name.isEmpty) return;
+    context.pop(TmuxAttachNew(sessionName: name));
+  }
+
+  Future<void> _createWindow(String sessionName) async {
+    if (!mounted) return;
+    setState(() {
+      _loadingWindows = true;
+    });
+    try {
+      final windows = await _withTmuxSession((tmuxSession) async {
+        await tmuxSession.runCommand(TmuxCommandBuilder.newWindow(sessionName));
+        return tmuxSession.listWindows(sessionName);
+      });
+      if (!mounted) return;
+      setState(() {
+        _windows = windows;
+        _loadingWindows = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _windows = [];
+        _loadingWindows = false;
+      });
+    }
+  }
+}
+
+/// Show the session/window selector with a "skip" option.
+Future<TmuxAttachChoice?> showTmuxSessionSelectorWithSkip(
+  BuildContext context, {
+  required List<TmuxSessionInfo> sessions,
+  required Future<TmuxSession> Function() tmuxSessionFactory,
+  String defaultSessionName = 'server_box',
+  String? initialSessionName,
+}) async {
+  return context.showRoundDialog<TmuxAttachChoice>(
+    title: 'tmux',
+    child: TmuxSessionSelector(
+      sessions: sessions,
+      tmuxSessionFactory: tmuxSessionFactory,
+      defaultSessionName: defaultSessionName,
+      initialSessionName: initialSessionName,
+    ),
+    actions: [
+      TextButton(
+        onPressed: () => context.pop(const TmuxAttachSkip()),
+        child: const Text('Skip'),
+      ),
+    ],
+  );
+}

--- a/test/tmux_command_builder_test.dart
+++ b/test/tmux_command_builder_test.dart
@@ -1,0 +1,110 @@
+import 'package:server_box/data/ssh/tmux/tmux_command_builder.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TmuxCommandBuilder', () {
+    test('escapeArg wraps in single quotes', () {
+      expect(TmuxCommandBuilder.escapeArg('main'), "'main'");
+    });
+
+    test('escapeArg escapes single quotes', () {
+      expect(TmuxCommandBuilder.escapeArg("it's"), "'it'\\''s'");
+    });
+
+    test('attachSession builds correct command', () {
+      expect(
+        TmuxCommandBuilder.attachSession('main'),
+        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' tmux attach-session -t 'main'",
+      );
+    });
+
+    test('attachSessionWindow builds correct command', () {
+      expect(
+        TmuxCommandBuilder.attachSessionWindow('main', 2),
+        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' tmux attach-session -t 'main:2'",
+      );
+    });
+
+    test('commands support custom tmux binary path', () {
+      const tmuxBin = '/home/linuxbrew/.linuxbrew/bin/tmux';
+      expect(
+        TmuxCommandBuilder.attachSession('main', tmuxBin: tmuxBin),
+        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' $tmuxBin attach-session -t 'main'",
+      );
+      expect(
+        TmuxCommandBuilder.attachSessionWindow('main', 2, tmuxBin: tmuxBin),
+        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' $tmuxBin attach-session -t 'main:2'",
+      );
+      expect(
+        TmuxCommandBuilder.newSessionOrAttach('server_box', tmuxBin: tmuxBin),
+        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' $tmuxBin new-session -A -s 'server_box'",
+      );
+    });
+
+    test('newSession builds correct command', () {
+      expect(
+        TmuxCommandBuilder.newSession('dev'),
+        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' tmux new-session -s 'dev'",
+      );
+    });
+
+    test('newSessionOrAttach builds correct command', () {
+      expect(
+        TmuxCommandBuilder.newSessionOrAttach('server_box'),
+        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' tmux new-session -A -s 'server_box'",
+      );
+    });
+
+    test('killSession builds correct command', () {
+      expect(
+        TmuxCommandBuilder.killSession('old'),
+        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' tmux kill-session -t 'old'",
+      );
+    });
+
+    test('listSessions is correct format string', () {
+      expect(
+        TmuxCommandBuilder.listSessionsCmd(),
+        contains('tmux list-sessions'),
+      );
+      expect(TmuxCommandBuilder.listSessionsCmd(), contains('#{session_name}'));
+      expect(
+        TmuxCommandBuilder.listSessionsCmd(),
+        contains('#{session_windows}'),
+      );
+    });
+
+    test('listClients uses client session and window fields', () {
+      expect(
+        TmuxCommandBuilder.listClients(),
+        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' tmux list-clients -F "
+        '"#{client_tty}|#{client_session}|#{window_index}|#{client_activity}"',
+      );
+    });
+
+    test('switchClient targets a specific client tty', () {
+      expect(
+        TmuxCommandBuilder.switchClient('/dev/pts/3', 'main:2'),
+        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' tmux switch-client -c '/dev/pts/3' -t 'main:2'",
+      );
+    });
+
+    test('checkTmux includes multiple paths', () {
+      expect(TmuxCommandBuilder.findTmux, contains('command -v tmux'));
+    });
+
+    test('attachSession handles special characters', () {
+      expect(
+        TmuxCommandBuilder.attachSession('my session'),
+        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' tmux attach-session -t 'my session'",
+      );
+    });
+
+    test('newSession handles special characters in name', () {
+      expect(
+        TmuxCommandBuilder.newSession("user's-work"),
+        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' tmux new-session -s 'user'\\''s-work'",
+      );
+    });
+  });
+}

--- a/test/tmux_launch_plan_test.dart
+++ b/test/tmux_launch_plan_test.dart
@@ -1,0 +1,81 @@
+import 'package:server_box/data/ssh/tmux/tmux_launch_plan.dart';
+import 'package:server_box/data/ssh/tmux/tmux_restore_state.dart';
+import 'package:server_box/data/ssh/tmux/tmux_session.dart';
+import 'package:server_box/data/ssh/tmux/tmux_session_info.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('buildRestoredTmuxLaunchPlan', () {
+    test('builds attach command for existing restored session', () {
+      final plan = buildRestoredTmuxLaunchPlan(
+        const TmuxRestoreState(sessionName: 'main', windowIndex: 2),
+        const [
+          TmuxSessionInfo(name: 'main', windows: 3, attached: true),
+        ],
+      );
+
+      expect(plan.shouldLaunchTmux, isTrue);
+      expect(
+        plan.command,
+        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' tmux attach-session -t 'main:2'",
+      );
+      expect(plan.sessionName, 'main');
+      expect(plan.windowIndex, 2);
+    });
+
+    test('returns none when restored session no longer exists', () {
+      final plan = buildRestoredTmuxLaunchPlan(
+        const TmuxRestoreState(sessionName: 'ghost'),
+        const [
+          TmuxSessionInfo(name: 'main', windows: 1, attached: false),
+        ],
+      );
+
+      expect(plan.shouldLaunchTmux, isFalse);
+      expect(plan.command, isNull);
+    });
+  });
+
+  group('buildChosenTmuxLaunchPlan', () {
+    test('uses attach-session for existing session choice', () {
+      final plan = buildChosenTmuxLaunchPlan(
+        const TmuxAttachExisting(sessionName: 'dev'),
+      );
+
+      expect(
+        plan.command,
+        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' tmux attach-session -t 'dev'",
+      );
+      expect(plan.sessionName, 'dev');
+      expect(plan.windowIndex, isNull);
+    });
+
+    test('uses new-session -A for auto/new session choice', () {
+      final plan = buildChosenTmuxLaunchPlan(
+        const TmuxAttachNew(sessionName: 'server_box'),
+      );
+
+      expect(
+        plan.command,
+        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' tmux new-session -A -s 'server_box'",
+      );
+      expect(plan.sessionName, 'server_box');
+      expect(plan.windowIndex, isNull);
+    });
+
+    test('uses custom tmux binary path', () {
+      const tmuxBin = '/home/linuxbrew/.linuxbrew/bin/tmux';
+      final plan = buildChosenTmuxLaunchPlan(
+        const TmuxAttachExisting(sessionName: 'codex', windowIndex: 0),
+        tmuxBin: tmuxBin,
+      );
+
+      expect(
+        plan.command,
+        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' $tmuxBin attach-session -t 'codex:0'",
+      );
+      expect(plan.sessionName, 'codex');
+      expect(plan.windowIndex, 0);
+    });
+  });
+}

--- a/test/tmux_restore_state_test.dart
+++ b/test/tmux_restore_state_test.dart
@@ -1,0 +1,38 @@
+import 'package:server_box/data/ssh/tmux/tmux_restore_state.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('resolveTmuxRestoreState', () {
+    test('prefers args state over restorable state', () {
+      final state = resolveTmuxRestoreState(
+        argsSession: 'restored-from-tab',
+        argsWindow: 3,
+        restorableSession: 'stale-page-state',
+        restorableWindow: 1,
+      );
+
+      expect(state.sessionName, 'restored-from-tab');
+      expect(state.windowIndex, 3);
+      expect(state.hasSession, isTrue);
+    });
+
+    test('falls back to restorable state when args are absent', () {
+      final state = resolveTmuxRestoreState(
+        restorableSession: 'page-bucket',
+        restorableWindow: 2,
+      );
+
+      expect(state.sessionName, 'page-bucket');
+      expect(state.windowIndex, 2);
+      expect(state.hasSession, isTrue);
+    });
+
+    test('drops window when no session exists', () {
+      final state = resolveTmuxRestoreState(restorableWindow: 7);
+
+      expect(state.sessionName, isNull);
+      expect(state.windowIndex, isNull);
+      expect(state.hasSession, isFalse);
+    });
+  });
+}

--- a/test/tmux_session_info_test.dart
+++ b/test/tmux_session_info_test.dart
@@ -1,0 +1,83 @@
+import 'package:server_box/data/ssh/tmux/tmux_session_info.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TmuxSessionInfo.tryParse', () {
+    test('parses full format line', () {
+      final info = TmuxSessionInfo.tryParse('main|3|1|2024-01-01|2024-01-02');
+      expect(info, isNotNull);
+      expect(info!.name, 'main');
+      expect(info.windows, 3);
+      expect(info.attached, true);
+      expect(info.createdAt, '2024-01-01');
+      expect(info.lastAttached, '2024-01-02');
+    });
+
+    test('parses unattached session', () {
+      final info = TmuxSessionInfo.tryParse('dev|1|0|2024-01-01|2024-01-02');
+      expect(info, isNotNull);
+      expect(info!.name, 'dev');
+      expect(info.windows, 1);
+      expect(info.attached, false);
+    });
+
+    test('parses minimal format (name only)', () {
+      final info = TmuxSessionInfo.tryParse('test');
+      expect(info, isNotNull);
+      expect(info!.name, 'test');
+      expect(info.windows, 0);
+      expect(info.attached, false);
+    });
+
+    test('returns null for empty line', () {
+      expect(TmuxSessionInfo.tryParse(''), isNull);
+    });
+
+    test('handles invalid window count gracefully', () {
+      final info = TmuxSessionInfo.tryParse('test|abc|0');
+      expect(info, isNotNull);
+      expect(info!.windows, 0);
+    });
+
+    test('displayName includes windows and attached status', () {
+      final attached = TmuxSessionInfo(
+        name: 'main',
+        windows: 3,
+        attached: true,
+      );
+      expect(attached.displayName, 'main · 3 windows · (attached)');
+
+      final detached = TmuxSessionInfo(
+        name: 'dev',
+        windows: 1,
+        attached: false,
+      );
+      expect(detached.displayName, 'dev · 1 window');
+    });
+
+    test('displayName handles zero windows', () {
+      final info = TmuxSessionInfo(
+        name: 'empty',
+        windows: 0,
+        attached: false,
+      );
+      expect(info.displayName, 'empty');
+    });
+
+    test('parses multiple sessions from list output', () {
+      const output = '''main|3|1|2024-01-01|2024-01-02
+dev|1|0|2024-01-01|2024-01-02
+work|5|0|2024-01-03|2024-01-04''';
+      final sessions = output
+          .split('\n')
+          .where((line) => line.trim().isNotEmpty)
+          .map(TmuxSessionInfo.tryParse)
+          .whereType<TmuxSessionInfo>()
+          .toList();
+      expect(sessions, hasLength(3));
+      expect(sessions[0].name, 'main');
+      expect(sessions[1].name, 'dev');
+      expect(sessions[2].name, 'work');
+    });
+  });
+}

--- a/test/tmux_session_scanner_test.dart
+++ b/test/tmux_session_scanner_test.dart
@@ -1,0 +1,105 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:server_box/data/ssh/persistent_shell.dart';
+import 'package:server_box/data/ssh/tmux/tmux_session_scanner.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TmuxSessionScanner', () {
+    test('listSessions resolves tmux binary before listing', () async {
+      final session = _FakePersistentShellSession(
+        responses: ['/opt/bin/tmux\n', 'main|2|1|created|attached|activity\n'],
+      );
+      final scanner = TmuxSessionScanner(
+        PersistentShell(null, sessionFactory: () async => session),
+      );
+
+      final sessions = await scanner.listSessions();
+
+      expect(sessions.single.name, 'main');
+      expect(session.writes.first, contains('command -v tmux'));
+      expect(session.writes.last, contains('/opt/bin/tmux list-sessions'));
+    });
+
+    test('listWindows resolves tmux binary before listing', () async {
+      final session = _FakePersistentShellSession(
+        responses: ['/opt/bin/tmux\n', '0|shell|1|1|activity\n'],
+      );
+      final scanner = TmuxSessionScanner(
+        PersistentShell(null, sessionFactory: () async => session),
+      );
+
+      final windows = await scanner.listWindows('main');
+
+      expect(windows.single.index, 0);
+      expect(session.writes.first, contains('command -v tmux'));
+      expect(
+        session.writes.last,
+        contains("/opt/bin/tmux list-windows -t 'main'"),
+      );
+    });
+  });
+}
+
+final class _FakePersistentShellSession implements PersistentShellSession {
+  final stdoutController = StreamController<Uint8List>();
+  final stderrController = StreamController<Uint8List>();
+  final List<String> responses;
+  final writes = <String>[];
+  int responseIndex = 0;
+
+  _FakePersistentShellSession({required this.responses});
+
+  @override
+  StreamSink<Uint8List> get stdin => _FakeSink((data) {
+    writes.add(utf8.decode(data));
+    stdoutController.add(utf8.encode(_nextResponse()));
+  });
+
+  @override
+  Stream<Uint8List> get stdout => stdoutController.stream;
+
+  @override
+  Stream<Uint8List> get stderr => stderrController.stream;
+
+  @override
+  void close() {
+    unawaited(stdoutController.close());
+    unawaited(stderrController.close());
+  }
+
+  String _nextResponse() {
+    final response = responses[responseIndex++];
+    final commandId = RegExp(
+      r'__SERVER_BOX_DONE__(\d+):%s',
+    ).firstMatch(writes.last)?.group(1);
+    return '$response\n__SERVER_BOX_DONE__$commandId:0\n';
+  }
+}
+
+final class _FakeSink implements StreamSink<Uint8List> {
+  final void Function(Uint8List data) _onAdd;
+
+  _FakeSink(this._onAdd);
+
+  @override
+  void add(Uint8List data) => _onAdd(data);
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) {}
+
+  @override
+  Future<void> addStream(Stream<Uint8List> stream) async {
+    await for (final chunk in stream) {
+      add(chunk);
+    }
+  }
+
+  @override
+  Future<void> close() async {}
+
+  @override
+  Future<void> get done async {}
+}


### PR DESCRIPTION
Bring native tmux support to ServerBox so developers can seamlessly
switch between SSH sessions, persist terminal state, and scroll through
tmux output — all from a phone. Essential for vibe coding on the go.

> [!IMPORTANT]
> Depends on lollipopkit/xterm.dart#10 — should be merged first.
> That PR fixes touch-scroll forwarding in alt-buffer / mouse-report
> mode, which is required for tmux scrolling on mobile.

### Tmux session switching
- Auto-detect tmux on connect and attach to existing sessions
- Session/window selector dialog with two-step flow, swipe-to-delete,
  and inline window creation — all via SSH channel
- `VirtKey.tmux` in virtual keyboard bar for one-tap switching
- SSH settings: auto-attach toggle, selector on connect, default session

### State restoration
- `RestorationMixin` + `RestorableInt` for home tab index
- Serialize SSH tab state (server ID, tmux session/window) as JSON
  via `RestorableString` in `SSHTabPage`
- `restorableRouteBuilder` + `Navigator.restorablePush` for
  state-restorable navigation
- Refactor `_onTapInitCard` into `_addTab` / `_generateTabName`
  for reuse during restoration

### Misc
- Update xterm submodule (picks up touch-scroll fix from lollipopkit/xterm.dart#10)

<img width="582" height="1280" alt="image" src="https://github.com/user-attachments/assets/371a4e14-9aa5-4667-a717-697b2bc8a01f" />

Signed-off-by: yuguorui <yuguorui@pku.edu.cn>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full tmux integration: discover/manage sessions & windows, attach/create/kill, client switching, and safe command generation
  * TMUX auto-attach flow with session selector UI and persistent restore of session/window on connect
  * New settings: enable auto-attach, show selector, default session name
  * Virtual key to open tmux switcher; SSH tabs, SSH page, and Home now persist/restore tmux & tab state; app state restoration enabled

* **Tests**
  * Added unit and UI tests covering tmux command generation, launch plans, restore logic, parsers, scanner, and selector UI
<!-- end of auto-generated comment: release notes by coderabbit.ai -->