### PR TITLE
fix(pve): recognize HttpException as connection failure

### DIFF
--- a/lib/data/provider/pve.dart
+++ b/lib/data/provider/pve.dart
@@ -448,7 +448,10 @@ class PveNotifier extends _$PveNotifier {
   }
 
   bool _isConnectionFailure(Object e) {
-    if (e is SocketException || e is HandshakeException || e is SSHStateError) {
+    if (e is SocketException ||
+        e is HandshakeException ||
+        e is SSHStateError ||
+        e is HttpException) {
       return true;
     }
     if (e is DioException) {


### PR DESCRIPTION
Follow-up to #1203. The issuer's new error is a different failure mode:

`
DioException [unknown]: null
HttpException: Connection closed before full header was received
`

This happens when the SSH tunnel drops mid-request (TCP connected, but connection closed before HTTP response headers arrive). Unlike the previous SocketException/HandshakeException, this was not recognized by _isConnectionFailure, so the PVE session was not closed and the refresh timer kept hitting the same dead tunnel.

Fix: add HttpException to _isConnectionFailure check.

#1201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for PVE-related operations by recognizing additional connection-related failures.
  * Some HTTP errors are now correctly classified as network issues, helping surface more accurate connection error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->