### PR TITLE
Switch update checks to GitHub releases

### DIFF
--- a/lib/data/res/url.dart
+++ b/lib/data/res/url.dart
@@ -1,8 +1,10 @@
 abstract final class Urls {
   static const cdnBase = 'https://cdn.lpkt.cn/serverbox';
-  static const updateCfg = '$cdnBase/update2.json';
   static const myGithub = 'https://github.com/lollipopkit';
+  static const githubApi = 'https://api.github.com/repos/lollipopkit';
   static const thisRepo = '$myGithub/flutter_server_box';
+  static const githubReleasesApi = '$githubApi/flutter_server_box/releases';
+  static const appStore = 'https://apps.apple.com/app/id1586449703';
   static const appHelp = '$thisRepo#-help';
   static const appWiki = '$thisRepo/wiki';
 }

--- a/lib/view/page/home.dart
+++ b/lib/view/page/home.dart
@@ -269,7 +269,8 @@ class _HomePageState extends ConsumerState<HomePage>
     if (Stores.setting.autoCheckAppUpdate.fetch()) {
       AppUpdateIface.doUpdate(
         build: BuildData.build,
-        url: Urls.updateCfg,
+        githubReleasesUrl: Urls.githubReleasesApi,
+        storeUrl: Urls.appStore,
         context: context,
       );
     }

--- a/lib/view/page/setting/entries/app.dart
+++ b/lib/view/page/setting/entries/app.dart
@@ -118,7 +118,8 @@ extension _App on _AppSettingsPageState {
         () => AppUpdateIface.doUpdate(
           context: context,
           build: BuildData.build,
-          url: Urls.updateCfg,
+          githubReleasesUrl: Urls.githubReleasesApi,
+          storeUrl: Urls.appStore,
           force: BuildMode.isDebug,
         ),
       ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Update checks now use separate sources for release information and the app store, improving how version updates are found and opened.
  * Added clearer app and GitHub release links for update-related actions.

* **Chores**
  * Updated an embedded library reference to a newer revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->