### PR TITLE
Use latest release build number for test builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,16 @@ jobs:
           submodules: recursive
           persist-credentials: false
           fetch-depth: 0
+      - name: Get last release version
+        id: last_release
+        shell: bash
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 --match 'v1.0.*' 2>/dev/null || echo "")
+          if [ -n "$LAST_TAG" ]; then
+            echo "version=${LAST_TAG#v1.0.}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=0" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
@@ -49,6 +59,10 @@ jobs:
           scripts/release/patch-jni-build-id.sh
       - name: Build
         run: dart run fl_build -bp -p android
+      - name: Override version for test build
+        if: inputs.release != true && github.ref_type != 'tag'
+        shell: bash
+        run: echo "BUILD_NUMBER=${{ steps.last_release.outputs.version }}" >> "$GITHUB_ENV"
       - name: Rename
         shell: bash
         run: |
@@ -98,6 +112,16 @@ jobs:
           submodules: recursive
           persist-credentials: false
           fetch-depth: 0
+      - name: Get last release version
+        id: last_release
+        shell: bash
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 --match 'v1.0.*' 2>/dev/null || echo "")
+          if [ -n "$LAST_TAG" ]; then
+            echo "version=${LAST_TAG#v1.0.}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=0" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
@@ -110,6 +134,10 @@ jobs:
           sudo apt install -y libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libunwind-dev libsecret-1-dev
       - name: Build
         run: dart run fl_build -bp -p linux
+      - name: Override version for test build
+        if: inputs.release != true && github.ref_type != 'tag'
+        shell: bash
+        run: echo "BUILD_NUMBER=${{ steps.last_release.outputs.version }}" >> "$GITHUB_ENV"
       - name: Rename
         shell: bash
         run: |
@@ -149,6 +177,16 @@ jobs:
           submodules: recursive
           persist-credentials: false
           fetch-depth: 0
+      - name: Get last release version
+        id: last_release
+        shell: bash
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 --match 'v1.0.*' 2>/dev/null || echo "")
+          if [ -n "$LAST_TAG" ]; then
+            echo "version=${LAST_TAG#v1.0.}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=0" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install Flutter
         uses: subosito/flutter-action@v2
         with:
@@ -156,6 +194,10 @@ jobs:
           flutter-version: "3.44.1"
       - name: Build
         run: dart run fl_build -bp -p windows
+      - name: Override version for test build
+        if: inputs.release != true && github.ref_type != 'tag'
+        shell: bash
+        run: echo "BUILD_NUMBER=${{ steps.last_release.outputs.version }}" >> "$GITHUB_ENV"
       - name: Rename
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,12 @@ jobs:
         run: |
           LAST_TAG=$(git describe --tags --abbrev=0 --match 'v1.0.*' 2>/dev/null || echo "")
           if [ -n "$LAST_TAG" ]; then
-            echo "version=${LAST_TAG#v1.0.}" >> "$GITHUB_OUTPUT"
+            VERSION="${LAST_TAG#v1.0.}"
+            if [ -n "$VERSION" ]; then
+              echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            else
+              echo "version=0" >> "$GITHUB_OUTPUT"
+            fi
           else
             echo "version=0" >> "$GITHUB_OUTPUT"
           fi
@@ -118,7 +123,12 @@ jobs:
         run: |
           LAST_TAG=$(git describe --tags --abbrev=0 --match 'v1.0.*' 2>/dev/null || echo "")
           if [ -n "$LAST_TAG" ]; then
-            echo "version=${LAST_TAG#v1.0.}" >> "$GITHUB_OUTPUT"
+            VERSION="${LAST_TAG#v1.0.}"
+            if [ -n "$VERSION" ]; then
+              echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            else
+              echo "version=0" >> "$GITHUB_OUTPUT"
+            fi
           else
             echo "version=0" >> "$GITHUB_OUTPUT"
           fi
@@ -183,7 +193,12 @@ jobs:
         run: |
           LAST_TAG=$(git describe --tags --abbrev=0 --match 'v1.0.*' 2>/dev/null || echo "")
           if [ -n "$LAST_TAG" ]; then
-            echo "version=${LAST_TAG#v1.0.}" >> "$GITHUB_OUTPUT"
+            VERSION="${LAST_TAG#v1.0.}"
+            if [ -n "$VERSION" ]; then
+              echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            else
+              echo "version=0" >> "$GITHUB_OUTPUT"
+            fi
           else
             echo "version=0" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
So that test builds can be easily upgrded to next release or rolled back to current release without breaking versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the build workflow to compute the previous release version and apply it to test (non-release, non-tag) builds for more consistent version numbering across Android, Linux, and Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->