### PR TITLE
Harden server parsing and shell command handling

### DIFF
--- a/lib/data/model/server/conn.dart
+++ b/lib/data/model/server/conn.dart
@@ -21,9 +21,12 @@ class Conn {
     if (idx != '') {
       final vals = idx.split(Miscs.blankReg);
       if (vals.length <= _attemptFailsIndex) return null;
+      final maxConn = int.tryParse(vals[_maxConnIndex]);
+      final fail = int.tryParse(vals[_attemptFailsIndex]);
+      if (maxConn == null || fail == null) return null;
       return Conn(
-        maxConn: int.tryParse(vals[_maxConnIndex]) ?? 0,
-        fail: int.tryParse(vals[_attemptFailsIndex]) ?? 0,
+        maxConn: maxConn,
+        fail: fail,
       );
     }
     return null;

--- a/lib/data/model/server/conn.dart
+++ b/lib/data/model/server/conn.dart
@@ -1,6 +1,9 @@
 import 'package:server_box/data/res/misc.dart';
 
 class Conn {
+  static const _maxConnIndex = 4;
+  static const _attemptFailsIndex = 7;
+
   final int maxConn;
   final int fail;
 
@@ -17,9 +20,10 @@ class Conn {
     );
     if (idx != '') {
       final vals = idx.split(Miscs.blankReg);
+      if (vals.length <= _attemptFailsIndex) return null;
       return Conn(
-        maxConn: int.tryParse(vals[5]) ?? 0,
-        fail: int.tryParse(vals[8]) ?? 0,
+        maxConn: int.tryParse(vals[_maxConnIndex]) ?? 0,
+        fail: int.tryParse(vals[_attemptFailsIndex]) ?? 0,
       );
     }
     return null;

--- a/lib/data/model/server/cpu.dart
+++ b/lib/data/model/server/cpu.dart
@@ -135,23 +135,26 @@ class SingleCpuCore extends TimeSeqIface<SingleCpuCore> {
     final List<SingleCpuCore> cpus = [];
 
     for (var item in raw.split('\n')) {
-      if (item == '') break;
-      final id = item.split(' ').firstOrNull;
-      if (id == null) continue;
-      final matches = item.replaceFirst(id, '').trim().split(' ');
-      if (matches.length < 7) continue;
-      cpus.add(
-        SingleCpuCore(
-          id,
-          int.parse(matches[0]),
-          int.parse(matches[1]),
-          int.parse(matches[2]),
-          int.parse(matches[3]),
-          int.parse(matches[4]),
-          int.parse(matches[5]),
-          int.parse(matches[6]),
-        ),
-      );
+      item = item.trim();
+      if (item.isEmpty) break;
+      final matches = item.split(RegExp(r'\s+'));
+      if (matches.length < 8) continue;
+      try {
+        cpus.add(
+          SingleCpuCore(
+            matches[0],
+            int.parse(matches[1]),
+            int.parse(matches[2]),
+            int.parse(matches[3]),
+            int.parse(matches[4]),
+            int.parse(matches[5]),
+            int.parse(matches[6]),
+            int.parse(matches[7]),
+          ),
+        );
+      } catch (e, trace) {
+        Loggers.app.warning('Skip malformed CPU row: $item', e, trace);
+      }
     }
     return cpus;
   }

--- a/lib/data/model/server/cpu.dart
+++ b/lib/data/model/server/cpu.dart
@@ -136,8 +136,9 @@ class SingleCpuCore extends TimeSeqIface<SingleCpuCore> {
 
     for (var item in raw.split('\n')) {
       item = item.trim();
-      if (item.isEmpty) break;
+      if (item.isEmpty) continue;
       final matches = item.split(RegExp(r'\s+'));
+      if (!RegExp(r'^cpu\d*$').hasMatch(matches.first)) break;
       if (matches.length < 8) continue;
       try {
         cpus.add(

--- a/lib/data/model/server/net_speed.dart
+++ b/lib/data/model/server/net_speed.dart
@@ -79,9 +79,17 @@ class NetSpeed extends TimeSeq<NetSpeedPart> {
   /// Time diff between [pre] and [now]
   BigInt get _timeDiff => BigInt.from(now[0].time - pre[0].time);
 
-  double speedInBytes(int i) => (now[i].bytesIn - pre[i].bytesIn) / _timeDiff;
-  double speedOutBytes(int i) =>
-      (now[i].bytesOut - pre[i].bytesOut) / _timeDiff;
+  double speedInBytes(int i) {
+    final timeDiff = _timeDiff;
+    if (timeDiff <= BigInt.zero) return 0;
+    return (now[i].bytesIn - pre[i].bytesIn) / timeDiff;
+  }
+
+  double speedOutBytes(int i) {
+    final timeDiff = _timeDiff;
+    if (timeDiff <= BigInt.zero) return 0;
+    return (now[i].bytesOut - pre[i].bytesOut) / timeDiff;
+  }
   BigInt sizeInBytes(int i) => now[i].bytesIn;
   BigInt sizeOutBytes(int i) => now[i].bytesOut;
 
@@ -169,8 +177,7 @@ class NetSpeed extends TimeSeq<NetSpeedPart> {
         final data = item.trim().split(':');
         final device = data.firstOrNull;
         if (device == null) continue;
-        final bytes = data.last.trim().split(' ');
-        bytes.removeWhere((element) => element == '');
+        final bytes = data.last.trim().split(_whitespaceRegExp);
         final bytesIn = BigInt.parse(bytes.first);
         final bytesOut = BigInt.parse(bytes[8]);
         results.add(NetSpeedPart(device, bytesIn, bytesOut, time));

--- a/lib/data/provider/container.dart
+++ b/lib/data/provider/container.dart
@@ -373,18 +373,19 @@ class ContainerNotifier extends _$ContainerNotifier {
     await refresh(generation: generation);
   }
 
-  Future<ContainerErr?> stop(String id) async => await run('stop $id');
+  Future<ContainerErr?> stop(String id) async => await run('stop ${shellSingleQuote(id)}');
 
-  Future<ContainerErr?> start(String id) async => await run('start $id');
+  Future<ContainerErr?> start(String id) async => await run('start ${shellSingleQuote(id)}');
 
   Future<ContainerErr?> delete(String id, bool force) async {
     if (force) {
-      return await run('rm -f $id');
+      return await run('rm -f ${shellSingleQuote(id)}');
     }
-    return await run('rm $id');
+    return await run('rm ${shellSingleQuote(id)}');
   }
 
-  Future<ContainerErr?> restart(String id) async => await run('restart $id');
+  Future<ContainerErr?> restart(String id) async =>
+      await run('restart ${shellSingleQuote(id)}');
 
   Future<ContainerErr?> pruneImages({bool all = true}) async {
     final cmd = 'image prune${all ? " -a" : ""} -f';
@@ -477,7 +478,9 @@ String _buildSudoCmd(String baseCmd, String password) {
   return 'echo "$pwdBase64" | base64 -d | sudo -S $baseCmd';
 }
 
-String _shellQuote(String value) => "'${value.replaceAll("'", "'\\''")}'";
+String shellSingleQuote(String value) => "'${value.replaceAll("'", "'\\''")}'";
+
+String _shellQuote(String value) => shellSingleQuote(value);
 
 enum ContainerCmdType {
   version,

--- a/lib/data/ssh/persistent_shell.dart
+++ b/lib/data/ssh/persistent_shell.dart
@@ -62,6 +62,7 @@ final class PersistentShell {
   StreamSubscription<String>? _stderrSub;
   Completer<PersistentShellCommandResult>? _pending;
   final StringBuffer _buffer = StringBuffer();
+  final StringBuffer _stderrBuffer = StringBuffer();
   int _commandId = 0;
   bool _closed = false;
   Future<void> _stateLock = Future<void>.value();
@@ -97,6 +98,7 @@ final class PersistentShell {
       final completer = Completer<PersistentShellCommandResult>();
       _pending = completer;
       _buffer.clear();
+      _stderrBuffer.clear();
       final commandId = (++_commandId).toString();
       _pendingCommandId = commandId;
       final wrappedCommand = _wrapCommand(command, commandId);
@@ -213,11 +215,15 @@ printf '\\n$_donePrefix$commandId:%s\\n' "\$__server_box_exit"
     _pendingCommandId = null;
     pending.complete(
       PersistentShellCommandResult(
-        output: parsed.result.output,
+        output: [
+          parsed.result.output,
+          _stderrBuffer.toString().trim(),
+        ].where((part) => part.isNotEmpty).join('\n'),
         exitCode: parsed.result.exitCode,
       ),
     );
     _buffer.clear();
+    _stderrBuffer.clear();
     final remaining = raw.substring(parsed.consumedLength);
     if (remaining.isNotEmpty) {
       _buffer.write(remaining);
@@ -230,7 +236,7 @@ printf '\\n$_donePrefix$commandId:%s\\n' "\$__server_box_exit"
       return;
     }
 
-    _buffer.write(data);
+    _stderrBuffer.write(data);
   }
 
   void _handleStreamDone() {

--- a/lib/view/page/container/actions.dart
+++ b/lib/view/page/container/actions.dart
@@ -146,7 +146,9 @@ extension on _ContainerPageState {
       actions: Btn.ok(
         onTap: () async {
           context.pop();
-          final result = await _containerNotifier.run('rmi ${e.id} -f');
+          final result = await _containerNotifier.run(
+            'rmi ${shellSingleQuote(e.id ?? '')} -f',
+          );
           if (result != null) {
             context.showSnackBar(_errorMessage(result.message));
           }
@@ -174,7 +176,11 @@ extension on _ContainerPageState {
           actions: Btn.ok(
             onTap: () async {
               context.pop();
-              await _execContainerAction(() => _containerNotifier.run('pull $imageRef'));
+              await _execContainerAction(
+                () => _containerNotifier.run(
+                  'pull ${shellSingleQuote(imageRef)}',
+                ),
+              );
             },
           ).toList,
         );
@@ -245,7 +251,7 @@ extension on _ContainerPageState {
               '${switch (_containerState.type) {
                 ContainerType.podman => 'podman',
                 ContainerType.docker => 'docker',
-              }} logs -f --tail 100 ${dItem.id}',
+              }} logs -f --tail 100 ${shellSingleQuote(dItem.id!)}',
         );
         SSHPage.route.go(context, args);
         break;
@@ -256,7 +262,7 @@ extension on _ContainerPageState {
               '${switch (_containerState.type) {
                 ContainerType.podman => 'podman',
                 ContainerType.docker => 'docker',
-              }} exec -it ${dItem.id} sh -c "command -v bash && exec bash || command -v ash && exec ash || exec sh"',
+              }} exec -it ${shellSingleQuote(dItem.id!)} sh -c "command -v bash && exec bash || command -v ash && exec ash || exec sh"',
         );
         SSHPage.route.go(context, args);
         break;

--- a/test/conn_test.dart
+++ b/test/conn_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:server_box/data/model/server/conn.dart';
+
+void main() {
+  test('Conn.parse reads MaxConn and AttemptFails from /proc/net/snmp', () {
+    const raw = '''Tcp: RtoAlgorithm RtoMin RtoMax MaxConn ActiveOpens PassiveOpens AttemptFails EstabResets CurrEstab InSegs OutSegs RetransSegs InErrs OutRsts InCsumErrors
+Tcp: 1 200 120000 -1 11 22 33 44 55 66 77 88 99 111 222''';
+
+    final result = Conn.parse(raw);
+
+    expect(result?.maxConn, -1);
+    expect(result?.fail, 33);
+  });
+
+  test('Conn.parse rejects truncated TCP rows', () {
+    expect(Conn.parse('Tcp: 1 2 3'), isNull);
+  });
+}

--- a/test/conn_test.dart
+++ b/test/conn_test.dart
@@ -15,4 +15,10 @@ Tcp: 1 200 120000 -1 11 22 33 44 55 66 77 88 99 111 222''';
   test('Conn.parse rejects truncated TCP rows', () {
     expect(Conn.parse('Tcp: 1 2 3'), isNull);
   });
+
+  test('Conn.parse rejects non-numeric TCP counters', () {
+    const raw = 'Tcp: 1 200 120000 unknown 11 22 invalid 44';
+
+    expect(Conn.parse(raw), isNull);
+  });
 }

--- a/test/container_test.dart
+++ b/test/container_test.dart
@@ -5,6 +5,12 @@ import 'package:server_box/data/model/container/type.dart';
 import 'package:server_box/data/provider/container.dart';
 
 void main() {
+  test('shellSingleQuote escapes untrusted command arguments', () {
+    expect(shellSingleQuote('abc'), "'abc'");
+    expect(shellSingleQuote("abc'; touch /tmp/pwn; echo '"),
+        "'abc'\\''; touch /tmp/pwn; echo '\\'''",);
+  });
+
   test('docker ps parse', () {
     const raw = '''
 CONTAINER ID\tSTATUS\tNAMES\tIMAGE

--- a/test/cpu_test.dart
+++ b/test/cpu_test.dart
@@ -22,6 +22,18 @@ cpu1  8 9 10 11 12 13 14''';
 
       expect(result.map((e) => e.id), ['cpu', 'cpu1']);
     });
+
+    test('SingleCpuCore.parse skips blanks and stops at non-CPU records', () {
+      const raw = '''cpu  1 2 3 4 5 6 7
+
+cpu0  8 9 10 11 12 13 14
+intr  1 2 3 4 5 6 7
+cpu1  15 16 17 18 19 20 21''';
+
+      final result = SingleCpuCore.parse(raw);
+
+      expect(result.map((e) => e.id), ['cpu', 'cpu0']);
+    });
     test('Test Cpus calculation', () {
       final pre = SingleCpuCore.parse(
         'cpu 18232538 52837 5772391 334460731 247294 0 134107 0 0 0',

--- a/test/cpu_test.dart
+++ b/test/cpu_test.dart
@@ -12,6 +12,16 @@ void main() {
       expect(result[0].id, 'cpu');
       expect(result[0].total, 358899898);
     });
+
+    test('SingleCpuCore.parse skips malformed rows', () {
+      const raw = '''cpu  1 2 3 4 5 6 7
+cpu0  broken 2 3 4 5 6 7
+cpu1  8 9 10 11 12 13 14''';
+
+      final result = SingleCpuCore.parse(raw);
+
+      expect(result.map((e) => e.id), ['cpu', 'cpu1']);
+    });
     test('Test Cpus calculation', () {
       final pre = SingleCpuCore.parse(
         'cpu 18232538 52837 5772391 334460731 247294 0 134107 0 0 0',

--- a/test/net_speed_test.dart
+++ b/test/net_speed_test.dart
@@ -2,6 +2,15 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:server_box/data/model/server/net_speed.dart';
 
 void main() {
+  test('NetSpeed returns zero speed for equal timestamps', () {
+    final pre = [NetSpeedPart('eth0', BigInt.from(100), BigInt.from(200), 1)];
+    final now = [NetSpeedPart('eth0', BigInt.from(200), BigInt.from(400), 1)];
+    final netSpeed = NetSpeed(pre, now);
+
+    expect(netSpeed.speedInBytes(0), 0);
+    expect(netSpeed.speedOutBytes(0), 0);
+  });
+
   group('NetSpeedPart Tests', () {
     test('NetSpeedPart.same method', () {
       final part1 = NetSpeedPart(

--- a/test/persistent_shell_test.dart
+++ b/test/persistent_shell_test.dart
@@ -51,6 +51,25 @@ void main() {
     expect(result.output, 'stdout line\nstderr line');
   });
 
+  test('PersistentShell does not parse completion markers from stderr', () async {
+    final factory = _FakeSessionFactory();
+    final shell = PersistentShell(null, sessionFactory: factory.call);
+
+    final future = shell.run('echo safe');
+    await Future<void>.delayed(Duration.zero);
+    factory.session.stderrController.add(
+      Uint8List.fromList(utf8.encode('__SERVER_BOX_DONE__1:99\n')),
+    );
+    factory.session.stdoutController.add(
+      Uint8List.fromList(utf8.encode('safe\n__SERVER_BOX_DONE__1:0\n')),
+    );
+
+    final result = await future;
+
+    expect(result.exitCode, 0);
+    expect(result.output, 'safe\n__SERVER_BOX_DONE__1:99');
+  });
+
   test(
     'PersistentShell tolerates malformed UTF-8 from stdout and stderr',
     () async {


### PR DESCRIPTION
## Summary
- Tighten parsing for connection, CPU, and network stats so malformed or truncated rows are skipped instead of crashing
- Quote container IDs and image refs before sending shell commands to reduce injection risk
- Capture stderr in persistent shell output while keeping completion marker parsing isolated to stdout
- Add tests covering the new parsing and quoting behavior

## Testing
- Added unit tests for `Conn.parse`, `SingleCpuCore.parse`, `NetSpeed`, `shellSingleQuote`, and `PersistentShell`
- Existing test coverage was extended to validate malformed input handling and command-quoting behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing robustness for server TCP, CPU, and network speed data, including handling truncated or malformed rows and irregular whitespace.
  * Prevented incorrect network speed results when time delta is non-positive.
  * Adjusted persistent shell results to include stderr in the returned output without treating stderr markers as completion status.
* **Security**
  * Added consistent shell-argument quoting for container/image and SSH-related commands.
* **Tests**
  * Added/expanded unit tests covering parsing failures, malformed CPU rows, zero delta speed behavior, stderr handling, and shell argument escaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->