### PR TITLE
Handle SSH commands on servers without a home directory

### DIFF
--- a/lib/core/extension/ssh_client.dart
+++ b/lib/core/extension/ssh_client.dart
@@ -11,6 +11,21 @@ typedef OnStdout = void Function(String data, SSHSession session);
 typedef OnStderr = void Function(String data, SSHSession session);
 typedef OnStdin = void Function(SSHSession session);
 
+final class SSHExecResult {
+  final int? exitCode;
+  final String stdout;
+  final String stderr;
+
+  const SSHExecResult({
+    required this.exitCode,
+    required this.stdout,
+    required this.stderr,
+  });
+
+  bool get succeeded =>
+      exitCode == 0 || (exitCode == null && stderr.isEmpty);
+}
+
 Future<void> _collectOutput(
   SSHSession session, {
   BytesBuilder? stdoutBuilder,
@@ -180,7 +195,7 @@ extension SSHClientX on SSHClient {
     );
   }
 
-  Future<(String stdout, String stderr)> execSafe(
+  Future<SSHExecResult> execSafe(
     void Function(SSHSession session) callback, {
     required String entry,
     SystemType? systemType,
@@ -214,6 +229,10 @@ extension SSHClientX on SSHClient {
       label: 'stderr',
     );
 
-    return (stdout, stderr);
+    return SSHExecResult(
+      exitCode: session.exitCode,
+      stdout: stdout,
+      stderr: stderr,
+    );
   }
 }

--- a/lib/data/provider/server/single.dart
+++ b/lib/data/provider/server/single.dart
@@ -293,7 +293,7 @@ class ServerNotifier extends _$ServerNotifier {
           'Writing script for ${spi.name} (${detectedSystemType.name})',
         );
 
-        final (stdoutResult, writeScriptResult) = await state.client!.execSafe(
+        final writeScriptResult = await state.client!.execSafe(
           (session) async {
             final scriptRaw = ShellFuncManager.allScript(
               spi.custom?.cmds,
@@ -312,23 +312,30 @@ class ServerNotifier extends _$ServerNotifier {
           context: 'WriteScript<${spi.name}>',
         );
 
-        if (stdoutResult.isNotEmpty) {
+        if (writeScriptResult.stdout.isNotEmpty) {
           Loggers.app.info(
-            'Script write stdout for ${spi.name}: $stdoutResult',
+            'Script write stdout for ${spi.name}: ${writeScriptResult.stdout}',
           );
         }
 
-        if (writeScriptResult.isNotEmpty) {
+        if (writeScriptResult.stderr.isNotEmpty) {
           Loggers.app.warning(
-            'Script write stderr for ${spi.name}: $writeScriptResult',
+            'Script write stderr for ${spi.name}: ${writeScriptResult.stderr}',
           );
+        }
+
+        if (!writeScriptResult.succeeded) {
           if (detectedSystemType != SystemType.windows) {
             ShellFuncManager.switchScriptDir(
               spi.id,
               systemType: detectedSystemType,
             );
-            throw writeScriptResult;
           }
+          final output = writeScriptResult.stderr.isNotEmpty
+              ? writeScriptResult.stderr
+              : writeScriptResult.stdout;
+          throw 'Script installation exited with code '
+              '${writeScriptResult.exitCode}: $output';
         } else {
           Loggers.app.info('Script written successfully for ${spi.name}');
         }
@@ -359,6 +366,7 @@ class ServerNotifier extends _$ServerNotifier {
         );
         return;
       } catch (e) {
+        TryLimiter.inc(sid);
         final err = SSHErr(type: SSHErrType.writeScript, message: e.toString());
         final newStatus = _copyStatus(state.status, err: err, setErr: true);
         Loggers.app.warning(err);

--- a/test/ssh_exec_result_test.dart
+++ b/test/ssh_exec_result_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:server_box/core/extension/ssh_client.dart';
+
+void main() {
+  group('SSHExecResult', () {
+    test('accepts stderr warnings when the remote command succeeds', () {
+      const result = SSHExecResult(
+        exitCode: 0,
+        stdout: '',
+        stderr:
+            'Could not chdir to home directory /home/test: No such file or directory',
+      );
+
+      expect(result.succeeded, isTrue);
+    });
+
+    test('rejects non-zero exit codes', () {
+      const failed = SSHExecResult(
+        exitCode: 1,
+        stdout: '',
+        stderr: 'mkdir: Permission denied',
+      );
+
+      expect(failed.succeeded, isFalse);
+    });
+
+    test('falls back to stderr when the server omits the exit code', () {
+      const succeeded = SSHExecResult(
+        exitCode: null,
+        stdout: '',
+        stderr: '',
+      );
+      const failed = SSHExecResult(
+        exitCode: null,
+        stdout: '',
+        stderr: 'mkdir: Permission denied',
+      );
+
+      expect(succeeded.succeeded, isTrue);
+      expect(failed.succeeded, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Add `SSHExecResult` with exit code, stdout, stderr, and success status.
- Treat stderr warnings as non-fatal when the remote command succeeds.
- Improve script installation error reporting and retry tracking.
- Add coverage for SSH command result handling.

## Testing

- Added unit tests for successful, failed, and missing-exit-code SSH results.

Resolve #1240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer SSH command results, including exit codes, standard output, and error output.
  * Improved success detection for remote commands, including commands that complete without an explicit exit code.

* **Bug Fixes**
  * Improved installation failure messages by reporting the most relevant command output.
  * Improved server error handling and retry tracking when script installation fails.

* **Tests**
  * Added coverage for successful, failed, and indeterminate SSH command outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->