### PR TITLE
fix: security hardening, memory leaks, and dead code cleanup

### DIFF
--- a/lib/data/model/app/menu/container.dart
+++ b/lib/data/model/app/menu/container.dart
@@ -7,9 +7,7 @@ enum ContainerMenu {
   restart,
   rm,
   logs,
-  terminal
-  //stats,
-  ;
+  terminal;
 
   static List<ContainerMenu> items(bool running) {
     if (running) {
@@ -19,7 +17,6 @@ enum ContainerMenu {
         rm,
         logs,
         terminal,
-        //stats,
       ];
     }
     return [start, rm, logs];
@@ -32,7 +29,6 @@ enum ContainerMenu {
     ContainerMenu.rm => Icons.delete,
     ContainerMenu.logs => Icons.logo_dev,
     ContainerMenu.terminal => Icons.terminal,
-    // DockerMenuType.stats => Icons.bar_chart,
   };
 
   String get toStr => switch (this) {
@@ -42,6 +38,5 @@ enum ContainerMenu {
     ContainerMenu.rm => libL10n.delete,
     ContainerMenu.logs => libL10n.log,
     ContainerMenu.terminal => libL10n.terminal,
-    // DockerMenuType.stats => s.stats,
   };
 }

--- a/lib/data/provider/pve.dart
+++ b/lib/data/provider/pve.dart
@@ -245,7 +245,7 @@ class PveNotifier extends _$PveNotifier {
       return SecureSocket.startConnect(
         'localhost',
         _localPort,
-        onBadCertificate: (_) => true,
+        onBadCertificate: _ignoreCert ? (_) => true : null,
       );
     } else {
       return Socket.startConnect('localhost', _localPort);

--- a/lib/data/provider/pve.dart
+++ b/lib/data/provider/pve.dart
@@ -242,11 +242,15 @@ class PveNotifier extends _$PveNotifier {
       throw PveErr(type: PveErrType.net, message: l10n.pveServerClientMissing);
     }
     if (url.isScheme('https')) {
-      return SecureSocket.startConnect(
-        'localhost',
-        _localPort,
-        onBadCertificate: _ignoreCert ? (_) => true : null,
+      final task = await Socket.startConnect('localhost', _localPort);
+      final secureSocket = task.socket.then(
+        (socket) => SecureSocket.secure(
+          socket,
+          host: url.host,
+          onBadCertificate: _ignoreCert ? (_) => true : null,
+        ),
       );
+      return ConnectionTask.fromSocket(secureSocket, task.cancel);
     } else {
       return Socket.startConnect('localhost', _localPort);
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: avoid_print
-
 import 'dart:async';
 
 import 'package:computer/computer.dart';
@@ -34,7 +32,7 @@ Future<void> _runInZone(Future<void> Function() body) async {
 
   await runZonedGuarded(
     body,
-    (e, s) => print('[ZONE] $e\n$s'),
+    (e, s) => Loggers.app.warning('Zone error', e, s),
     zoneSpecification: zoneSpec,
   );
 }
@@ -71,11 +69,9 @@ Future<void> _initData() async {
 }
 
 void _setupDebug() {
-  Logger.root.level = Level.ALL;
+  Logger.root.level = Level.WARNING;
   Logger.root.onRecord.listen((record) {
     DebugProvider.addLog(record);
-    if (record.error != null) print(record.error);
-    if (record.stackTrace != null) print(record.stackTrace);
   });
 }
 

--- a/lib/view/page/backup.dart
+++ b/lib/view/page/backup.dart
@@ -144,12 +144,16 @@ final class _BackupPageState extends ConsumerState<BackupPage>
       final pwd = controller.text.trim();
       if (pwd.isEmpty) {
         context.showSnackBar(libL10n.empty);
+        controller.dispose();
+        node.dispose();
         return;
       }
       await SecureStoreProps.bakPwd.write(pwd);
       context.showSnackBar(l10n.backupPasswordSet);
       setState(() {});
     }
+    controller.dispose();
+    node.dispose();
   }
 
   Widget get _buildTip {
@@ -718,6 +722,9 @@ extension on _BackupPageState {
         context.showErrDialog(e, s, 'Gist');
       }
     }
+    tokenCtrl.dispose();
+    gistIdCtrl.dispose();
+    nodeToken.dispose();
   }
 
   Future<void> _onTapWebdavSetting(BuildContext context) async {
@@ -777,6 +784,11 @@ extension on _BackupPageState {
         context.showErrDialog(e, s, 'Webdav');
       }
     }
+    url.dispose();
+    user.dispose();
+    pwd.dispose();
+    nodeUser.dispose();
+    nodePwd.dispose();
   }
 
   void _onBulkImportServers(BuildContext context) async {

--- a/lib/view/page/container/actions.dart
+++ b/lib/view/page/container/actions.dart
@@ -73,6 +73,9 @@ extension on _ContainerPageState {
         },
       ).toList,
     );
+    imageCtrl.dispose();
+    nameCtrl.dispose();
+    argsCtrl.dispose();
   }
 
   Future<void> _showPruneDialog({

--- a/lib/view/page/container/container.dart
+++ b/lib/view/page/container/container.dart
@@ -39,9 +39,9 @@ class _ContainerPageState extends ConsumerState<ContainerPage> {
 
   @override
   void dispose() {
-    super.dispose();
     _autoRefreshTimer?.cancel();
     _textController.dispose();
+    super.dispose();
   }
 
   @override

--- a/lib/view/page/home.dart
+++ b/lib/view/page/home.dart
@@ -266,8 +266,6 @@ class _HomePageState extends ConsumerState<HomePage>
     }
     _goAuth();
 
-    //_reqNotiPerm();
-
     if (Stores.setting.autoCheckAppUpdate.fetch()) {
       AppUpdateIface.doUpdate(
         build: BuildData.build,

--- a/lib/view/page/process.dart
+++ b/lib/view/page/process.dart
@@ -40,8 +40,8 @@ class _ProcessPageState extends ConsumerState<ProcessPage> {
 
   @override
   void dispose() {
-    super.dispose();
     _timer?.cancel();
+    super.dispose();
   }
 
   @override

--- a/lib/view/page/server/edit/edit.dart
+++ b/lib/view/page/server/edit/edit.dart
@@ -94,7 +94,6 @@ class _ServerEditPageState extends ConsumerState<ServerEditPage>
 
   @override
   void dispose() {
-    super.dispose();
     _nameController.dispose();
     _ipController.dispose();
     _altUrlController.dispose();
@@ -130,6 +129,7 @@ class _ServerEditPageState extends ConsumerState<ServerEditPage>
     _systemType.dispose();
     _disabledCmdTypes.dispose();
     _hasStoredSudoPassword.dispose();
+    super.dispose();
   }
 
   @override

--- a/lib/view/page/server/tab/tab.dart
+++ b/lib/view/page/server/tab/tab.dart
@@ -64,13 +64,13 @@ class _ServerPageState extends ConsumerState<ServerPage>
 
   @override
   void dispose() {
-    super.dispose();
     _timer?.cancel();
     _scrollController.dispose();
     _autoHideCtrl.dispose();
     _tag.dispose();
     _tags.dispose();
     _offsetNotifier.dispose();
+    super.dispose();
   }
 
   @override

--- a/lib/view/page/setting/entry.dart
+++ b/lib/view/page/setting/entry.dart
@@ -69,8 +69,8 @@ class _SettingsPageState extends ConsumerState<SettingsPage>
 
   @override
   void dispose() {
-    super.dispose();
     _tabCtrl.dispose();
+    super.dispose();
   }
 
   @override
@@ -148,6 +148,15 @@ final class _AppSettingsPageState extends ConsumerState<AppSettingsPage> {
   late final _serverLogoCtrl = TextEditingController(
     text: _setting.serverLogoUrl.fetch(),
   );
+
+  @override
+  void dispose() {
+    _sshOpacityCtrl.dispose();
+    _sshBlurCtrl.dispose();
+    _textScalerCtrl.dispose();
+    _serverLogoCtrl.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/view/page/ssh/page/init.dart
+++ b/lib/view/page/ssh/page/init.dart
@@ -221,7 +221,6 @@ extension _Init on SSHPageState {
         .listen(
           _queueTerminalOutput,
           onError: (Object error, StackTrace stack) {
-            // _terminal.write('Stream error: $error\n');
             Loggers.root.warning('Error in SSH stream', error, stack);
           },
           cancelOnError: false,

--- a/lib/view/page/ssh/tab.dart
+++ b/lib/view/page/ssh/tab.dart
@@ -125,11 +125,11 @@ class _SSHTabPageState extends ConsumerState<SSHTabPage>
     for (final entry in entries) {
       _disposeTabEntry(entry);
     }
-    super.dispose();
     _pageCtrl.dispose();
     _tabRN.dispose();
     _fabVN.dispose();
     _sortVersionVN.dispose();
+    super.dispose();
   }
 
   @override


### PR DESCRIPTION
## Changes

### Security (S2)
- Set Logger level to WARNING and remove print() calls in production (main.dart)
- Fix PVE onBadCertificate to respect ignoreCert flag (pve.dart)

### Memory Leaks (P1/P2)
- Fix super.dispose() call order in 6 files — must be called last
- Add missing dispose() for 4 TextEditingControllers in _AppSettingsPageState
- Add dispose() for dialog controllers in backup page (3 methods) and container page (1 method)

### Dead Code (P4)
- Remove commented-out //stats enum remnants in container.dart
- Remove stale //_reqNotiPerm() comment in home.dart
- Remove commented-out debug line in ssh/page/init.dart

## Testing
- Manual testing passed for all changes
- dart analyze reports no issues on modified files
- No compatibility or data format changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented memory leaks and cleanup issues by disposing timers, controllers, and focus nodes in the correct order across multiple screens.
  * Fixed HTTPS/TLS handling to respect the certificate-ignore setting during secure connections.
  * Reduced noisy console output by routing zone and debug errors through the app’s logger while keeping warnings visible.
* **Style**
  * Removed an unused “stats” container action mapping (icon/label) from the container options list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->