### PR TITLE
Fix unit incorrection when parsing through `df -k`

### DIFF
--- a/lib/data/model/server/disk.dart
+++ b/lib/data/model/server/disk.dart
@@ -277,9 +277,9 @@ class Disk with EquatableMixin {
             path: fs,
             mount: mount,
             usedPercent: int.parse(vals[4].replaceFirst('%', '')),
-            used: BigInt.parse(vals[2]) ~/ BigInt.from(1024),
-            size: BigInt.parse(vals[1]) ~/ BigInt.from(1024),
-            avail: BigInt.parse(vals[3]) ~/ BigInt.from(1024),
+            used: BigInt.parse(vals[2]),
+            size: BigInt.parse(vals[1]),
+            avail: BigInt.parse(vals[3]),
           ),
         );
       } catch (e) {

--- a/lib/data/res/github_id.dart
+++ b/lib/data/res/github_id.dart
@@ -179,7 +179,8 @@ abstract final class GithubIds {
     'Muska-Ami',
     'wu4339',
     'shengroubao',
-    'nuclear06'
+    'nuclear06',
+    'shen-lan'
   };
 }
 

--- a/test/disk_test.dart
+++ b/test/disk_test.dart
@@ -136,22 +136,33 @@ void main() {
       expect(rootFs.usedPercent, 47);
       expect(
         rootFs.size,
-        BigInt.from(40910528 ~/ 1024),
-      ); // df -k output divided by 1024 = MB
-      expect(rootFs.used, BigInt.from(18067948 ~/ 1024));
-      expect(rootFs.avail, BigInt.from(20951380 ~/ 1024));
+        BigInt.from(40910528),
+      ); // df -k output is already in 1K blocks.
+      expect(rootFs.used, BigInt.from(18067948));
+      expect(rootFs.avail, BigInt.from(20951380));
 
       // Verify boot/efi filesystem
       final efiFs = disks.firstWhere((disk) => disk.mount == '/boot/efi');
       expect(efiFs.path, '/dev/vda2');
       expect(efiFs.usedPercent, 7);
-      expect(efiFs.size, BigInt.from(192559 ~/ 1024));
+      expect(efiFs.size, BigInt.from(192559));
 
       // Verify udev filesystem is included (virtual filesystem)
       final udevFs = disks.firstWhere((disk) => disk.path == 'udev');
       expect(udevFs.mount, '/dev');
       expect(udevFs.usedPercent, 0);
-      expect(udevFs.size, BigInt.from(864088 ~/ 1024));
+      expect(udevFs.size, BigInt.from(864088));
+    });
+
+    test('parse ImmortalWrt df -k output without shrinking units', () {
+      final disks = Disk.parse(_immortalWrtDfOutput);
+      final dataDisk = disks.firstWhere((disk) => disk.mount == '/mnt/sda');
+
+      expect(dataDisk.path, '/dev/sda');
+      expect(dataDisk.size, BigInt.from(468851544));
+      expect(dataDisk.used, BigInt.from(465106484));
+      expect(dataDisk.avail, BigInt.from(1960492));
+      expect(dataDisk.usedPercent, 100);
     });
 
     test('handle empty input gracefully', () {
@@ -524,6 +535,19 @@ tmpfs             883612        0    883612   0% /dev/shm
 tmpfs               5120        0      5120   0% /run/lock
 /dev/vda2         192559    11807    180752   7% /boot/efi
 tmpfs             176720      104    176616   1% /run/user/1000
+''';
+
+const _immortalWrtDfOutput = '''
+Filesystem           1K-blocks      Used Available Use% Mounted on
+/dev/root                 9984      9984         0 100% /rom
+tmpfs                  3989112      3876   3985236   0% /tmp
+/dev/nvme0n1p4         5335040   4570160    315616  94% /overlay
+overlayfs:/overlay     5335040   4570160    315616  94% /
+/dev/nvme0n1p1           32686      8514     24172  26% /boot
+/dev/nvme0n1p1           32686      8514     24172  26% /boot
+tmpfs                      512         0       512   0% /dev
+/dev/sda             468851544 465106484   1960492 100% /mnt/sda
+overlayfs:/overlay     5335040   4570160    315616  94% /opt
 ''';
 
 // Test data for edge cases

--- a/test/disk_test.dart
+++ b/test/disk_test.dart
@@ -165,6 +165,22 @@ void main() {
       expect(dataDisk.usedPercent, 100);
     });
 
+    test('parse Debian df -k output preserves KB values', () {
+      final disks = Disk.parse(_debianDfOutput);
+      final rootFs = disks.firstWhere((disk) => disk.mount == '/');
+
+      expect(rootFs.path, '/dev/sda2');
+      expect(rootFs.usedPercent, 36);
+      expect(rootFs.size, BigInt.from(474286144));
+      expect(rootFs.used, BigInt.from(158343564));
+      expect(rootFs.avail, BigInt.from(291776744));
+
+      final efiFs = disks.firstWhere((disk) => disk.mount == '/boot/efi');
+      expect(efiFs.path, '/dev/sda1');
+      expect(efiFs.usedPercent, 1);
+      expect(efiFs.size, BigInt.from(997432));
+    });
+
     test('handle empty input gracefully', () {
       final disks = Disk.parse('');
       expect(disks, isEmpty);
@@ -548,6 +564,23 @@ overlayfs:/overlay     5335040   4570160    315616  94% /
 tmpfs                      512         0       512   0% /dev
 /dev/sda             468851544 465106484   1960492 100% /mnt/sda
 overlayfs:/overlay     5335040   4570160    315616  94% /opt
+''';
+
+const _debianDfOutput = '''
+Filesystem     1K-blocks      Used Available Use% Mounted on
+udev             3879172         0   3879172   0% /dev
+tmpfs             800412      1792    798620   1% /run
+/dev/sda2      474286144 158343564 291776744  36% /
+tmpfs            4002060         0   4002060   0% /dev/shm
+efivarfs             148        57        87  40% /sys/firmware/efi/efivars
+tmpfs               5120        16      5104   1% /run/lock
+tmpfs            4002060         4   4002056   1% /tmp
+/dev/sda1         997432      8984    988448   1% /boot/efi
+tmpfs             800412        88    800324   1% /run/user/1000
+tmpfs                100         0       100   0% /var/lib/incus/shmounts
+tmpfs                100         0       100   0% /var/lib/incus/guestapi
+tmpfs               1024         0      1024   0% /run/credentials/systemd-journald.service
+tmpfs             800412        72    800340   1% /run/user/1001
 ''';
 
 // Test data for edge cases


### PR DESCRIPTION
Resolve #1200.

Also add issuer of #1200 to participants list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected disk space value calculations to report accurate storage metrics.

* **Chores**
  * Added new project contributor to credits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->