### PR TITLE
fix: preserve model JSON in backups

### DIFF
--- a/lib/data/model/app/bak/backup2.dart
+++ b/lib/data/model/app/bak/backup2.dart
@@ -4,6 +4,11 @@ import 'dart:io';
 import 'package:fl_lib/fl_lib.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:logging/logging.dart';
+import 'package:server_box/data/model/server/custom.dart';
+import 'package:server_box/data/model/server/private_key_info.dart';
+import 'package:server_box/data/model/server/server_private_info.dart';
+import 'package:server_box/data/model/server/snippet.dart';
+import 'package:server_box/data/model/server/wol_cfg.dart';
 import 'package:server_box/data/provider/private_key.dart';
 import 'package:server_box/data/provider/server/all.dart';
 import 'package:server_box/data/provider/snippet.dart';
@@ -137,15 +142,7 @@ abstract class BackupV2 with _$BackupV2 implements Mergeable {
     return BackupV2.fromJson(map);
   }
 
-  String toJsonString() {
-    try {
-      return json.encode(toJson(), toEncodable: _toEncodable);
-    } on JsonUnsupportedObjectError catch (e) {
-      final cause = e.cause;
-      if (cause is UnsupportedError) throw cause;
-      rethrow;
-    }
-  }
+  String toJsonString() => json.encode(_toJsonValue(toJson()));
 
   void _validateRestorableTypedStores() {
     _validateRestorableStore('spis', spis);
@@ -157,13 +154,36 @@ abstract class BackupV2 with _$BackupV2 implements Mergeable {
 Object? _toEncodable(Object? value) {
   if (value is Enum) return value.name;
 
-  try {
-    return (value as dynamic).toJson();
-  } on NoSuchMethodError {
-    throw UnsupportedError(
-      'Cannot JSON-encode ${value.runtimeType}: missing toJson()',
-    );
+  return switch (value) {
+    final Spi spi => spi.toJson(),
+    final Snippet snippet => snippet.toJson(),
+    final PrivateKeyInfo key => key.toJson(),
+    final ServerCustom custom => custom.toJson(),
+    final WakeOnLanCfg wolCfg => wolCfg.toJson(),
+    _ => throw UnsupportedError(
+      'Cannot JSON-encode ${value.runtimeType}: missing supported toJson()',
+    ),
+  };
+}
+
+Object? _toJsonValue(Object? value) {
+  if (value == null || value is num || value is bool || value is String) {
+    return value;
   }
+  if (value is Map) {
+    return value.map((key, entryValue) {
+      if (key is! String) {
+        throw UnsupportedError(
+          'Cannot JSON-encode map key ${key.runtimeType}: keys must be String',
+        );
+      }
+      return MapEntry(key, _toJsonValue(entryValue));
+    });
+  }
+  if (value is Iterable) {
+    return value.map(_toJsonValue).toList(growable: false);
+  }
+  return _toJsonValue(_toEncodable(value));
 }
 
 void _validateRestorableStore(String storeName, Map<String, Object?> data) {

--- a/lib/data/model/app/bak/backup2.dart
+++ b/lib/data/model/app/bak/backup2.dart
@@ -41,11 +41,15 @@ abstract class BackupV2 with _$BackupV2 implements Mergeable {
     required Map<String, Object?> settings,
   }) = _BackupV2;
 
-  factory BackupV2.fromJson(Map<String, dynamic> json) =>
-      _$BackupV2FromJson(json);
+  factory BackupV2.fromJson(Map<String, dynamic> json) {
+    final backup = _$BackupV2FromJson(json);
+    backup._validateRestorableTypedStores();
+    return backup;
+  }
 
   @override
   Future<void> merge({bool force = false}) async {
+    _validateRestorableTypedStores();
     _loggerV2.info('Merging...');
 
     final results = await Future.wait([
@@ -59,11 +63,7 @@ abstract class BackupV2 with _$BackupV2 implements Mergeable {
         store: Stores.snippet,
         force: force,
       ),
-      Mergeable.mergeStore(
-        backupData: keys,
-        store: Stores.key,
-        force: force,
-      ),
+      Mergeable.mergeStore(backupData: keys, store: Stores.key, force: force),
       Mergeable.mergeStore(
         backupData: container,
         store: Stores.container,
@@ -114,7 +114,7 @@ abstract class BackupV2 with _$BackupV2 implements Mergeable {
     bool includeSettings = true,
   ]) async {
     final bak = await BackupV2.loadFromStore(includeSettings: includeSettings);
-    var result = json.encode(bak.toJson(), toEncodable: _toEncodable);
+    var result = bak.toJsonString();
 
     if (password != null && password.isNotEmpty) {
       result = Cryptor.encrypt(result, password);
@@ -136,11 +136,50 @@ abstract class BackupV2 with _$BackupV2 implements Mergeable {
     final map = json.decode(jsonString) as Map<String, dynamic>;
     return BackupV2.fromJson(map);
   }
+
+  String toJsonString() {
+    try {
+      return json.encode(toJson(), toEncodable: _toEncodable);
+    } on JsonUnsupportedObjectError catch (e) {
+      final cause = e.cause;
+      if (cause is UnsupportedError) throw cause;
+      rethrow;
+    }
+  }
+
+  void _validateRestorableTypedStores() {
+    _validateRestorableStore('spis', spis);
+    _validateRestorableStore('snippets', snippets);
+    _validateRestorableStore('keys', keys);
+  }
 }
 
 Object? _toEncodable(Object? value) {
   if (value is Enum) return value.name;
-  _loggerV2.warning('Non-JSON-encodable type: ${value.runtimeType}, '
-      'serialized via toString() and may not be deserializable');
-  return value.toString();
+
+  try {
+    return (value as dynamic).toJson();
+  } on NoSuchMethodError {
+    throw UnsupportedError(
+      'Cannot JSON-encode ${value.runtimeType}: missing toJson()',
+    );
+  }
 }
+
+void _validateRestorableStore(String storeName, Map<String, Object?> data) {
+  for (final entry in data.entries) {
+    if (_isInternalStoreKey(entry.key) || entry.value == null) continue;
+    if (entry.value is Map) continue;
+
+    throw FormatException(
+      'Backup contains corrupted $storeName entry "${entry.key}": '
+      'expected JSON object, got ${entry.value.runtimeType}. '
+      'Backups created by app versions 1.0.1448-1.0.1450 may be affected '
+      'and cannot be fully restored.',
+    );
+  }
+}
+
+bool _isInternalStoreKey(String key) =>
+    key.startsWith(StoreDefaults.prefixKey) ||
+    key.startsWith(StoreDefaults.prefixKeyOld);

--- a/test/backup_v2_test.dart
+++ b/test/backup_v2_test.dart
@@ -71,6 +71,21 @@ void main() {
 
       expect(backup.toJsonString, throwsA(isA<UnsupportedError>()));
     });
+
+    test('preserves failures from supported toJson implementations', () {
+      final backup = BackupV2(
+        version: BackupV2.formatVer,
+        date: 1,
+        spis: const {},
+        snippets: const {},
+        keys: {'bad': const _ThrowingPrivateKeyInfo()},
+        container: const {},
+        history: const {},
+        settings: const {},
+      );
+
+      expect(backup.toJsonString, throwsA(isA<StateError>()));
+    });
   });
 
   group('BackupV2 restore validation', () {
@@ -96,9 +111,7 @@ void main() {
       final raw = json.encode({
         'version': BackupV2.formatVer,
         'date': 1,
-        'spis': {
-          '__lkpt_lastUpdateTs': {'server': 1},
-        },
+        'spis': {'__lkpt_lastUpdateTs': 'legacy timestamp metadata'},
         'snippets': {},
         'keys': {},
         'container': {},
@@ -108,9 +121,17 @@ void main() {
 
       final backup = BackupV2.fromJsonString(raw);
 
-      expect(backup.spis['__lkpt_lastUpdateTs'], {'server': 1});
+      expect(backup.spis['__lkpt_lastUpdateTs'], 'legacy timestamp metadata');
     });
   });
 }
 
 final class _NotJsonEncodable {}
+
+final class _ThrowingPrivateKeyInfo extends PrivateKeyInfo {
+  const _ThrowingPrivateKeyInfo()
+    : super(id: 'bad', key: '-----BEGIN OPENSSH PRIVATE KEY-----\nbad');
+
+  @override
+  Map<String, dynamic> toJson() => throw StateError('broken toJson');
+}

--- a/test/backup_v2_test.dart
+++ b/test/backup_v2_test.dart
@@ -1,0 +1,116 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:server_box/data/model/app/bak/backup2.dart';
+import 'package:server_box/data/model/app/tab.dart';
+import 'package:server_box/data/model/server/private_key_info.dart';
+import 'package:server_box/data/model/server/server_private_info.dart';
+import 'package:server_box/data/model/server/snippet.dart';
+
+void main() {
+  group('BackupV2 JSON encoding', () {
+    test('serializes typed store objects as JSON objects', () {
+      final backup = BackupV2(
+        version: BackupV2.formatVer,
+        date: 1,
+        spis: {'server': Spix.example},
+        snippets: {'snippet': Snippet.example},
+        keys: {
+          'key': const PrivateKeyInfo(
+            id: 'key',
+            key: '-----BEGIN OPENSSH PRIVATE KEY-----\nkey',
+          ),
+        },
+        container: const {},
+        history: const {},
+        settings: const {},
+      );
+
+      final encoded = backup.toJsonString();
+      final decoded = json.decode(encoded) as Map<String, dynamic>;
+
+      expect(decoded['spis']['server'], isA<Map>());
+      expect(decoded['spis']['server']['name'], Spix.example.name);
+      expect(decoded['snippets']['snippet'], isA<Map>());
+      expect(decoded['snippets']['snippet']['script'], Snippet.example.script);
+      expect(decoded['keys']['key'], isA<Map>());
+      expect(decoded['keys']['key']['private_key'], contains('OPENSSH'));
+    });
+
+    test('serializes enum values by name', () {
+      final backup = BackupV2(
+        version: BackupV2.formatVer,
+        date: 1,
+        spis: const {},
+        snippets: const {},
+        keys: const {},
+        container: const {},
+        history: const {},
+        settings: const {
+          'homeTabs': [AppTab.server, AppTab.ssh],
+        },
+      );
+
+      final decoded =
+          json.decode(backup.toJsonString()) as Map<String, dynamic>;
+
+      expect(decoded['settings']['homeTabs'], ['server', 'ssh']);
+    });
+
+    test('fails instead of stringifying unknown objects', () {
+      final backup = BackupV2(
+        version: BackupV2.formatVer,
+        date: 1,
+        spis: const {},
+        snippets: const {},
+        keys: const {},
+        container: const {},
+        history: const {},
+        settings: {'bad': _NotJsonEncodable()},
+      );
+
+      expect(backup.toJsonString, throwsA(isA<UnsupportedError>()));
+    });
+  });
+
+  group('BackupV2 restore validation', () {
+    test('rejects corrupted typed store entries', () {
+      final raw = json.encode({
+        'version': BackupV2.formatVer,
+        'date': 1,
+        'spis': {'server': 'Spi<root@example.com:22>'},
+        'snippets': {},
+        'keys': {},
+        'container': {},
+        'history': {},
+        'settings': {},
+      });
+
+      expect(
+        () => BackupV2.fromJsonString(raw),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('allows internal metadata in typed stores', () {
+      final raw = json.encode({
+        'version': BackupV2.formatVer,
+        'date': 1,
+        'spis': {
+          '__lkpt_lastUpdateTs': {'server': 1},
+        },
+        'snippets': {},
+        'keys': {},
+        'container': {},
+        'history': {},
+        'settings': {},
+      });
+
+      final backup = BackupV2.fromJsonString(raw);
+
+      expect(backup.spis['__lkpt_lastUpdateTs'], {'server': 1});
+    });
+  });
+}
+
+final class _NotJsonEncodable {}


### PR DESCRIPTION
#1223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup and restore reliability by performing stricter typed-store validation when loading and before merging backups.
  * Backup JSON encoding is now more robust: unsupported values fail fast with a clear `UnsupportedError` instead of being silently stringified.
  * Restore now rejects corrupted typed-store entry shapes with a `FormatException`, while preserving required internal metadata fields.
* **Tests**
  * Added unit coverage for JSON encoding behavior and restore-time validation, including failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->