### PR TITLE
fix: use CONTAINER_HOST for Podman

### DIFF
--- a/lib/data/provider/container.dart
+++ b/lib/data/provider/container.dart
@@ -464,14 +464,13 @@ class ContainerNotifier extends _$ContainerNotifier {
 
   /// Wrap commands with the container runtime host environment variable.
   String _wrap(String cmd) {
-    final dockerHost = Stores.container.fetch(hostId);
+    final containerHost = Stores.container.fetch(hostId, state.type);
     cmd = 'export LANG=en_US.UTF-8 && $cmd';
-    final noDockerHost = dockerHost?.isEmpty ?? true;
-    if (!noDockerHost) {
+    if (containerHost?.isNotEmpty ?? false) {
       final hostVariable = state.type == ContainerType.podman
           ? 'CONTAINER_HOST'
           : 'DOCKER_HOST';
-      cmd = 'export $hostVariable=${shellSingleQuote(dockerHost!)} && $cmd';
+      cmd = 'export $hostVariable=${shellSingleQuote(containerHost!)} && $cmd';
     }
     return cmd;
   }

--- a/lib/data/provider/container.dart
+++ b/lib/data/provider/container.dart
@@ -118,9 +118,7 @@ class ContainerNotifier extends _$ContainerNotifier {
     }
 
     try {
-      final res = await client?.run(
-        _wrap(ContainerCmdType.images.exec(type)),
-      );
+      final res = await client?.run(_wrap(ContainerCmdType.images.exec(type)));
       if (res?.string.toLowerCase().contains('permission denied') ?? false) {
         return completer.complete(true);
       }
@@ -321,9 +319,7 @@ class ContainerNotifier extends _$ContainerNotifier {
       } else {
         final lines = imageRaw.split('\n');
         lines.removeWhere((element) => element.isEmpty);
-        images = lines
-            .map((e) => ContainerImg.fromRawJson(e, type))
-            .toList();
+        images = lines.map((e) => ContainerImg.fromRawJson(e, type)).toList();
       }
       state = state.copyWith(images: images);
     } catch (e, trace) {
@@ -378,9 +374,11 @@ class ContainerNotifier extends _$ContainerNotifier {
     await refresh(generation: generation);
   }
 
-  Future<ContainerErr?> stop(String id) async => await run('stop ${shellSingleQuote(id)}');
+  Future<ContainerErr?> stop(String id) async =>
+      await run('stop ${shellSingleQuote(id)}');
 
-  Future<ContainerErr?> start(String id) async => await run('start ${shellSingleQuote(id)}');
+  Future<ContainerErr?> start(String id) async =>
+      await run('start ${shellSingleQuote(id)}');
 
   Future<ContainerErr?> delete(String id, bool force) async {
     if (force) {
@@ -464,13 +462,16 @@ class ContainerNotifier extends _$ContainerNotifier {
     return null;
   }
 
-  /// wrap cmd with `docker host`
+  /// Wrap commands with the container runtime host environment variable.
   String _wrap(String cmd) {
     final dockerHost = Stores.container.fetch(hostId);
     cmd = 'export LANG=en_US.UTF-8 && $cmd';
     final noDockerHost = dockerHost?.isEmpty ?? true;
     if (!noDockerHost) {
-      cmd = 'export DOCKER_HOST=${shellSingleQuote(dockerHost!)} && $cmd';
+      final hostVariable = state.type == ContainerType.podman
+          ? 'CONTAINER_HOST'
+          : 'DOCKER_HOST';
+      cmd = 'export $hostVariable=${shellSingleQuote(dockerHost!)} && $cmd';
     }
     return cmd;
   }

--- a/lib/data/store/container.dart
+++ b/lib/data/store/container.dart
@@ -3,19 +3,27 @@ import 'package:server_box/data/model/container/type.dart';
 import 'package:server_box/data/res/store.dart';
 
 const _keyConfig = 'providerConfig';
+const _keyHost = 'containerHost';
 
 class ContainerStore extends HiveStore {
   ContainerStore._() : super('docker');
 
   static final instance = ContainerStore._();
 
-  String? fetch(String? id) {
+  String? fetch(String? id, ContainerType type) {
+    final host = box.get(_hostKey(id, type));
+    if (host != null || type == ContainerType.podman) return host;
+
+    // Preserve existing Docker host settings stored before per-runtime hosts.
     return box.get(id);
   }
 
-  void put(String id, String host) {
-    set(id, host);
+  void put(String id, ContainerType type, String host) {
+    set(_hostKey(id, type), host);
   }
+
+  String _hostKey(String? id, ContainerType type) =>
+      '$_keyHost${type.name}${id ?? ''}';
 
   ContainerType getType([String id = '']) {
     final cfg = box.get(_keyConfig + id);

--- a/lib/data/store/container.dart
+++ b/lib/data/store/container.dart
@@ -22,6 +22,10 @@ class ContainerStore extends HiveStore {
     set(_hostKey(id, type), host);
   }
 
+  void removeHost(String id, ContainerType type) {
+    remove(_hostKey(id, type));
+  }
+
   String _hostKey(String? id, ContainerType type) =>
       '$_keyHost${type.name}${id ?? ''}';
 

--- a/lib/data/store/container.dart
+++ b/lib/data/store/container.dart
@@ -24,6 +24,7 @@ class ContainerStore extends HiveStore {
 
   void removeHost(String id, ContainerType type) {
     remove(_hostKey(id, type));
+    remove(id);
   }
 
   String _hostKey(String? id, ContainerType type) =>

--- a/lib/data/store/server.dart
+++ b/lib/data/store/server.dart
@@ -1,3 +1,4 @@
+import 'package:server_box/data/model/container/type.dart';
 import 'package:server_box/data/model/server/server_private_info.dart';
 import 'package:server_box/data/store/cached_store.dart';
 import 'package:server_box/data/store/container.dart';
@@ -59,10 +60,10 @@ class ServerStore extends CachedHiveStore<Spi> {
         }
       }
 
-      final dockerHost = container.fetch(oldId);
+      final dockerHost = container.fetch(oldId, ContainerType.docker);
       if (dockerHost != null) {
         container.remove(oldId);
-        container.set(newId, dockerHost);
+        container.put(newId, ContainerType.docker, dockerHost);
       }
     }
 

--- a/lib/data/store/server.dart
+++ b/lib/data/store/server.dart
@@ -62,7 +62,7 @@ class ServerStore extends CachedHiveStore<Spi> {
 
       final dockerHost = container.fetch(oldId, ContainerType.docker);
       if (dockerHost != null) {
-        container.remove(oldId);
+        container.removeHost(oldId, ContainerType.docker);
         container.put(newId, ContainerType.docker, dockerHost);
       }
     }

--- a/lib/view/page/container/actions.dart
+++ b/lib/view/page/container/actions.dart
@@ -117,7 +117,7 @@ extension on _ContainerPageState {
 
   Future<void> _showEditHostDialog() async {
     final id = widget.args.spi.id;
-    final host = Stores.container.fetch(id);
+    final host = Stores.container.fetch(id, _containerState.type);
     final hostVariable = _containerState.type == ContainerType.podman
         ? 'CONTAINER_HOST'
         : 'DOCKER_HOST';
@@ -127,19 +127,19 @@ extension on _ContainerPageState {
       child: Input(
         maxLines: 2,
         controller: ctrl,
-        onSubmitted: _onSaveDockerHost,
+        onSubmitted: _onSaveContainerHost,
         hint: hostVariable == 'CONTAINER_HOST'
-            ? 'unix:///run/podman/podman.sock'
+            ? r'$XDG_RUNTIME_DIR/podman/podman.sock'
             : 'unix:///run/user/1000/docker.sock',
         suggestion: false,
       ),
-      actions: Btn.ok(onTap: () => _onSaveDockerHost(ctrl.text)).toList,
+      actions: Btn.ok(onTap: () => _onSaveContainerHost(ctrl.text)).toList,
     );
   }
 
-  void _onSaveDockerHost(String val) {
+  void _onSaveContainerHost(String val) {
     context.pop();
-    Stores.container.put(widget.args.spi.id, val.trim());
+    Stores.container.put(widget.args.spi.id, _containerState.type, val.trim());
     _containerNotifier.resetSudoProbe();
     _containerNotifier.refresh();
   }

--- a/lib/view/page/container/actions.dart
+++ b/lib/view/page/container/actions.dart
@@ -13,7 +13,9 @@ extension on _ContainerPageState {
   }
 
   /// Execute a container action with loading dialog and error handling.
-  Future<void> _execContainerAction(Future<ContainerErr?> Function() action) async {
+  Future<void> _execContainerAction(
+    Future<ContainerErr?> Function() action,
+  ) async {
     final (result, err) = await context.showLoadingDialog(fn: action);
     if (!mounted) return;
     if (err != null || result != null) {
@@ -116,6 +118,9 @@ extension on _ContainerPageState {
   Future<void> _showEditHostDialog() async {
     final id = widget.args.spi.id;
     final host = Stores.container.fetch(id);
+    final hostVariable = _containerState.type == ContainerType.podman
+        ? 'CONTAINER_HOST'
+        : 'DOCKER_HOST';
     final ctrl = TextEditingController(text: host);
     await context.showRoundDialog(
       title: libL10n.edit,
@@ -123,7 +128,9 @@ extension on _ContainerPageState {
         maxLines: 2,
         controller: ctrl,
         onSubmitted: _onSaveDockerHost,
-        hint: 'unix:///run/user/1000/docker.sock',
+        hint: hostVariable == 'CONTAINER_HOST'
+            ? 'unix:///run/podman/podman.sock'
+            : 'unix:///run/user/1000/docker.sock',
         suggestion: false,
       ),
       actions: Btn.ok(onTap: () => _onSaveDockerHost(ctrl.text)).toList,
@@ -230,7 +237,9 @@ extension on _ContainerPageState {
           actions: Btn.ok(
             onTap: () async {
               context.pop();
-              await _execContainerAction(() => _containerNotifier.delete(id, force));
+              await _execContainerAction(
+                () => _containerNotifier.delete(id, force),
+              );
             },
           ).toList,
         );

--- a/lib/view/page/container/container.dart
+++ b/lib/view/page/container/container.dart
@@ -392,7 +392,7 @@ class _ContainerPageState extends ConsumerState<ContainerPage> {
   ) {
     final String title;
     switch (item) {
-      case _SettingsMenuItems.editDockerHost:
+      case _SettingsMenuItems.editContainerHost:
         final hostVariable = containerState.type == ContainerType.podman
             ? 'CONTAINER_HOST'
             : 'DOCKER_HOST';
@@ -407,7 +407,7 @@ class _ContainerPageState extends ConsumerState<ContainerPage> {
     return ListTile(
       onTap: () {
         switch (item) {
-          case _SettingsMenuItems.editDockerHost:
+          case _SettingsMenuItems.editContainerHost:
             _showEditHostDialog();
             break;
           case _SettingsMenuItems.switchProvider:

--- a/lib/view/page/container/container.dart
+++ b/lib/view/page/container/container.dart
@@ -393,7 +393,10 @@ class _ContainerPageState extends ConsumerState<ContainerPage> {
     final String title;
     switch (item) {
       case _SettingsMenuItems.editDockerHost:
-        title = '${libL10n.edit} DOCKER_HOST';
+        final hostVariable = containerState.type == ContainerType.podman
+            ? 'CONTAINER_HOST'
+            : 'DOCKER_HOST';
+        title = '${libL10n.edit} $hostVariable';
         break;
       case _SettingsMenuItems.switchProvider:
         title = containerState.type == ContainerType.podman

--- a/lib/view/page/container/types.dart
+++ b/lib/view/page/container/types.dart
@@ -1,6 +1,6 @@
 part of 'container.dart';
 
-enum _SettingsMenuItems { editDockerHost, switchProvider }
+enum _SettingsMenuItems { editContainerHost, switchProvider }
 
 enum _PruneTypes {
   images,


### PR DESCRIPTION
## Summary
- use CONTAINER_HOST when executing Podman commands
- keep DOCKER_HOST for Docker commands
- update the container settings label and socket hint for the selected runtime

## Validation
- flutter analyze lib/data/provider/container.dart lib/view/page/container/container.dart lib/view/page/container/actions.dart
- flutter test test/container_test.dart

Related to #1232.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Podman-aware host configuration, showing and editing `CONTAINER_HOST` for Podman and `DOCKER_HOST` for Docker.
  * Updated the container host editor dialog and settings tiles to follow the selected container runtime.
* **Bug Fixes**
  * Fixed container host values to be saved and retrieved per runtime, preventing cross-runtime mix-ups.
  * Improved server Docker-container ID migration to preserve the correct Docker host settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->