### PR TITLE
Add reproducibility checks to CI workflows

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -12,6 +12,37 @@ on:
     branches: [ "main" ]
 
 jobs:
+  reproducibilityCheck:
+    name: Reproducibility check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          submodules: recursive
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          flutter-version: '3.44.4'
+
+      - name: Check locked dependencies
+        env:
+          PUB_HOSTED_URL: https://pub.dev
+        run: |
+          flutter pub get --enforce-lockfile
+          git diff --exit-code -- pubspec.yaml pubspec.lock
+
+      - name: Check JNI build-id patch
+        run: |
+          scripts/release/patch-jni-build-id.sh
+          pub_cache="$(dart pub cache path)"
+          if ! grep -R -- '--build-id=none' "$pub_cache"/hosted/pub.dev/jni-*/src/CMakeLists.txt >/dev/null; then
+            echo "jni build-id patch was not applied."
+            exit 1
+          fi
+
   check:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 env:
   FLUTTER_VERSION: '3.44.4'
 
@@ -24,6 +27,7 @@ jobs:
         with:
           fetch-depth: 1
           submodules: recursive
+          persist-credentials: false
 
       - uses: subosito/flutter-action@v2
         with:
@@ -38,13 +42,7 @@ jobs:
           git diff --exit-code -- pubspec.yaml pubspec.lock
 
       - name: Check JNI build-id patch
-        run: |
-          scripts/release/patch-jni-build-id.sh
-          pub_cache="$(dart pub cache path)"
-          if ! grep -R -- '--build-id=none' "$pub_cache"/hosted/pub.dev/jni-*/src/CMakeLists.txt >/dev/null; then
-            echo "jni build-id patch was not applied."
-            exit 1
-          fi
+        run: scripts/release/patch-jni-build-id.sh
 
   check:
     runs-on: ubuntu-latest
@@ -54,6 +52,7 @@ jobs:
         with:
           fetch-depth: 1
           submodules: recursive
+          persist-credentials: false
       
       - uses: subosito/flutter-action@v2
         with:

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          # flutter-version: '3.44.1'
+          flutter-version: '3.44.4'
 
       - name: Install dependencies
         run: flutter pub get

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  FLUTTER_VERSION: '3.44.4'
+
 jobs:
   reproducibilityCheck:
     name: Reproducibility check
@@ -25,7 +28,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          flutter-version: '3.44.4'
+          flutter-version: ${{ env.FLUTTER_VERSION }}
 
       - name: Check locked dependencies
         env:
@@ -55,7 +58,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          flutter-version: '3.44.4'
+          flutter-version: ${{ env.FLUTTER_VERSION }}
 
       - name: Install dependencies
         run: flutter pub get

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,68 @@ env:
   BUILD_TAG: test-build-${{ github.run_number }}-${{ github.sha }}
 
 jobs:
+  reproducibilityCheck:
+    name: Reproducibility check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+          flutter-version: "3.44.1"
+      - name: Require tagged releases
+        if: inputs.release == true && github.ref_type != 'tag'
+        shell: bash
+        run: |
+          echo "Release builds must be started from a committed tag so the source can be reproduced by downstream builders."
+          echo "Create and push a v1.0.<build> tag after committing the release version files."
+          exit 1
+      - name: Check tag source version
+        if: github.ref_type == 'tag'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          expected="${GITHUB_REF_NAME#v}"
+          build="${expected##*.}"
+          pub_version="$(sed -n -E 's/^version:[[:space:]]*([^+]+)\+([0-9]+)$/\1+\2/p' pubspec.yaml | head -n 1)"
+          build_data="$(sed -n -E 's/.*static const int build = ([0-9]+);/\1/p' lib/data/res/build_data.dart | head -n 1)"
+
+          if [[ "$pub_version" != "$expected+$build" ]]; then
+            echo "pubspec.yaml version must match tag ${GITHUB_REF_NAME}; got ${pub_version}."
+            exit 1
+          fi
+
+          if [[ "$build_data" != "$build" ]]; then
+            echo "BuildData.build must match tag ${GITHUB_REF_NAME}; got ${build_data}."
+            exit 1
+          fi
+      - name: Check locked dependencies
+        shell: bash
+        env:
+          PUB_HOSTED_URL: https://pub.dev
+        run: |
+          flutter pub get --enforce-lockfile
+          git diff --exit-code -- pubspec.yaml pubspec.lock
+      - name: Check JNI build-id patch
+        shell: bash
+        run: |
+          scripts/release/patch-jni-build-id.sh
+          pub_cache="$(dart pub cache path)"
+          if ! grep -R -- '--build-id=none' "$pub_cache"/hosted/pub.dev/jni-*/src/CMakeLists.txt >/dev/null; then
+            echo "jni build-id patch was not applied."
+            exit 1
+          fi
+
   buildAndroid:
     name: Build android
+    needs: reproducibilityCheck
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -86,6 +146,7 @@ jobs:
 
   buildLinux:
     name: Build linux
+    needs: reproducibilityCheck
     strategy:
       fail-fast: false
       matrix:
@@ -153,6 +214,7 @@ jobs:
 
   buildWindows:
     name: Build windows
+    needs: reproducibilityCheck
     runs-on: windows-latest
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: "stable"
-          flutter-version: "3.44.1"
+          flutter-version: "3.44.4"
       - name: Require tagged releases
         if: inputs.release == true && github.ref_type != 'tag'
         shell: bash
@@ -94,7 +94,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: "stable"
-          flutter-version: "3.44.1"
+          flutter-version: "3.44.4"
       - uses: actions/setup-java@v4
         with:
           distribution: "zulu"
@@ -169,7 +169,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          flutter-version: "3.44.1"
+          flutter-version: "3.44.4"
       - name: Install dependencies
         run: |
           sudo apt update
@@ -227,7 +227,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          flutter-version: "3.44.1"
+          flutter-version: "3.44.4"
       - name: Build (release)
         if: inputs.release == true || github.ref_type == 'tag'
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       release:
-        description: 'Create GitHub Release (auto tag v1.0.<commit_count>)'
+        description: 'Create GitHub Release from the selected v1.0.<build> tag'
         required: false
         type: boolean
         default: false
@@ -18,6 +18,7 @@ permissions:
 env:
   APP_NAME: ServerBox
   BUILD_TAG: test-build-${{ github.run_number }}-${{ github.sha }}
+  FLUTTER_VERSION: "3.44.4"
 
 jobs:
   reproducibilityCheck:
@@ -34,7 +35,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: "stable"
-          flutter-version: "3.44.4"
+          flutter-version: ${{ env.FLUTTER_VERSION }}
       - name: Require tagged releases
         if: inputs.release == true && github.ref_type != 'tag'
         shell: bash
@@ -94,7 +95,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: "stable"
-          flutter-version: "3.44.4"
+          flutter-version: ${{ env.FLUTTER_VERSION }}
       - uses: actions/setup-java@v4
         with:
           distribution: "zulu"
@@ -169,7 +170,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          flutter-version: "3.44.4"
+          flutter-version: ${{ env.FLUTTER_VERSION }}
       - name: Install dependencies
         run: |
           sudo apt update
@@ -227,7 +228,7 @@ jobs:
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          flutter-version: "3.44.4"
+          flutter-version: ${{ env.FLUTTER_VERSION }}
       - name: Build (release)
         if: inputs.release == true || github.ref_type == 'tag'
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,13 +72,7 @@ jobs:
           git diff --exit-code -- pubspec.yaml pubspec.lock
       - name: Check JNI build-id patch
         shell: bash
-        run: |
-          scripts/release/patch-jni-build-id.sh
-          pub_cache="$(dart pub cache path)"
-          if ! grep -R -- '--build-id=none' "$pub_cache"/hosted/pub.dev/jni-*/src/CMakeLists.txt >/dev/null; then
-            echo "jni build-id patch was not applied."
-            exit 1
-          fi
+        run: scripts/release/patch-jni-build-id.sh
 
   buildAndroid:
     name: Build android


### PR DESCRIPTION
## Summary
- Add a dedicated reproducibility check job to validate locked dependencies and the JNI build-id patch before platform builds run.
- Align Flutter version usage across analysis and build workflows through a single `FLUTTER_VERSION` value.
- Tighten release flow by requiring tagged builds and verifying tag-derived version metadata.
- Update the release workflow description to reflect tag-based release creation.

## Testing
- Not run (not requested)
- CI workflows updated to perform lockfile, version, and patch validation during pipeline execution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added release gating to ensure builds are produced from a verified, reproducible source.
  * Standardized the Flutter version used across CI jobs for more consistent builds.

* **Bug Fixes**
  * Added checks to prevent dependency drift during release builds.
  * Improved release validation so tagged builds must match the expected app version and build metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->