### PR TITLE
fix(ssh): Windows IME candidate window text not sent to terminal

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,8 @@
 	branch = master
 [submodule "xterm"]
 	path = packages/xterm
-	url = https://github.com/LittleWool/xterm.dart
-	branch = fix/windows-ime-input
+	url = https://github.com/lollipopkit/xterm.dart
+	branch = master
 [submodule "fl_lib"]
 	path = packages/fl_lib
 	url = https://github.com/lollipopkit/fl_lib

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,8 +4,8 @@
 	branch = master
 [submodule "xterm"]
 	path = packages/xterm
-	url = https://github.com/lollipopkit/xterm.dart
-	branch = master
+	url = https://github.com/LittleWool/xterm.dart
+	branch = fix/windows-ime-input
 [submodule "fl_lib"]
 	path = packages/fl_lib
 	url = https://github.com/lollipopkit/fl_lib


### PR DESCRIPTION
Fix Windows IME candidate window text not sent to terminal.

Depends on https://github.com/lollipopkit/xterm.dart/pull/11

## Problem
On Windows, when using an IME (e.g., Microsoft Pinyin, Sogou), text selected from the candidate window is not sent to the terminal.

## Root Cause
`updateEditingValue` in xterm's `custom_text_edit.dart` incorrectly computes text deltas from the previous composing text length. When IME composing ends and commits text of a different length (e.g., "ni" → "你"), the code misinterprets it as a deletion.

## Changes
- Update xterm submodule to `LittleWool/xterm.dart` fix/windows-ime-input branch which contains the fix
- See xterm.dart PR #11 for the actual code change

## Testing
- Build Windows version and test with Microsoft Pinyin IME
- Committed text from candidate window should now appear in the terminal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the terminal component to a newer maintenance revision, including the latest available improvements and fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->