### PR TITLE
Fix SFTP download progress and throughput

### DIFF
--- a/lib/data/model/sftp/req.dart
+++ b/lib/data/model/sftp/req.dart
@@ -12,9 +12,15 @@ class SftpReq {
   Map<String, String>? privateKeysByKeyId;
   Map<String, String>? knownHostFingerprints;
   late final int timeoutSeconds;
+  late final int progressUpdateIntervalSeconds;
 
   SftpReq(this.spi, this.remotePath, this.localPath, this.type) {
     timeoutSeconds = Stores.setting.timeout.fetch();
+    progressUpdateIntervalSeconds =
+        normalizeServerStatusRefreshSeconds(
+          Stores.setting.serverStatusUpdateInterval.fetch(),
+        ) ??
+        Defaults.updateInterval;
     privateKeysByKeyId = {};
 
     final keyId = spi.keyId;
@@ -71,6 +77,16 @@ class SftpReq {
 
 enum SftpReqType { download, upload }
 
+class SftpTransferProgress {
+  final double percent;
+  final int transferredBytes;
+
+  const SftpTransferProgress({
+    required this.percent,
+    required this.transferredBytes,
+  });
+}
+
 class SftpReqStatus {
   final int id;
   final SftpReq req;
@@ -82,6 +98,10 @@ class SftpReqStatus {
 
   // status of the download
   double? progress;
+  double? speedBytesPerSecond;
+  int? transferredBytes;
+  DateTime? _speedSampleTime;
+  int _speedSampleBytes = 0;
   SftpWorkerStatus? status;
   int? size;
   Exception? error;
@@ -118,6 +138,11 @@ class SftpReqStatus {
       case final double val:
         progress = val;
         break;
+      case final SftpTransferProgress val:
+        progress = val.percent;
+        transferredBytes = val.transferredBytes;
+        _initSpeedSampleIfNeeded(val.transferredBytes);
+        break;
       case final int val:
         size = val;
         break;
@@ -131,6 +156,36 @@ class SftpReqStatus {
     }
     notifyListeners();
     if (shouldDispose) dispose();
+  }
+
+  void _initSpeedSampleIfNeeded(int transferredBytes) {
+    if (_speedSampleTime != null) return;
+    _speedSampleTime = DateTime.now();
+    _speedSampleBytes = transferredBytes;
+  }
+
+  bool refreshSpeed([DateTime? now]) {
+    if (status != SftpWorkerStatus.loading) return false;
+
+    final sampleTime = now ?? DateTime.now();
+    final sampleBytes = transferredBytes ?? 0;
+    final lastSampleTime = _speedSampleTime;
+    if (lastSampleTime == null) {
+      _speedSampleTime = sampleTime;
+      _speedSampleBytes = sampleBytes;
+      return false;
+    }
+
+    final elapsedMs = sampleTime.difference(lastSampleTime).inMilliseconds;
+    if (elapsedMs <= 0) return false;
+
+    final speed = (sampleBytes - _speedSampleBytes) * 1000 / elapsedMs;
+    _speedSampleTime = sampleTime;
+    _speedSampleBytes = sampleBytes;
+
+    if (speedBytesPerSecond == speed) return false;
+    speedBytesPerSecond = speed;
+    return true;
   }
 }
 

--- a/lib/data/model/sftp/worker.dart
+++ b/lib/data/model/sftp/worker.dart
@@ -7,17 +7,21 @@ import 'package:dartssh2/dartssh2.dart';
 import 'package:easy_isolate/easy_isolate.dart';
 import 'package:fl_lib/fl_lib.dart';
 import 'package:server_box/core/utils/jump_chain.dart';
+import 'package:server_box/core/utils/refresh_interval.dart';
 import 'package:server_box/core/utils/server.dart';
 import 'package:server_box/data/model/server/server_private_info.dart';
+import 'package:server_box/data/res/default.dart';
 import 'package:server_box/data/res/store.dart';
 
 part 'req.dart';
 
 const _sftpTransferChunkSize = 32 * 1024;
 
-const _sftpDownloadChunkSize = 16 * 1024;
+const _sftpDownloadChunkSize = 32 * 1024;
 
-const _sftpDownloadMaxPendingRequests = 1;
+const _sftpDownloadMaxPendingRequests = 64;
+
+const _sftpDownloadMinIdleTimeout = Duration(seconds: 60);
 
 const _sftpUploadMaxBytesOnTheWire = _sftpTransferChunkSize * 64;
 
@@ -39,6 +43,14 @@ Future<T> _withSftpPrepareTimeout<T>(
     Loggers.app.warning(error.message, e, s);
     throw error;
   }
+}
+
+Duration _sftpDownloadIdleTimeout(SftpReq req) {
+  final seconds = req.timeoutSeconds;
+  final timeout = Duration(seconds: seconds <= 0 ? 60 : seconds);
+  return timeout < _sftpDownloadMinIdleTimeout
+      ? _sftpDownloadMinIdleTimeout
+      : timeout;
 }
 
 class SftpWorker {
@@ -157,60 +169,89 @@ Future<void> _download(
       'chunk=$_sftpDownloadChunkSize, pending=$_sftpDownloadMaxPendingRequests',
     );
 
-    var lastProgress = -1.0;
-    final localFile = File(req.localPath).openWrite(mode: FileMode.write);
+    final localFile = await File(req.localPath).open(mode: FileMode.write);
 
     try {
       const segmentSize = 5 * 1024 * 1024; // 5MB per segment
+      final progressUpdateInterval = Duration(
+        seconds: req.progressUpdateIntervalSeconds,
+      );
+      final progressUpdateIntervalMs = progressUpdateInterval.inMilliseconds;
       var offset = 0;
       var totalBytes = 0;
       var chunkCount = 0;
+      var lastProgressUpdateMs = -progressUpdateIntervalMs;
       final dlWatch = Stopwatch()..start();
       Loggers.app.info('SFTP download start size=$size');
 
-      final timeout = Duration(
-        seconds: req.timeoutSeconds <= 0 ? 60 : req.timeoutSeconds,
-      );
+      final timeout = _sftpDownloadIdleTimeout(req);
 
       while (offset < size) {
         final remaining = size - offset;
         final length = remaining < segmentSize ? remaining : segmentSize;
-        var segmentBytes = 0;
+
+        Timer? idleTimer;
+        final idleTimeout = Completer<Never>();
+
+        void resetIdleTimer() {
+          if (idleTimeout.isCompleted) return;
+          idleTimer?.cancel();
+          idleTimer = Timer(timeout, () {
+            if (!idleTimeout.isCompleted) {
+              idleTimeout.completeError(
+                TimeoutException('SFTP download idle timed out', timeout),
+              );
+            }
+          });
+        }
 
         try {
-          await for (final chunk
-              in openedRemoteFile
-                  .read(
-                    length: length,
-                    offset: offset,
-                    chunkSize: _sftpDownloadChunkSize,
-                    maxPendingRequests: _sftpDownloadMaxPendingRequests,
-                  )
-                  .timeout(timeout)) {
-            localFile.add(chunk);
-            segmentBytes += chunk.length;
-            totalBytes += chunk.length;
-            chunkCount++;
-
-            if (size > 0) {
+          resetIdleTimer();
+          final downloadFuture = openedRemoteFile.downloadToRandomAccess(
+            localFile,
+            length: length,
+            offset: offset,
+            chunkSize: _sftpDownloadChunkSize,
+            maxPendingRequests: _sftpDownloadMaxPendingRequests,
+            onProgress: (bytes) {
+              resetIdleTimer();
+              final transferred = totalBytes + bytes;
               final progress =
-                  (totalBytes / size * 100 * 10).roundToDouble() / 10;
-              if (progress != lastProgress) {
-                lastProgress = progress;
-                mainSendPort.send(progress);
+                  (transferred / size * 100 * 10).roundToDouble() / 10;
+              final elapsedMs = dlWatch.elapsedMilliseconds;
+              final shouldUpdate =
+                  elapsedMs - lastProgressUpdateMs >=
+                      progressUpdateIntervalMs ||
+                  transferred >= size;
+
+              if (shouldUpdate) {
+                lastProgressUpdateMs = elapsedMs;
+                mainSendPort.send(
+                  SftpTransferProgress(
+                    percent: progress,
+                    transferredBytes: transferred,
+                  ),
+                );
               }
-            }
-          }
+            },
+          );
+          final segmentBytes = await Future.any([
+            downloadFuture,
+            idleTimeout.future,
+          ]);
+
+          totalBytes += segmentBytes;
+          chunkCount += (segmentBytes / _sftpDownloadChunkSize).ceil();
         } on TimeoutException {
           throw SftpError('Download timed out at offset=$offset');
+        } finally {
+          idleTimer?.cancel();
         }
 
-        if (segmentBytes == 0) {
-          throw SftpError(
-            'Download returned 0 bytes at offset=$offset',
-          );
+        if (length > 0 && totalBytes <= offset) {
+          throw SftpError('Download returned 0 bytes at offset=$offset');
         }
-        offset += segmentBytes;
+        offset = totalBytes;
       }
 
       Loggers.app.info(

--- a/lib/data/provider/sftp.dart
+++ b/lib/data/provider/sftp.dart
@@ -12,6 +12,7 @@ part 'sftp.g.dart';
 abstract class SftpState with _$SftpState {
   const factory SftpState({
     @Default(<SftpReqStatus>[]) List<SftpReqStatus> requests,
+    @Default(0) int revision,
   }) = _SftpState;
 }
 
@@ -32,11 +33,11 @@ class SftpNotifier extends _$SftpNotifier {
 
   int add(SftpReq req, {Completer? completer}) {
     final reqStat = SftpReqStatus(
-      notifyListeners: _notifyListeners,
+      notifyListeners: _notifyRequestUpdated,
       completer: completer,
       req: req,
     );
-    state = state.copyWith(requests: [...state.requests, reqStat]);
+    _setRequests([...state.requests, reqStat]);
     return reqStat.id;
   }
 
@@ -44,7 +45,7 @@ class SftpNotifier extends _$SftpNotifier {
     for (final item in state.requests) {
       item.dispose();
     }
-    state = state.copyWith(requests: []);
+    _setRequests([]);
   }
 
   void cancel(int id) {
@@ -56,11 +57,27 @@ class SftpNotifier extends _$SftpNotifier {
     final item = state.requests[idx];
     item.dispose();
     final newRequests = List<SftpReqStatus>.from(state.requests)..removeAt(idx);
-    state = state.copyWith(requests: newRequests);
+    _setRequests(newRequests);
   }
 
-  void _notifyListeners() {
-    // Force state update to notify listeners
-    state = state.copyWith();
+  void refreshTransferSpeeds() {
+    final now = DateTime.now();
+    var changed = false;
+    for (final item in state.requests) {
+      changed = item.refreshSpeed(now) || changed;
+    }
+    if (changed) _notifyRequestUpdated();
+  }
+
+  void _setRequests(List<SftpReqStatus> requests) {
+    state = state.copyWith(requests: requests, revision: state.revision + 1);
+  }
+
+  void _notifyRequestUpdated() {
+    // SftpReqStatus is mutable, so bump revision to make updates observable.
+    state = state.copyWith(
+      requests: List<SftpReqStatus>.from(state.requests),
+      revision: state.revision + 1,
+    );
   }
 }

--- a/lib/data/provider/sftp.freezed.dart
+++ b/lib/data/provider/sftp.freezed.dart
@@ -14,7 +14,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$SftpState {
 
- List<SftpReqStatus> get requests;
+ List<SftpReqStatus> get requests; int get revision;
 /// Create a copy of SftpState
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -25,16 +25,16 @@ $SftpStateCopyWith<SftpState> get copyWith => _$SftpStateCopyWithImpl<SftpState>
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is SftpState&&const DeepCollectionEquality().equals(other.requests, requests));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is SftpState&&const DeepCollectionEquality().equals(other.requests, requests)&&(identical(other.revision, revision) || other.revision == revision));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(requests));
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(requests),revision);
 
 @override
 String toString() {
-  return 'SftpState(requests: $requests)';
+  return 'SftpState(requests: $requests, revision: $revision)';
 }
 
 
@@ -45,7 +45,7 @@ abstract mixin class $SftpStateCopyWith<$Res>  {
   factory $SftpStateCopyWith(SftpState value, $Res Function(SftpState) _then) = _$SftpStateCopyWithImpl;
 @useResult
 $Res call({
- List<SftpReqStatus> requests
+ List<SftpReqStatus> requests, int revision
 });
 
 
@@ -62,10 +62,11 @@ class _$SftpStateCopyWithImpl<$Res>
 
 /// Create a copy of SftpState
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? requests = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? requests = null,Object? revision = null,}) {
   return _then(_self.copyWith(
 requests: null == requests ? _self.requests : requests // ignore: cast_nullable_to_non_nullable
-as List<SftpReqStatus>,
+as List<SftpReqStatus>,revision: null == revision ? _self.revision : revision // ignore: cast_nullable_to_non_nullable
+as int,
   ));
 }
 
@@ -150,10 +151,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<SftpReqStatus> requests)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<SftpReqStatus> requests,  int revision)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _SftpState() when $default != null:
-return $default(_that.requests);case _:
+return $default(_that.requests,_that.revision);case _:
   return orElse();
 
 }
@@ -171,10 +172,10 @@ return $default(_that.requests);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<SftpReqStatus> requests)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<SftpReqStatus> requests,  int revision)  $default,) {final _that = this;
 switch (_that) {
 case _SftpState():
-return $default(_that.requests);case _:
+return $default(_that.requests,_that.revision);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -191,10 +192,10 @@ return $default(_that.requests);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<SftpReqStatus> requests)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<SftpReqStatus> requests,  int revision)?  $default,) {final _that = this;
 switch (_that) {
 case _SftpState() when $default != null:
-return $default(_that.requests);case _:
+return $default(_that.requests,_that.revision);case _:
   return null;
 
 }
@@ -206,7 +207,7 @@ return $default(_that.requests);case _:
 
 
 class _SftpState implements SftpState {
-  const _SftpState({final  List<SftpReqStatus> requests = const <SftpReqStatus>[]}): _requests = requests;
+  const _SftpState({final  List<SftpReqStatus> requests = const <SftpReqStatus>[], this.revision = 0}): _requests = requests;
   
 
  final  List<SftpReqStatus> _requests;
@@ -216,6 +217,7 @@ class _SftpState implements SftpState {
   return EqualUnmodifiableListView(_requests);
 }
 
+@override@JsonKey() final  int revision;
 
 /// Create a copy of SftpState
 /// with the given fields replaced by the non-null parameter values.
@@ -227,16 +229,16 @@ _$SftpStateCopyWith<_SftpState> get copyWith => __$SftpStateCopyWithImpl<_SftpSt
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SftpState&&const DeepCollectionEquality().equals(other._requests, _requests));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _SftpState&&const DeepCollectionEquality().equals(other._requests, _requests)&&(identical(other.revision, revision) || other.revision == revision));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_requests));
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_requests),revision);
 
 @override
 String toString() {
-  return 'SftpState(requests: $requests)';
+  return 'SftpState(requests: $requests, revision: $revision)';
 }
 
 
@@ -247,7 +249,7 @@ abstract mixin class _$SftpStateCopyWith<$Res> implements $SftpStateCopyWith<$Re
   factory _$SftpStateCopyWith(_SftpState value, $Res Function(_SftpState) _then) = __$SftpStateCopyWithImpl;
 @override @useResult
 $Res call({
- List<SftpReqStatus> requests
+ List<SftpReqStatus> requests, int revision
 });
 
 
@@ -264,10 +266,11 @@ class __$SftpStateCopyWithImpl<$Res>
 
 /// Create a copy of SftpState
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? requests = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? requests = null,Object? revision = null,}) {
   return _then(_SftpState(
 requests: null == requests ? _self._requests : requests // ignore: cast_nullable_to_non_nullable
-as List<SftpReqStatus>,
+as List<SftpReqStatus>,revision: null == revision ? _self.revision : revision // ignore: cast_nullable_to_non_nullable
+as int,
   ));
 }
 

--- a/lib/data/provider/sftp.g.dart
+++ b/lib/data/provider/sftp.g.dart
@@ -41,7 +41,7 @@ final class SftpNotifierProvider
   }
 }
 
-String _$sftpNotifierHash() => r'f8412a4bd1f2bc5919ec31a3eba1c27e9a578f41';
+String _$sftpNotifierHash() => r'aa7b1fd34729501dd8c88980e4d136233071f1ef';
 
 abstract class _$SftpNotifier extends $Notifier<SftpState> {
   SftpState build();

--- a/lib/view/page/storage/sftp_mission.dart
+++ b/lib/view/page/storage/sftp_mission.dart
@@ -1,9 +1,13 @@
+import 'dart:async';
+
 import 'package:fl_lib/fl_lib.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:server_box/core/extension/context/locale.dart';
+import 'package:server_box/core/utils/refresh_interval.dart';
 import 'package:server_box/data/model/sftp/worker.dart';
 import 'package:server_box/data/provider/sftp.dart';
+import 'package:server_box/data/res/default.dart';
 import 'package:server_box/view/page/storage/local.dart';
 
 class SftpMissionPage extends ConsumerStatefulWidget {
@@ -19,6 +23,25 @@ class SftpMissionPage extends ConsumerStatefulWidget {
 }
 
 class _SftpMissionPageState extends ConsumerState<SftpMissionPage> {
+  Timer? _speedRefreshTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    final interval =
+        serverStatusRefreshInterval() ??
+        const Duration(seconds: Defaults.updateInterval);
+    _speedRefreshTimer = Timer.periodic(interval, (_) {
+      ref.read(sftpProvider.notifier).refreshTransferSpeeds();
+    });
+  }
+
+  @override
+  void dispose() {
+    _speedRefreshTimer?.cancel();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -28,15 +51,15 @@ class _SftpMissionPageState extends ConsumerState<SftpMissionPage> {
   }
 
   Widget _buildBody() {
-    final status = ref.watch(sftpProvider.select((pro) => pro.requests));
-    if (status.isEmpty) {
+    final requests = ref.watch(sftpProvider).requests;
+    if (requests.isEmpty) {
       return Center(child: Text(libL10n.empty));
     }
     return ListView.builder(
       padding: const EdgeInsets.all(11),
-      itemCount: status.length,
+      itemCount: requests.length,
       itemBuilder: (context, index) {
-        return _buildItem(status[index]);
+        return _buildItem(requests[index]);
       },
     );
   }
@@ -97,10 +120,12 @@ class _SftpMissionPageState extends ConsumerState<SftpMissionPage> {
 
   Widget _buildLoading(SftpReqStatus status) {
     final percentStr = (status.progress ?? 0.0).toStringAsFixed(2);
+    final transferred = (status.transferredBytes ?? 0).bytes2Str;
     final size = (status.size ?? 0).bytes2Str;
+    final speed = '${(status.speedBytesPerSecond ?? 0).bytes2Str}/s';
     return _wrapInCard(
       status: status,
-      subtitle: l10n.percentOfSize(percentStr, size),
+      subtitle: '$transferred / $size - $percentStr% - ${l10n.speed}: $speed',
       trailing: _buildDelete(status.fileName, status.id),
     );
   }


### PR DESCRIPTION
#1147 

## Summary
- use the updated dartssh2 SFTP transport fixes and OpenSSH-style download settings
- download SFTP files through random-access writes for pipelined reads
- refresh transfer progress and speed while the task page stays open

## Validation
- dart analyze lib\\data\\model\\sftp\\req.dart lib\\data\\model\\sftp\\worker.dart lib\\data\\provider\\sftp.dart lib\\view\\page\\storage\\sftp_mission.dart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added richer live SFTP transfer details, including transferred bytes, percent, and current speed.
  * Updated progress reporting cadence to refresh during long downloads.
* **Bug Fixes**
  * Improved reliability of transfer status/speed updates so UI stays in sync with ongoing mutations.
  * Enhanced download behavior with larger chunks, higher concurrency, and stronger idle-timeout enforcement.
* **UI Updates**
  * Updated the SFTP mission view to refresh transfer speeds periodically and display transferred bytes, size/percent, and speed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->