### PR TITLE
Fix SSH terminal locale injection

### DIFF
--- a/lib/data/res/github_id.dart
+++ b/lib/data/res/github_id.dart
@@ -180,7 +180,9 @@ abstract final class GithubIds {
     'wu4339',
     'shengroubao',
     'nuclear06',
-    'shen-lan'
+    'shen-lan',
+    'Sahib911',
+    'SiLong96',
   };
 }
 

--- a/lib/data/ssh/ssh_terminal_environment.dart
+++ b/lib/data/ssh/ssh_terminal_environment.dart
@@ -6,6 +6,11 @@ Map<String, String>? buildSshTerminalEnvironment(Map<String, String>? envs) {
 }
 
 String? resolveTmuxLang(Map<String, String>? envs) {
+  final lcAll = envs?['LC_ALL']?.trim();
+  if (lcAll != null && lcAll.isNotEmpty) {
+    return lcAll;
+  }
+
   final lcCtype = envs?['LC_CTYPE']?.trim();
   if (lcCtype != null && lcCtype.isNotEmpty) {
     return lcCtype;

--- a/lib/data/ssh/ssh_terminal_environment.dart
+++ b/lib/data/ssh/ssh_terminal_environment.dart
@@ -1,0 +1,20 @@
+Map<String, String>? buildSshTerminalEnvironment(Map<String, String>? envs) {
+  if (envs == null || envs.isEmpty) {
+    return null;
+  }
+  return Map<String, String>.unmodifiable(envs);
+}
+
+String? resolveTmuxLang(Map<String, String>? envs) {
+  final lcCtype = envs?['LC_CTYPE']?.trim();
+  if (lcCtype != null && lcCtype.isNotEmpty) {
+    return lcCtype;
+  }
+
+  final lang = envs?['LANG']?.trim();
+  if (lang != null && lang.isNotEmpty) {
+    return lang;
+  }
+
+  return null;
+}

--- a/lib/data/ssh/tmux/tmux_command_builder.dart
+++ b/lib/data/ssh/tmux/tmux_command_builder.dart
@@ -2,17 +2,15 @@
 ///
 /// Extracted from TmuxSession for testability without flutter dependencies.
 abstract final class TmuxCommandBuilder {
-  static const defaultLang = 'en_US.UTF-8';
-
   /// Escape a shell argument for use in tmux commands.
   static String escapeArg(String arg) {
     return "'${arg.replaceAll("'", "'\\''")}'";
   }
 
-  static String tmuxPrefix({
-    String tmuxBin = 'tmux',
-    String lang = defaultLang,
-  }) {
+  static String tmuxPrefix({String tmuxBin = 'tmux', String? lang}) {
+    if (lang == null || lang.trim().isEmpty) {
+      return tmuxBin;
+    }
     final escapedLang = escapeArg(lang);
     return 'env LANG=$escapedLang LC_CTYPE=$escapedLang LC_ALL=$escapedLang $tmuxBin';
   }
@@ -21,7 +19,7 @@ abstract final class TmuxCommandBuilder {
   static String attachSession(
     String sessionName, {
     String tmuxBin = 'tmux',
-    String lang = defaultLang,
+    String? lang,
   }) {
     return '${tmuxPrefix(tmuxBin: tmuxBin, lang: lang)} attach-session -t ${escapeArg(sessionName)}';
   }
@@ -31,7 +29,7 @@ abstract final class TmuxCommandBuilder {
     String sessionName,
     int windowIndex, {
     String tmuxBin = 'tmux',
-    String lang = defaultLang,
+    String? lang,
   }) {
     return '${tmuxPrefix(tmuxBin: tmuxBin, lang: lang)} attach-session -t ${escapeArg('$sessionName:$windowIndex')}';
   }
@@ -40,7 +38,7 @@ abstract final class TmuxCommandBuilder {
   static String newSession(
     String sessionName, {
     String tmuxBin = 'tmux',
-    String lang = defaultLang,
+    String? lang,
   }) {
     return '${tmuxPrefix(tmuxBin: tmuxBin, lang: lang)} new-session -s ${escapeArg(sessionName)}';
   }
@@ -49,7 +47,7 @@ abstract final class TmuxCommandBuilder {
   static String newSessionOrAttach(
     String sessionName, {
     String tmuxBin = 'tmux',
-    String lang = defaultLang,
+    String? lang,
   }) {
     return '${tmuxPrefix(tmuxBin: tmuxBin, lang: lang)} new-session -A -s ${escapeArg(sessionName)}';
   }
@@ -58,16 +56,13 @@ abstract final class TmuxCommandBuilder {
   static String killSession(
     String sessionName, {
     String tmuxBin = 'tmux',
-    String lang = defaultLang,
+    String? lang,
   }) {
     return '${tmuxPrefix(tmuxBin: tmuxBin, lang: lang)} kill-session -t ${escapeArg(sessionName)}';
   }
 
   /// Build the list-sessions command with format string.
-  static String listSessionsCmd({
-    String tmuxBin = 'tmux',
-    String lang = defaultLang,
-  }) =>
+  static String listSessionsCmd({String tmuxBin = 'tmux', String? lang}) =>
       '${tmuxPrefix(tmuxBin: tmuxBin, lang: lang)} list-sessions -F '
       '"#{session_name}|#{session_windows}|#{session_attached}'
       '|#{session_created_string}|#{session_last_attached_string}'
@@ -77,16 +72,13 @@ abstract final class TmuxCommandBuilder {
   static String listWindows(
     String sessionName, {
     String tmuxBin = 'tmux',
-    String lang = defaultLang,
+    String? lang,
   }) =>
       '${tmuxPrefix(tmuxBin: tmuxBin, lang: lang)} list-windows -t ${escapeArg(sessionName)} -F '
       '"#{window_index}|#{window_name}|#{window_active}|#{window_panes}|#{window_activity_string}"';
 
   /// Build the list-clients command with identity and disambiguation fields.
-  static String listClients({
-    String tmuxBin = 'tmux',
-    String lang = defaultLang,
-  }) =>
+  static String listClients({String tmuxBin = 'tmux', String? lang}) =>
       '${tmuxPrefix(tmuxBin: tmuxBin, lang: lang)} list-clients -F '
       '"#{client_tty}|#{client_session}|#{window_index}|#{client_activity}"';
 
@@ -95,7 +87,7 @@ abstract final class TmuxCommandBuilder {
     String clientTty,
     String target, {
     String tmuxBin = 'tmux',
-    String lang = defaultLang,
+    String? lang,
   }) =>
       '${tmuxPrefix(tmuxBin: tmuxBin, lang: lang)} switch-client -c ${escapeArg(clientTty)} -t ${escapeArg(target)}';
 
@@ -104,7 +96,7 @@ abstract final class TmuxCommandBuilder {
     String sessionName,
     int windowIndex, {
     String tmuxBin = 'tmux',
-    String lang = defaultLang,
+    String? lang,
   }) =>
       '${tmuxPrefix(tmuxBin: tmuxBin, lang: lang)} kill-window -t ${escapeArg('$sessionName:$windowIndex')}';
 
@@ -113,7 +105,7 @@ abstract final class TmuxCommandBuilder {
     String sessionName,
     int windowIndex, {
     String tmuxBin = 'tmux',
-    String lang = defaultLang,
+    String? lang,
   }) =>
       '${tmuxPrefix(tmuxBin: tmuxBin, lang: lang)} select-window -t ${escapeArg('$sessionName:$windowIndex')}';
 
@@ -121,7 +113,7 @@ abstract final class TmuxCommandBuilder {
   static String newWindow(
     String sessionName, {
     String tmuxBin = 'tmux',
-    String lang = defaultLang,
+    String? lang,
   }) =>
       '${tmuxPrefix(tmuxBin: tmuxBin, lang: lang)} new-window -t ${escapeArg(sessionName)}';
 

--- a/lib/data/ssh/tmux/tmux_launch_plan.dart
+++ b/lib/data/ssh/tmux/tmux_launch_plan.dart
@@ -14,7 +14,8 @@ final class TmuxLaunchPlan {
     required this.windowIndex,
   });
 
-  const TmuxLaunchPlan.none() : this._(command: null, sessionName: null, windowIndex: null);
+  const TmuxLaunchPlan.none()
+    : this._(command: null, sessionName: null, windowIndex: null);
 
   const TmuxLaunchPlan.tmux({
     required String command,
@@ -31,12 +32,10 @@ final class TmuxLaunchPlan {
 
 TmuxLaunchPlan buildRestoredTmuxLaunchPlan(
   TmuxRestoreState restoreState,
-  List<TmuxSessionInfo> sessions,
-  {
-    String tmuxBin = 'tmux',
-    String lang = TmuxCommandBuilder.defaultLang,
-  }
-) {
+  List<TmuxSessionInfo> sessions, {
+  String tmuxBin = 'tmux',
+  String? lang,
+}) {
   if (!restoreState.hasSession) return const TmuxLaunchPlan.none();
 
   final sessionName = restoreState.sessionName!;
@@ -66,10 +65,13 @@ TmuxLaunchPlan buildRestoredTmuxLaunchPlan(
 TmuxLaunchPlan buildChosenTmuxLaunchPlan(
   TmuxAttachChoice choice, {
   String tmuxBin = 'tmux',
-  String lang = TmuxCommandBuilder.defaultLang,
+  String? lang,
 }) {
   return switch (choice) {
-    TmuxAttachExisting(sessionName: final sessionName, windowIndex: final windowIndex) =>
+    TmuxAttachExisting(
+      sessionName: final sessionName,
+      windowIndex: final windowIndex,
+    ) =>
       TmuxLaunchPlan.tmux(
         command: windowIndex != null
             ? TmuxCommandBuilder.attachSessionWindow(

--- a/lib/data/ssh/tmux/tmux_session.dart
+++ b/lib/data/ssh/tmux/tmux_session.dart
@@ -38,14 +38,12 @@ final class TmuxSession {
   final PersistentShell _shell;
   final TmuxSessionScanner _scanner;
   final ValueNotifier<TmuxAttachChoice?> choiceNotifier = ValueNotifier(null);
-  final String _lang;
+  final String? _lang;
 
-  TmuxSession(
-    PersistentShell shell, {
-    String lang = TmuxCommandBuilder.defaultLang,
-  }) : _shell = shell,
-       _lang = lang,
-       _scanner = TmuxSessionScanner(shell, lang: lang);
+  TmuxSession(PersistentShell shell, {String? lang})
+    : _shell = shell,
+      _lang = lang,
+      _scanner = TmuxSessionScanner(shell, lang: lang);
 
   TmuxSessionScanner get scanner => _scanner;
 

--- a/lib/data/ssh/tmux/tmux_session_scanner.dart
+++ b/lib/data/ssh/tmux/tmux_session_scanner.dart
@@ -10,14 +10,11 @@ import 'package:server_box/data/ssh/tmux/tmux_window_info.dart';
 /// tmux -CC connections.
 final class TmuxSessionScanner {
   final PersistentShell _shell;
-  final String _lang;
+  final String? _lang;
   String? _tmuxBin;
   String? get tmuxBin => _tmuxBin;
 
-  TmuxSessionScanner(
-    this._shell, {
-    String lang = TmuxCommandBuilder.defaultLang,
-  }) : _lang = lang;
+  TmuxSessionScanner(this._shell, {String? lang}) : _lang = lang;
 
   Future<String?> _findTmuxBin() async {
     final result = await _shell.run(

--- a/lib/view/page/ssh/page/init.dart
+++ b/lib/view/page/ssh/page/init.dart
@@ -5,23 +5,10 @@ extension _Init on SSHPageState {
     Loggers.app.info('[TMUX] $message');
   }
 
-  Map<String, String> get _sshEnvironment {
-    final env = <String, String>{...?widget.args.spi.envs};
-    final lang = (env['LANG']?.trim().isNotEmpty ?? false)
-        ? env['LANG']!
-        : TmuxCommandBuilder.defaultLang;
-    env['LANG'] = lang;
-    env.putIfAbsent('LC_CTYPE', () => lang);
-    env.putIfAbsent('LC_ALL', () => lang);
-    return env;
-  }
+  Map<String, String>? get _sshEnvironment =>
+      buildSshTerminalEnvironment(widget.args.spi.envs);
 
-  String get _tmuxLang {
-    final env = _sshEnvironment;
-    return (env['LC_CTYPE']?.trim().isNotEmpty ?? false)
-        ? env['LC_CTYPE']!
-        : env['LANG']!;
-  }
+  String? get _tmuxLang => resolveTmuxLang(widget.args.spi.envs);
 
   void _resetForegroundTerminal() {
     _terminal.buffer.clear();
@@ -383,21 +370,23 @@ extension _Init on SSHPageState {
 
   /// Cancellable progress dialog shown while reconnecting.
   void _showReconnectingDialog({required VoidCallback onCancel}) {
-    unawaited(context.showRoundDialog(
-      child: Row(
-        children: [
-          const SizedBox(
-            width: 24,
-            height: 24,
-            child: CircularProgressIndicator(strokeWidth: 2.5),
-          ),
-          const SizedBox(width: 16),
-          Expanded(child: Text(l10n.reconnecting)),
-          Btn.cancel(onTap: onCancel),
-        ],
+    unawaited(
+      context.showRoundDialog(
+        child: Row(
+          children: [
+            const SizedBox(
+              width: 24,
+              height: 24,
+              child: CircularProgressIndicator(strokeWidth: 2.5),
+            ),
+            const SizedBox(width: 16),
+            Expanded(child: Text(l10n.reconnecting)),
+            Btn.cancel(onTap: onCancel),
+          ],
+        ),
+        barrierDismiss: false,
       ),
-      barrierDismiss: false,
-    ));
+    );
   }
 
   Future<void> _showDisconnectDialog() async {
@@ -451,7 +440,11 @@ extension _Init on SSHPageState {
     try {
       oldClient?.close();
     } catch (e, st) {
-      Loggers.app.warning('Failed to close stale SSH client on reconnect', e, st);
+      Loggers.app.warning(
+        'Failed to close stale SSH client on reconnect',
+        e,
+        st,
+      );
     }
 
     TermSessionManager.updateStatus(_sessionId, TermSessionStatus.connecting);
@@ -460,7 +453,11 @@ extension _Init on SSHPageState {
     const baseInterval = Duration(milliseconds: 200);
     const maxInterval = Duration(seconds: 3);
     var connected = false;
-    for (var attempt = 0; attempt < maxAttempts && mounted && !_reconnectCancelled; attempt++) {
+    for (
+      var attempt = 0;
+      attempt < maxAttempts && mounted && !_reconnectCancelled;
+      attempt++
+    ) {
       if (attempt > 0) {
         final backoffMs = (baseInterval.inMilliseconds << (attempt - 1))
             .clamp(0, maxInterval.inMilliseconds)
@@ -530,7 +527,11 @@ extension _Init on SSHPageState {
       try {
         available = await control.isAvailable;
       } catch (e, st) {
-        Loggers.app.warning('tmux availability check on reconnect failed', e, st);
+        Loggers.app.warning(
+          'tmux availability check on reconnect failed',
+          e,
+          st,
+        );
         return false;
       }
       if (!available) return false;
@@ -621,10 +622,7 @@ extension _Init on SSHPageState {
       PersistentShell(
         _client,
         sessionFactory: () async {
-          final sh = await _client!.execute(
-            'bash --login',
-            environment: _sshEnvironment,
-          );
+          final sh = await _client!.execute('sh', environment: _sshEnvironment);
           return SshPersistentShellSession(sh);
         },
       ),
@@ -637,7 +635,19 @@ extension _Init on SSHPageState {
       return const TmuxLaunchPlan.none();
     }
 
-    final tmuxSession = await _createTmuxControlSession();
+    final TmuxSession tmuxSession;
+    try {
+      tmuxSession = await _createTmuxControlSession().timeout(
+        const Duration(seconds: 5),
+      );
+    } on TimeoutException catch (e, st) {
+      Loggers.app.warning('tmux control session creation timed out', e, st);
+      return const TmuxLaunchPlan.none();
+    } catch (e, st) {
+      Loggers.app.warning('tmux control session creation failed', e, st);
+      return const TmuxLaunchPlan.none();
+    }
+
     try {
       bool available;
       try {
@@ -692,7 +702,7 @@ extension _Init on SSHPageState {
   Future<TmuxLaunchPlan> _buildRestoredForegroundLaunchPlan(
     List<TmuxSessionInfo> sessions, {
     required String tmuxBin,
-    required String lang,
+    required String? lang,
   }) async {
     final restoredState = _restoreTmuxState;
     if (!restoredState.hasSession) return const TmuxLaunchPlan.none();
@@ -721,7 +731,7 @@ extension _Init on SSHPageState {
     TmuxSession tmuxSession, {
     List<TmuxSessionInfo>? preloadedSessions,
     required String tmuxBin,
-    required String lang,
+    required String? lang,
   }) async {
     final showSelector = Stores.setting.tmuxShowSelector.fetch();
     final defaultName = Stores.setting.tmuxSessionName.fetch();
@@ -867,7 +877,7 @@ extension _Init on SSHPageState {
   Future<String?> _resolveTmuxClientTty(
     TmuxSession tmuxSession, {
     required String tmuxBin,
-    required String lang,
+    required String? lang,
   }) async {
     final clients = await _listTmuxClients(
       tmuxSession,
@@ -918,7 +928,7 @@ extension _Init on SSHPageState {
   Future<List<_TmuxClientCandidate>> _listTmuxClients(
     TmuxSession tmuxSession, {
     required String tmuxBin,
-    required String lang,
+    required String? lang,
   }) async {
     final result = await tmuxSession.scanner.runCommandAndCapture(
       TmuxCommandBuilder.listClients(tmuxBin: tmuxBin, lang: lang),

--- a/lib/view/page/ssh/page/page.dart
+++ b/lib/view/page/ssh/page/page.dart
@@ -26,6 +26,7 @@ import 'package:server_box/data/res/store.dart';
 import 'package:server_box/data/res/terminal.dart';
 import 'package:server_box/data/ssh/persistent_shell.dart';
 import 'package:server_box/data/ssh/session_manager.dart';
+import 'package:server_box/data/ssh/ssh_terminal_environment.dart';
 import 'package:server_box/data/ssh/terminal_output_buffer.dart';
 import 'package:server_box/data/ssh/tmux/tmux_export.dart';
 import 'package:server_box/view/page/storage/sftp.dart';

--- a/test/ssh_terminal_environment_test.dart
+++ b/test/ssh_terminal_environment_test.dart
@@ -26,6 +26,17 @@ void main() {
   });
 
   group('resolveTmuxLang', () {
+    test('uses LC_ALL before LC_CTYPE and LANG', () {
+      expect(
+        resolveTmuxLang({
+          'LANG': 'zh_CN.UTF-8',
+          'LC_CTYPE': 'C.UTF-8',
+          'LC_ALL': 'C',
+        }),
+        'C',
+      );
+    });
+
     test('uses LC_CTYPE before LANG', () {
       expect(
         resolveTmuxLang({'LANG': 'zh_CN.UTF-8', 'LC_CTYPE': 'C.UTF-8'}),

--- a/test/ssh_terminal_environment_test.dart
+++ b/test/ssh_terminal_environment_test.dart
@@ -1,0 +1,42 @@
+import 'package:server_box/data/ssh/ssh_terminal_environment.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('buildSshTerminalEnvironment', () {
+    test('does not inject locale when no env is configured', () {
+      expect(buildSshTerminalEnvironment(null), isNull);
+      expect(buildSshTerminalEnvironment({}), isNull);
+    });
+
+    test('preserves explicit env values', () {
+      final env = buildSshTerminalEnvironment({
+        'LANG': 'zh_CN.UTF-8',
+        'LC_CTYPE': 'C.UTF-8',
+        'LC_ALL': 'C',
+        'CUSTOM': 'value',
+      });
+
+      expect(env, {
+        'LANG': 'zh_CN.UTF-8',
+        'LC_CTYPE': 'C.UTF-8',
+        'LC_ALL': 'C',
+        'CUSTOM': 'value',
+      });
+    });
+  });
+
+  group('resolveTmuxLang', () {
+    test('uses LC_CTYPE before LANG', () {
+      expect(
+        resolveTmuxLang({'LANG': 'zh_CN.UTF-8', 'LC_CTYPE': 'C.UTF-8'}),
+        'C.UTF-8',
+      );
+    });
+
+    test('falls back to LANG and otherwise stays unset', () {
+      expect(resolveTmuxLang({'LANG': 'zh_CN.UTF-8'}), 'zh_CN.UTF-8');
+      expect(resolveTmuxLang(null), isNull);
+      expect(resolveTmuxLang({'LANG': '  '}), isNull);
+    });
+  });
+}

--- a/test/tmux_command_builder_test.dart
+++ b/test/tmux_command_builder_test.dart
@@ -14,14 +14,14 @@ void main() {
     test('attachSession builds correct command', () {
       expect(
         TmuxCommandBuilder.attachSession('main'),
-        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' tmux attach-session -t 'main'",
+        "tmux attach-session -t 'main'",
       );
     });
 
     test('attachSessionWindow builds correct command', () {
       expect(
         TmuxCommandBuilder.attachSessionWindow('main', 2),
-        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' tmux attach-session -t 'main:2'",
+        "tmux attach-session -t 'main:2'",
       );
     });
 
@@ -29,36 +29,33 @@ void main() {
       const tmuxBin = '/home/linuxbrew/.linuxbrew/bin/tmux';
       expect(
         TmuxCommandBuilder.attachSession('main', tmuxBin: tmuxBin),
-        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' $tmuxBin attach-session -t 'main'",
+        "$tmuxBin attach-session -t 'main'",
       );
       expect(
         TmuxCommandBuilder.attachSessionWindow('main', 2, tmuxBin: tmuxBin),
-        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' $tmuxBin attach-session -t 'main:2'",
+        "$tmuxBin attach-session -t 'main:2'",
       );
       expect(
         TmuxCommandBuilder.newSessionOrAttach('server_box', tmuxBin: tmuxBin),
-        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' $tmuxBin new-session -A -s 'server_box'",
+        "$tmuxBin new-session -A -s 'server_box'",
       );
     });
 
     test('newSession builds correct command', () {
-      expect(
-        TmuxCommandBuilder.newSession('dev'),
-        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' tmux new-session -s 'dev'",
-      );
+      expect(TmuxCommandBuilder.newSession('dev'), "tmux new-session -s 'dev'");
     });
 
     test('newSessionOrAttach builds correct command', () {
       expect(
         TmuxCommandBuilder.newSessionOrAttach('server_box'),
-        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' tmux new-session -A -s 'server_box'",
+        "tmux new-session -A -s 'server_box'",
       );
     });
 
     test('killSession builds correct command', () {
       expect(
         TmuxCommandBuilder.killSession('old'),
-        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' tmux kill-session -t 'old'",
+        "tmux kill-session -t 'old'",
       );
     });
 
@@ -77,7 +74,7 @@ void main() {
     test('listClients uses client session and window fields', () {
       expect(
         TmuxCommandBuilder.listClients(),
-        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' tmux list-clients -F "
+        'tmux list-clients -F '
         '"#{client_tty}|#{client_session}|#{window_index}|#{client_activity}"',
       );
     });
@@ -85,8 +82,16 @@ void main() {
     test('switchClient targets a specific client tty', () {
       expect(
         TmuxCommandBuilder.switchClient('/dev/pts/3', 'main:2'),
-        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' tmux switch-client -c '/dev/pts/3' -t 'main:2'",
+        "tmux switch-client -c '/dev/pts/3' -t 'main:2'",
       );
+    });
+
+    test('commands include locale only when lang is explicit', () {
+      expect(
+        TmuxCommandBuilder.attachSession('main', lang: 'C.UTF-8'),
+        "env LANG='C.UTF-8' LC_CTYPE='C.UTF-8' LC_ALL='C.UTF-8' tmux attach-session -t 'main'",
+      );
+      expect(TmuxCommandBuilder.tmuxPrefix(lang: ''), 'tmux');
     });
 
     test('checkTmux includes multiple paths', () {
@@ -96,14 +101,14 @@ void main() {
     test('attachSession handles special characters', () {
       expect(
         TmuxCommandBuilder.attachSession('my session'),
-        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' tmux attach-session -t 'my session'",
+        "tmux attach-session -t 'my session'",
       );
     });
 
     test('newSession handles special characters in name', () {
       expect(
         TmuxCommandBuilder.newSession("user's-work"),
-        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' tmux new-session -s 'user'\\''s-work'",
+        "tmux new-session -s 'user'\\''s-work'",
       );
     });
   });

--- a/test/tmux_launch_plan_test.dart
+++ b/test/tmux_launch_plan_test.dart
@@ -9,16 +9,11 @@ void main() {
     test('builds attach command for existing restored session', () {
       final plan = buildRestoredTmuxLaunchPlan(
         const TmuxRestoreState(sessionName: 'main', windowIndex: 2),
-        const [
-          TmuxSessionInfo(name: 'main', windows: 3, attached: true),
-        ],
+        const [TmuxSessionInfo(name: 'main', windows: 3, attached: true)],
       );
 
       expect(plan.shouldLaunchTmux, isTrue);
-      expect(
-        plan.command,
-        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' tmux attach-session -t 'main:2'",
-      );
+      expect(plan.command, "tmux attach-session -t 'main:2'");
       expect(plan.sessionName, 'main');
       expect(plan.windowIndex, 2);
     });
@@ -26,9 +21,7 @@ void main() {
     test('returns none when restored session no longer exists', () {
       final plan = buildRestoredTmuxLaunchPlan(
         const TmuxRestoreState(sessionName: 'ghost'),
-        const [
-          TmuxSessionInfo(name: 'main', windows: 1, attached: false),
-        ],
+        const [TmuxSessionInfo(name: 'main', windows: 1, attached: false)],
       );
 
       expect(plan.shouldLaunchTmux, isFalse);
@@ -42,10 +35,7 @@ void main() {
         const TmuxAttachExisting(sessionName: 'dev'),
       );
 
-      expect(
-        plan.command,
-        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' tmux attach-session -t 'dev'",
-      );
+      expect(plan.command, "tmux attach-session -t 'dev'");
       expect(plan.sessionName, 'dev');
       expect(plan.windowIndex, isNull);
     });
@@ -55,10 +45,7 @@ void main() {
         const TmuxAttachNew(sessionName: 'server_box'),
       );
 
-      expect(
-        plan.command,
-        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' tmux new-session -A -s 'server_box'",
-      );
+      expect(plan.command, "tmux new-session -A -s 'server_box'");
       expect(plan.sessionName, 'server_box');
       expect(plan.windowIndex, isNull);
     });
@@ -70,12 +57,21 @@ void main() {
         tmuxBin: tmuxBin,
       );
 
-      expect(
-        plan.command,
-        "env LANG='en_US.UTF-8' LC_CTYPE='en_US.UTF-8' LC_ALL='en_US.UTF-8' $tmuxBin attach-session -t 'codex:0'",
-      );
+      expect(plan.command, "$tmuxBin attach-session -t 'codex:0'");
       expect(plan.sessionName, 'codex');
       expect(plan.windowIndex, 0);
+    });
+
+    test('uses explicit lang when provided', () {
+      final plan = buildChosenTmuxLaunchPlan(
+        const TmuxAttachExisting(sessionName: 'dev'),
+        lang: 'zh_CN.UTF-8',
+      );
+
+      expect(
+        plan.command,
+        "env LANG='zh_CN.UTF-8' LC_CTYPE='zh_CN.UTF-8' LC_ALL='zh_CN.UTF-8' tmux attach-session -t 'dev'",
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary
- stop injecting en_US.UTF-8 into built-in SSH terminal sessions by default
- only pass explicit server env values through to SSH/tmux
- avoid blocking shell startup on tmux control session creation by using sh and falling back when control setup times out

## Tests
- dart analyze lib\\data\\ssh\\ssh_terminal_environment.dart lib\\data\\ssh\\tmux\\tmux_command_builder.dart lib\\data\\ssh\\tmux\\tmux_session.dart lib\\data\\ssh\\tmux\\tmux_session_scanner.dart lib\\data\\ssh\\tmux\\tmux_launch_plan.dart lib\\view\\page\\ssh\\page\\page.dart lib\\view\\page\\ssh\\page\\init.dart test\\tmux_command_builder_test.dart test\\tmux_launch_plan_test.dart test\\ssh_terminal_environment_test.dart
- flutter test test\\tmux_command_builder_test.dart test\\tmux_launch_plan_test.dart test\\tmux_session_scanner_test.dart test\\persistent_shell_test.dart test\\ssh_terminal_environment_test.dart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved SSH/TMUX environment handling with clearer locale resolution based on available terminal variables.
  * Added helpers to preserve provided SSH terminal environment values (without introducing defaults).

* **Bug Fixes**
  * TMUX commands no longer inject a default locale when no language is explicitly provided.
  * Reconnect/session restoration now handles tmux control/session timeouts and failures more safely.
  * Updated contributor credits list.

* **Tests**
  * Expanded/updated unit tests for SSH environment + TMUX command/launch expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->