### PR TITLE
Parse Docker ps output with tab-separated fields

### DIFF
--- a/lib/data/model/container/ps.dart
+++ b/lib/data/model/container/ps.dart
@@ -4,7 +4,6 @@ import 'package:fl_lib/fl_lib.dart';
 import 'package:server_box/core/extension/context/locale.dart';
 import 'package:server_box/data/model/container/status.dart';
 import 'package:server_box/data/model/container/type.dart';
-import 'package:server_box/data/res/misc.dart';
 
 sealed class ContainerPs {
   String? get id;
@@ -146,15 +145,21 @@ final class DockerPs implements ContainerPs {
         '${l10n.read} ${blockParts.firstOrNull ?? '0B'} / ${l10n.write} ${blockParts.length > 1 ? blockParts[1] : '0B'}';
   }
 
-  /// CONTAINER ID                   NAMES                          IMAGE                          STATUS
-  /// a049d689e7a1                   aria2-pro                      p3terx/aria2-pro               Up 3 weeks
+  /// CONTAINER ID\tSTATUS\tNAMES\tIMAGE
+  /// a049d689e7a1\tUp 3 weeks\taria2-pro\tp3terx/aria2-pro
   factory DockerPs.parse(String raw) {
-    final parts = raw.split(Miscs.multiBlankReg);
+    final parts = raw.split('\t');
+    if (parts.length < 4) {
+      throw FormatException(
+        'Docker ps row has ${parts.length} fields, expected 4',
+        raw,
+      );
+    }
     return DockerPs(
       id: parts[0],
       state: parts[1],
       names: parts[2],
-      image: parts[3].trim(),
+      image: parts[3],
     );
   }
 }

--- a/lib/data/provider/container.dart
+++ b/lib/data/provider/container.dart
@@ -487,14 +487,8 @@ enum ContainerCmdType {
     final baseCmd = switch (this) {
       ContainerCmdType.version => '${type.name} version $_jsonFmt',
       ContainerCmdType.ps => switch (type) {
-        /// TODO: Rollback to json format when performance recovers.
-        /// Use [_jsonFmt] in Docker will cause the operation to slow down.
         ContainerType.docker =>
-          '${type.name} ps -a --format "table {{printf \\"'
-              '%-15.15s '
-              '%-30.30s '
-              '${"%-50.50s " * 2}\\"'
-              ' .ID .Status .Names .Image}}"',
+          '${type.name} ps -a --format "{{.ID}}\\t{{.State}}\\t{{.Names}}\\t{{.Image}}"',
         ContainerType.podman => '${type.name} ps -a $_jsonFmt',
       },
       ContainerCmdType.stats =>

--- a/lib/data/provider/container.dart
+++ b/lib/data/provider/container.dart
@@ -286,9 +286,14 @@ class ContainerNotifier extends _$ContainerNotifier {
         if (headerIdx != -1) lines.removeAt(headerIdx);
       }
       lines.removeWhere((element) => element.isEmpty);
-      final items = lines
-          .map((e) => ContainerPs.fromRaw(e, type))
-          .toList();
+      final items = <ContainerPs>[];
+      for (final line in lines) {
+        try {
+          items.add(ContainerPs.fromRaw(line, type));
+        } on FormatException catch (e, trace) {
+          Loggers.app.warning('Skip malformed container ps row', e, trace);
+        }
+      }
       state = state.copyWith(items: items);
     } catch (e, trace) {
       if (state.error == null) {
@@ -488,7 +493,7 @@ enum ContainerCmdType {
       ContainerCmdType.version => '${type.name} version $_jsonFmt',
       ContainerCmdType.ps => switch (type) {
         ContainerType.docker =>
-          '${type.name} ps -a --format "{{.ID}}\\t{{.State}}\\t{{.Names}}\\t{{.Image}}"',
+          '${type.name} ps -a --format "{{.ID}}\\t{{.Status}}\\t{{.Names}}\\t{{.Image}}"',
         ContainerType.podman => '${type.name} ps -a $_jsonFmt',
       },
       ContainerCmdType.stats =>

--- a/test/container_test.dart
+++ b/test/container_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:server_box/data/model/container/ps.dart';
 import 'package:server_box/data/model/container/status.dart';
+import 'package:server_box/data/model/container/type.dart';
+import 'package:server_box/data/provider/container.dart';
 
 void main() {
   test('docker ps parse', () {
@@ -54,6 +56,13 @@ fa1215b4be74\tUp 12 hours\tfirefly\tuusec/firefly:latest
             .having((e) => e.message, 'message', contains('expected 4')),
       ),
     );
+  });
+
+  test('docker ps command uses human-readable status', () {
+    final cmd = ContainerCmdType.ps.exec(ContainerType.docker);
+
+    expect(cmd, contains('{{.Status}}'));
+    expect(cmd, isNot(contains('{{.State}}')));
   });
 
   test('docker ps status detection', () {

--- a/test/container_test.dart
+++ b/test/container_test.dart
@@ -5,10 +5,10 @@ import 'package:server_box/data/model/container/status.dart';
 void main() {
   test('docker ps parse', () {
     const raw = '''
-CONTAINER ID    STATUS                         NAMES                                              IMAGE                                              
-0e9e2ef860d2    Up 2 hours                     hbbs                                               rustdesk/rustdesk-server:latest                    
-9a4df3ed340c    Up 41 minutes                  hbbr                                               rustdesk/rustdesk-server:latest                    
-fa1215b4be74    Up 12 hours                    firefly                                            uusec/firefly:latest
+CONTAINER ID\tSTATUS\tNAMES\tIMAGE
+0e9e2ef860d2\tUp 2 hours\thbbs\trustdesk/rustdesk-server:latest
+9a4df3ed340c\tUp 41 minutes\thbbr\trustdesk/rustdesk-server:latest
+fa1215b4be74\tUp 12 hours\tfirefly\tuusec/firefly:latest
 ''';
     final lines = raw.split('\n');
     const ids = ['0e9e2ef860d2', '9a4df3ed340c', 'fa1215b4be74'];
@@ -30,6 +30,30 @@ fa1215b4be74    Up 12 hours                    firefly                          
       expect(ps.status, ContainerStatus.running);
       expect(ps.status.isRunning, true);
     }
+  });
+
+  test('docker ps parse handles long swarm container names', () {
+    const name =
+        'apps-all-stack_komari-agent.zdngp1z1t23llz9l30s86tq3g.fjmkg9amn0u76tbln96mmzlq2';
+    const image = 'registry.example.com/team/komari-agent:2026.07.10';
+    final ps = DockerPs.parse('0e9e2ef860d2\tUp 2 hours\t$name\t$image');
+
+    expect(name.length, greaterThan(50));
+    expect(ps.id, '0e9e2ef860d2');
+    expect(ps.state, 'Up 2 hours');
+    expect(ps.names, name);
+    expect(ps.image, image);
+  });
+
+  test('docker ps parse reports malformed rows', () {
+    expect(
+      () => DockerPs.parse('0e9e2ef860d2\tUp 2 hours\thbbs'),
+      throwsA(
+        isA<FormatException>()
+            .having((e) => e.message, 'message', contains('Docker ps row'))
+            .having((e) => e.message, 'message', contains('expected 4')),
+      ),
+    );
   });
 
   test('docker ps status detection', () {

--- a/test/container_test.dart
+++ b/test/container_test.dart
@@ -61,8 +61,10 @@ fa1215b4be74\tUp 12 hours\tfirefly\tuusec/firefly:latest
   test('docker ps command uses human-readable status', () {
     final cmd = ContainerCmdType.ps.exec(ContainerType.docker);
 
-    expect(cmd, contains('{{.Status}}'));
-    expect(cmd, isNot(contains('{{.State}}')));
+    expect(
+      cmd,
+      'docker ps -a --format "{{.ID}}\\t{{.Status}}\\t{{.Names}}\\t{{.Image}}"',
+    );
   });
 
   test('docker ps status detection', () {


### PR DESCRIPTION
#1226

## Summary
- Switch Docker `ps` output parsing to a tab-delimited format so long swarm names no longer break field alignment.
- Add a clear `FormatException` when a row does not contain the expected four fields.
- Extend tests to cover long swarm container names and malformed rows.

## Testing
- Added unit coverage for tab-separated Docker rows with long container names.
- Added unit coverage for malformed row validation.
- Not run (not requested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary
* **Bug Fixes**
  * Updated container listing parsing to align with tab-separated `docker ps` output.
  * Added clearer validation errors when rows are malformed.
  * Improved container refresh resilience by skipping only invalid rows instead of failing the entire update.
  * Adjusted `docker ps` command output to use status (`{{.Status}}`) and preserve image values correctly (including unusually long container names).
* **Tests**
  * Expanded coverage for parsing edge cases and malformed-row failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->