### PR TITLE
fix: use systemctl to list units

### DIFF
--- a/lib/data/model/server/systemd.dart
+++ b/lib/data/model/server/systemd.dart
@@ -42,6 +42,15 @@ enum SystemdUnitScope {
     }
     return 'systemctl --user';
   }
+
+  /// Command to enumerate units for this scope.
+  ///
+  /// Listing is read-only, so no `sudo` is needed even for the system scope.
+  String get listUnitsCmd {
+    final prefix = this == system ? 'systemctl' : 'systemctl --user';
+    return '$prefix list-units --all --no-legend --no-pager --plain '
+        '--type=service,socket,mount,timer';
+  }
 }
 
 enum SystemdScopeFilter {
@@ -91,6 +100,44 @@ final class SystemdUnit {
   String getCmd({required SystemdUnitFunc func, required bool isRoot}) {
     final prefix = scope.getCmdPrefix(isRoot);
     return '$prefix ${func.name} ${name.replaceAll(RegExp(r'[^a-zA-Z0-9\-_.@:]'), '')}';
+  }
+
+  /// Parses the output of `systemctl list-units --plain --no-legend`.
+  ///
+  /// Each line has the columns: `UNIT LOAD ACTIVE SUB DESCRIPTION...`, where
+  /// the description is the (possibly multi-word) remainder of the line.
+  /// Lines with an unsupported unit type or unmapped active state are skipped.
+  static List<SystemdUnit> parseListUnits(
+    String output,
+    SystemdUnitScope scope,
+  ) {
+    final units = <SystemdUnit>[];
+    for (final line in output.split('\n')) {
+      final trimmed = line.trim();
+      if (trimmed.isEmpty) continue;
+
+      final parts = trimmed.split(RegExp(r'\s+'));
+      if (parts.length < 4) continue;
+
+      final fullName = parts[0];
+      final lastDot = fullName.lastIndexOf('.');
+      if (lastDot <= 0) continue;
+
+      final type = SystemdUnitType.fromString(fullName.substring(lastDot + 1));
+      if (type == null) continue;
+
+      final state = SystemdUnitState.fromString(parts[2]);
+      if (state == null) continue;
+
+      units.add(SystemdUnit(
+        name: fullName.substring(0, lastDot),
+        type: type,
+        scope: scope,
+        state: state,
+        description: parts.length > 4 ? parts.sublist(4).join(' ') : null,
+      ));
+    }
+    return units;
   }
 
   List<SystemdUnitFunc> get availableFuncs {

--- a/lib/data/provider/systemd.dart
+++ b/lib/data/provider/systemd.dart
@@ -2,7 +2,6 @@ import 'package:fl_lib/fl_lib.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:server_box/core/extension/ssh_client.dart';
-import 'package:server_box/data/model/app/scripts/script_consts.dart';
 import 'package:server_box/data/model/server/server_private_info.dart';
 import 'package:server_box/data/model/server/systemd.dart';
 import 'package:server_box/data/provider/server/single.dart';
@@ -56,154 +55,39 @@ class SystemdNotifier extends _$SystemdNotifier {
 
     try {
       final client = _si.client;
-      final result = await client!.execForOutput(_getUnitsCmd);
-      final units = result.split('\n');
+      if (client == null) return;
 
-      final userUnits = <String>[];
-      final systemUnits = <String>[];
-      for (final unit in units) {
-        final maybeSystem = unit.contains('/systemd/system');
-        final maybeUser = unit.contains('/.config/systemd/user');
-        if (maybeSystem && !maybeUser) {
-          systemUnits.add(unit);
-        } else {
-          userUnits.add(unit);
-        }
-      }
-
-      final parsedUserUnits = await _parseUnitObj(
-        userUnits,
-        SystemdUnitScope.user,
-      );
-      final parsedSystemUnits = await _parseUnitObj(
-        systemUnits,
+      final systemUnits = SystemdUnit.parseListUnits(
+        await client.execForOutput(SystemdUnitScope.system.listUnitsCmd),
         SystemdUnitScope.system,
       );
-      state = state.copyWith(
-        units: [...parsedUserUnits, ...parsedSystemUnits],
-        isBusy: false,
+
+      // The user manager may be unavailable over SSH (no session bus). Its
+      // error output simply parses to no units, so no special handling is
+      // needed here.
+      final userUnits = SystemdUnit.parseListUnits(
+        await client.execForOutput(SystemdUnitScope.user.listUnitsCmd),
+        SystemdUnitScope.user,
       );
+
+      final units = [...userUnits, ...systemUnits]..sort(_compareUnits);
+      state = state.copyWith(units: units);
     } catch (e, s) {
       dprint('Parse systemd', e, s);
+    } finally {
       state = state.copyWith(isBusy: false);
     }
   }
-
-  Future<List<SystemdUnit>> _parseUnitObj(
-    List<String> unitNames,
-    SystemdUnitScope scope,
-  ) async {
-    final unitNames_ = unitNames.map((e) {
-      final fullName = e.trim().split('/').last;
-      final lastDot = fullName.lastIndexOf('.');
-      final name = lastDot > 0 ? fullName.substring(0, lastDot) : fullName;
-      return name.replaceAll(RegExp(r'[^a-zA-Z0-9\-_.@:]'), '');
-    }).toList();
-    final script =
-        '''
-for unit in ${unitNames_.map((e) => '"$e"').join(' ')}; do
-  state=\$(systemctl show --no-pager -- "\$unit")
-  echo "\$state"
-  echo -n "\n${ScriptConstants.separator}\n"
-done
-''';
-    final client = _si.client!;
-    final result = await client.execForOutput(script);
-    final units = result.split(ScriptConstants.separator);
-
-    final parsedUnits = <SystemdUnit>[];
-    for (final unit in units.where((e) => e.trim().isNotEmpty)) {
-      final parts = unit.split('\n').where((e) => e.trim().isNotEmpty).toList();
-      if (parts.isEmpty) continue;
-      var name = '';
-      var type = '';
-      var state = '';
-      String? description;
-      for (final part in parts) {
-        if (part.startsWith('Id=')) {
-          final val = _getIniVal(part);
-          if (val == null) continue;
-          // Id=org.cups.cupsd.service
-          final lastDot = val.lastIndexOf('.');
-          if (lastDot > 0) {
-            name = val.substring(0, lastDot);
-            type = val.substring(lastDot + 1);
-          } else {
-            name = val;
-            type = '';
-          }
-          continue;
-        }
-        if (part.startsWith('ActiveState=')) {
-          final val = _getIniVal(part);
-          if (val == null) continue;
-          state = val;
-          continue;
-        }
-        if (part.startsWith('Description=')) {
-          description = _getIniVal(part);
-          continue;
-        }
-      }
-
-      final unitType = SystemdUnitType.fromString(type);
-      if (unitType == null) {
-        dprint('Unit type: $type');
-        continue;
-      }
-      final unitState = SystemdUnitState.fromString(state);
-      if (unitState == null) {
-        dprint('Unit state: $state');
-        continue;
-      }
-
-      parsedUnits.add(
-        SystemdUnit(
-          name: name,
-          type: unitType,
-          scope: scope,
-          state: unitState,
-          description: description,
-        ),
-      );
-    }
-
-    parsedUnits.sort((a, b) {
-      // user units first
-      if (a.scope != b.scope) {
-        return a.scope == SystemdUnitScope.user ? -1 : 1;
-      }
-      // active units first
-      if (a.state != b.state) {
-        return a.state == SystemdUnitState.active ? -1 : 1;
-      }
-      return a.name.compareTo(b.name);
-    });
-    return parsedUnits;
-  }
-
-  late final _getUnitsCmd = '''
-    types="service socket mount timer"
-
-    get_files() {
-      unit_type=\$1
-      base_dir=\$2
-      [ -d "\$base_dir" ] || return
-      find "\$base_dir" -type f -name "*.\$unit_type" -print
-    }
-
-    for type in \$types; do
-      get_files \$type /etc/systemd/system
-      # Parsing these paths can lead to SSH transport closed errors
-      # get_files \$type /lib/systemd/system
-      # get_files \$type /usr/lib/systemd/system
-      get_files \$type ~/.config/systemd/user
-    done | sort
-    ''';
 }
 
-String? _getIniVal(String line) {
-  final idx = line.indexOf('=');
-  if (idx < 0) return null;
-  return line.substring(idx + 1).trim();
+int _compareUnits(SystemdUnit a, SystemdUnit b) {
+  // user units first
+  if (a.scope != b.scope) {
+    return a.scope == SystemdUnitScope.user ? -1 : 1;
+  }
+  // active units first
+  if (a.state != b.state) {
+    return a.state == SystemdUnitState.active ? -1 : 1;
+  }
+  return a.name.compareTo(b.name);
 }

--- a/lib/data/provider/systemd.dart
+++ b/lib/data/provider/systemd.dart
@@ -71,10 +71,13 @@ class SystemdNotifier extends _$SystemdNotifier {
       final client = _si.client;
       if (client == null) return SystemdRefreshResult.systemFailed;
 
-      final systemUnits = SystemdUnit.parseListUnits(
-        await client.execForOutput(SystemdUnitScope.system.listUnitsCmd),
-        SystemdUnitScope.system,
-      );
+      final systemRaw =
+          await client.execForOutput(SystemdUnitScope.system.listUnitsCmd);
+      final systemUnits =
+          SystemdUnit.parseListUnits(systemRaw, SystemdUnitScope.system);
+      if (_listFailed(systemRaw, systemUnits)) {
+        return SystemdRefreshResult.systemFailed;
+      }
 
       var userUnits = <SystemdUnit>[];
       var userFailed = false;
@@ -82,10 +85,7 @@ class SystemdNotifier extends _$SystemdNotifier {
         final userRaw =
             await client.execForOutput(SystemdUnitScope.user.listUnitsCmd);
         userUnits = SystemdUnit.parseListUnits(userRaw, SystemdUnitScope.user);
-        // A successful-but-empty list yields no output. Non-empty output that
-        // parses to no units means systemctl printed an error instead (e.g.
-        // no session bus), which is a failure worth surfacing.
-        userFailed = userUnits.isEmpty && userRaw.trim().isNotEmpty;
+        userFailed = _listFailed(userRaw, userUnits);
       } catch (e, s) {
         dprint('Systemd user units', e, s);
         userFailed = true;
@@ -104,6 +104,12 @@ class SystemdNotifier extends _$SystemdNotifier {
     }
   }
 }
+
+/// systemctl prints nothing for an empty list, so non-empty output that yields
+/// no units means it reported an error (no session bus, systemd not the init
+/// system, command missing) rather than an empty list.
+bool _listFailed(String raw, List<SystemdUnit> units) =>
+    units.isEmpty && raw.trim().isNotEmpty;
 
 int _compareUnits(SystemdUnit a, SystemdUnit b) {
   // user units first

--- a/lib/data/provider/systemd.dart
+++ b/lib/data/provider/systemd.dart
@@ -1,3 +1,4 @@
+import 'package:dartssh2/dartssh2.dart';
 import 'package:fl_lib/fl_lib.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -71,45 +72,43 @@ class SystemdNotifier extends _$SystemdNotifier {
       final client = _si.client;
       if (client == null) return SystemdRefreshResult.systemFailed;
 
-      final systemRaw =
-          await client.execForOutput(SystemdUnitScope.system.listUnitsCmd);
-      final systemUnits =
-          SystemdUnit.parseListUnits(systemRaw, SystemdUnitScope.system);
-      if (_listFailed(systemRaw, systemUnits)) {
-        return SystemdRefreshResult.systemFailed;
-      }
+      final system = await _listScope(client, SystemdUnitScope.system);
+      if (system.failed) return SystemdRefreshResult.systemFailed;
 
-      var userUnits = <SystemdUnit>[];
-      var userFailed = false;
-      try {
-        final userRaw =
-            await client.execForOutput(SystemdUnitScope.user.listUnitsCmd);
-        userUnits = SystemdUnit.parseListUnits(userRaw, SystemdUnitScope.user);
-        userFailed = _listFailed(userRaw, userUnits);
-      } catch (e, s) {
-        dprint('Systemd user units', e, s);
-        userFailed = true;
-      }
+      final user = await _listScope(client, SystemdUnitScope.user);
 
-      final units = [...userUnits, ...systemUnits]..sort(_compareUnits);
+      final units = [...user.units, ...system.units]..sort(_compareUnits);
       state = state.copyWith(units: units);
-      return userFailed
+      return user.failed
           ? SystemdRefreshResult.userFailed
           : SystemdRefreshResult.ok;
     } catch (e, s) {
-      dprint('Parse systemd', e, s);
+      dprint('Systemd refresh', e, s);
       return SystemdRefreshResult.systemFailed;
     } finally {
       state = state.copyWith(isBusy: false);
     }
   }
-}
 
-/// systemctl prints nothing for an empty list, so non-empty output that yields
-/// no units means it reported an error (no session bus, systemd not the init
-/// system, command missing) rather than an empty list.
-bool _listFailed(String raw, List<SystemdUnit> units) =>
-    units.isEmpty && raw.trim().isNotEmpty;
+  /// Lists the units of [scope].
+  ///
+  /// systemctl prints nothing for an empty list, so non-empty output that
+  /// yields no units means it reported an error (no session bus, systemd not
+  /// the init system, command missing) rather than an empty list.
+  Future<({List<SystemdUnit> units, bool failed})> _listScope(
+    SSHClient client,
+    SystemdUnitScope scope,
+  ) async {
+    try {
+      final raw = await client.execForOutput(scope.listUnitsCmd);
+      final units = SystemdUnit.parseListUnits(raw, scope);
+      return (units: units, failed: units.isEmpty && raw.trim().isNotEmpty);
+    } catch (e, s) {
+      dprint('Systemd ${scope.name} units', e, s);
+      return (units: const <SystemdUnit>[], failed: true);
+    }
+  }
+}
 
 int _compareUnits(SystemdUnit a, SystemdUnit b) {
   // user units first

--- a/lib/data/provider/systemd.dart
+++ b/lib/data/provider/systemd.dart
@@ -9,6 +9,19 @@ import 'package:server_box/data/provider/server/single.dart';
 part 'systemd.freezed.dart';
 part 'systemd.g.dart';
 
+/// Outcome of [SystemdNotifier.getUnits], so the view can inform the user
+/// about what failed.
+enum SystemdRefreshResult {
+  ok,
+
+  /// System units could not be listed at all (no client or command failed).
+  systemFailed,
+
+  /// System units loaded, but the user manager could not be queried (e.g. no
+  /// session bus over SSH). User units are simply absent.
+  userFailed,
+}
+
 @freezed
 abstract class SystemdState with _$SystemdState {
   const factory SystemdState({
@@ -26,8 +39,7 @@ class SystemdNotifier extends _$SystemdNotifier {
   SystemdState build(Spi spi) {
     final si = ref.read(serverProvider(spi.id));
     _si = si;
-    // Async initialization
-    Future.microtask(() => getUnits());
+    // The initial load is driven by the view so it can surface failures.
     return const SystemdState();
   }
 
@@ -50,30 +62,43 @@ class SystemdNotifier extends _$SystemdNotifier {
     state = state.copyWith(scopeFilter: filter);
   }
 
-  Future<void> getUnits() async {
+  /// Refreshes the unit list and reports what, if anything, failed so the view
+  /// can inform the user instead of silently dropping units.
+  Future<SystemdRefreshResult> getUnits() async {
     state = state.copyWith(isBusy: true);
 
     try {
       final client = _si.client;
-      if (client == null) return;
+      if (client == null) return SystemdRefreshResult.systemFailed;
 
       final systemUnits = SystemdUnit.parseListUnits(
         await client.execForOutput(SystemdUnitScope.system.listUnitsCmd),
         SystemdUnitScope.system,
       );
 
-      // The user manager may be unavailable over SSH (no session bus). Its
-      // error output simply parses to no units, so no special handling is
-      // needed here.
-      final userUnits = SystemdUnit.parseListUnits(
-        await client.execForOutput(SystemdUnitScope.user.listUnitsCmd),
-        SystemdUnitScope.user,
-      );
+      var userUnits = <SystemdUnit>[];
+      var userFailed = false;
+      try {
+        final userRaw =
+            await client.execForOutput(SystemdUnitScope.user.listUnitsCmd);
+        userUnits = SystemdUnit.parseListUnits(userRaw, SystemdUnitScope.user);
+        // A successful-but-empty list yields no output. Non-empty output that
+        // parses to no units means systemctl printed an error instead (e.g.
+        // no session bus), which is a failure worth surfacing.
+        userFailed = userUnits.isEmpty && userRaw.trim().isNotEmpty;
+      } catch (e, s) {
+        dprint('Systemd user units', e, s);
+        userFailed = true;
+      }
 
       final units = [...userUnits, ...systemUnits]..sort(_compareUnits);
       state = state.copyWith(units: units);
+      return userFailed
+          ? SystemdRefreshResult.userFailed
+          : SystemdRefreshResult.ok;
     } catch (e, s) {
       dprint('Parse systemd', e, s);
+      return SystemdRefreshResult.systemFailed;
     } finally {
       state = state.copyWith(isBusy: false);
     }

--- a/lib/data/provider/systemd.dart
+++ b/lib/data/provider/systemd.dart
@@ -10,18 +10,8 @@ import 'package:server_box/data/provider/server/single.dart';
 part 'systemd.freezed.dart';
 part 'systemd.g.dart';
 
-/// Outcome of [SystemdNotifier.getUnits], so the view can inform the user
-/// about what failed.
-enum SystemdRefreshResult {
-  ok,
-
-  /// System units could not be listed at all (no client or command failed).
-  systemFailed,
-
-  /// System units loaded, but the user manager could not be queried (e.g. no
-  /// session bus over SSH). User units are simply absent.
-  userFailed,
-}
+/// Outcome of [SystemdNotifier.getUnits], so the view can report what failed.
+enum SystemdRefreshResult { ok, systemFailed, userFailed }
 
 @freezed
 abstract class SystemdState with _$SystemdState {
@@ -63,8 +53,7 @@ class SystemdNotifier extends _$SystemdNotifier {
     state = state.copyWith(scopeFilter: filter);
   }
 
-  /// Refreshes the unit list and reports what, if anything, failed so the view
-  /// can inform the user instead of silently dropping units.
+  /// System units are essential; user units are optional and only reported.
   Future<SystemdRefreshResult> getUnits() async {
     state = state.copyWith(isBusy: true);
 
@@ -90,11 +79,8 @@ class SystemdNotifier extends _$SystemdNotifier {
     }
   }
 
-  /// Lists the units of [scope].
-  ///
-  /// systemctl prints nothing for an empty list, so non-empty output that
-  /// yields no units means it reported an error (no session bus, systemd not
-  /// the init system, command missing) rather than an empty list.
+  /// systemctl prints nothing for an empty list, so non-empty output yielding
+  /// no units means it reported an error rather than an empty list.
   Future<({List<SystemdUnit> units, bool failed})> _listScope(
     SSHClient client,
     SystemdUnitScope scope,

--- a/lib/view/page/systemd.dart
+++ b/lib/view/page/systemd.dart
@@ -33,19 +33,6 @@ final class _SystemdPageState extends ConsumerState<SystemdPage> {
     Future.microtask(_refresh);
   }
 
-  Future<void> _refresh() async {
-    final result = await _notifier.getUnits();
-    if (!mounted) return;
-    switch (result) {
-      case SystemdRefreshResult.ok:
-        break;
-      case SystemdRefreshResult.systemFailed:
-        context.showSnackBar(libL10n.error);
-      case SystemdRefreshResult.userFailed:
-        context.showSnackBar('${libL10n.fail}: ${libL10n.user}');
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -208,5 +195,20 @@ final class _SystemdPageState extends ConsumerState<SystemdPage> {
         style: UIs.text11,
       ).paddingSymmetric(horizontal: 5, vertical: 1),
     ).paddingOnly(right: noPad ? 0 : 5);
+  }
+}
+
+extension _SystemdPageActions on _SystemdPageState {
+  Future<void> _refresh() async {
+    final result = await _notifier.getUnits();
+    if (!mounted) return;
+    switch (result) {
+      case SystemdRefreshResult.ok:
+        break;
+      case SystemdRefreshResult.systemFailed:
+        context.showSnackBar(libL10n.error);
+      case SystemdRefreshResult.userFailed:
+        context.showSnackBar('${libL10n.fail}: ${libL10n.user}');
+    }
   }
 }

--- a/lib/view/page/systemd.dart
+++ b/lib/view/page/systemd.dart
@@ -28,6 +28,25 @@ final class _SystemdPageState extends ConsumerState<SystemdPage> {
   late final _notifier = ref.read(_pro.notifier);
 
   @override
+  void initState() {
+    super.initState();
+    Future.microtask(_refresh);
+  }
+
+  Future<void> _refresh() async {
+    final result = await _notifier.getUnits();
+    if (!mounted) return;
+    switch (result) {
+      case SystemdRefreshResult.ok:
+        break;
+      case SystemdRefreshResult.systemFailed:
+        context.showSnackBar(libL10n.error);
+      case SystemdRefreshResult.userFailed:
+        context.showSnackBar('${libL10n.fail}: ${libL10n.user}');
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: CustomAppBar(
@@ -37,13 +56,13 @@ final class _SystemdPageState extends ConsumerState<SystemdPage> {
             ? [
                 Btn.icon(
                   icon: const Icon(Icons.refresh),
-                  onTap: _notifier.getUnits,
+                  onTap: _refresh,
                 ),
               ]
             : null,
       ),
       body: RefreshIndicator(
-        onRefresh: _notifier.getUnits,
+        onRefresh: _refresh,
         child: _buildBody(),
       ),
     );

--- a/test/systemd_test.dart
+++ b/test/systemd_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:server_box/data/model/server/systemd.dart';
+
+void main() {
+  group('SystemdUnit.parseListUnits', () {
+    test('parses `systemctl list-units --plain --no-legend` output', () {
+      final units = SystemdUnit.parseListUnits(
+        _listUnitsOutput,
+        SystemdUnitScope.system,
+      );
+
+      // session-1.scope is an unsupported unit type and must be skipped;
+      // reloading.service has an unmapped active state and must be skipped too.
+      expect(units.length, 6);
+
+      final sshd = units.firstWhere((u) => u.name == 'sshd');
+      expect(sshd.type, SystemdUnitType.service);
+      expect(sshd.state, SystemdUnitState.active);
+      expect(sshd.scope, SystemdUnitScope.system);
+      expect(sshd.description, 'OpenSSH server daemon');
+
+      // Multi-word description keeps all trailing columns.
+      final nginx = units.firstWhere((u) => u.name == 'nginx');
+      expect(nginx.state, SystemdUnitState.inactive);
+      expect(
+        nginx.description,
+        'A high performance web server and a reverse proxy server',
+      );
+
+      final broken = units.firstWhere((u) => u.name == 'broken');
+      expect(broken.state, SystemdUnitState.failed);
+
+      expect(units.firstWhere((u) => u.name == 'dbus').type,
+          SystemdUnitType.socket);
+      expect(units.firstWhere((u) => u.name == 'logrotate').type,
+          SystemdUnitType.timer);
+
+      // A unit with no description column yields a null description.
+      final empty = units.firstWhere((u) => u.name == 'empty');
+      expect(empty.description, isNull);
+    });
+
+    test('tags units with the requested scope', () {
+      final units = SystemdUnit.parseListUnits(
+        'foo.service loaded active running Foo',
+        SystemdUnitScope.user,
+      );
+      expect(units.single.scope, SystemdUnitScope.user);
+    });
+
+    test('returns empty list for empty / error output', () {
+      expect(SystemdUnit.parseListUnits('', SystemdUnitScope.system), isEmpty);
+      expect(
+        SystemdUnit.parseListUnits(
+          'Failed to connect to bus: No such file or directory\n',
+          SystemdUnitScope.user,
+        ),
+        isEmpty,
+      );
+    });
+
+    test('skips lines with fewer than the four required columns', () {
+      // Only sshd.service has the full UNIT/LOAD/ACTIVE/SUB set; the short
+      // lines lack columns and must be dropped instead of throwing.
+      const output = 'garbage\n'
+          'partial.service loaded\n'
+          'sshd.service loaded active running OpenSSH server daemon\n';
+      final units = SystemdUnit.parseListUnits(output, SystemdUnitScope.system);
+      expect(units.single.name, 'sshd');
+    });
+  });
+}
+
+// Simulated `systemctl list-units --all --no-legend --no-pager --plain` output.
+const _listUnitsOutput = '''
+sshd.service loaded active running OpenSSH server daemon
+nginx.service loaded inactive dead A high performance web server and a reverse proxy server
+dbus.socket loaded active running D-Bus System Message Bus Socket
+logrotate.timer loaded active waiting Daily rotation of log files
+broken.service loaded failed failed A broken unit
+empty.service loaded inactive dead
+session-1.scope loaded active running Unsupported type stays out
+reloading.service loaded reloading start-post Unmapped active state stays out
+
+''';


### PR DESCRIPTION
On NixOS the systemd tab is empty, as listing unit files is done through `find -type f ...`, but on NixOS these are symlinks to the nix store. Using `systemctl` avoids any discrepancies and ensures future systemd changes are followed. A specific error for missing user units or no systemd connection is also added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced system and user unit discovery.
  * Added robust parsing for `systemctl list-units` output, including unit type, scope, state, and multi-word descriptions.
  * Introduced refresh status reporting for system vs user loading failures.

* **Bug Fixes**
  * Improved resilience to incomplete, unsupported, or malformed unit output.
  * Refresh behavior is now more consistent, with proper completion handling and user notifications.

* **Tests**
  * Added unit parsing tests covering valid output, empty/bus-error cases, and invalid column structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->