### PR TITLE
fix(android): probe Impeller graphics compatibility before startup

### DIFF
--- a/android/app/src/main/kotlin/tech/lolli/toolbox/ImpellerCompatibility.kt
+++ b/android/app/src/main/kotlin/tech/lolli/toolbox/ImpellerCompatibility.kt
@@ -41,9 +41,8 @@ internal object ImpellerCompatibility {
         try {
             if (prefs.getString(KEY_SIGNATURE, null) == signature) {
                 if (prefs.getBoolean(KEY_IN_PROGRESS, false)) {
-                    return cacheIncompatible(
+                    return invalidateAndDisable(
                         prefs,
-                        signature,
                         "Previous Impeller EGL probe did not complete",
                     )
                 }
@@ -51,16 +50,14 @@ internal object ImpellerCompatibility {
                     !prefs.contains(KEY_DISABLE) ||
                     !prefs.contains(KEY_REASON)
                 ) {
-                    return cacheIncompatible(
+                    return invalidateAndDisable(
                         prefs,
-                        signature,
                         "Cached Impeller EGL probe result is incomplete",
                     )
                 }
                 val reason = prefs.getString(KEY_REASON, null)
-                    ?: return cacheIncompatible(
+                    ?: return invalidateAndDisable(
                         prefs,
-                        signature,
                         "Cached Impeller EGL probe reason is missing",
                     )
                 return Result(prefs.getBoolean(KEY_DISABLE, true), reason)
@@ -74,9 +71,8 @@ internal object ImpellerCompatibility {
                 .remove(KEY_REASON)
                 .commit()
             if (!markerPersisted) {
-                return cacheIncompatible(
+                return invalidateAndDisable(
                     prefs,
-                    signature,
                     "Impeller EGL probe state could not be persisted",
                 )
             }
@@ -89,16 +85,14 @@ internal object ImpellerCompatibility {
             if (persistResult(prefs, signature, result)) {
                 result
             } else {
-                cacheIncompatible(
+                invalidateAndDisable(
                     prefs,
-                    signature,
                     "Impeller EGL probe result could not be persisted",
                 )
             }
         } catch (e: RuntimeException) {
-            cacheIncompatible(
+            invalidateAndDisable(
                 prefs,
-                signature,
                 "Impeller EGL probe result persistence failed: ${errorMessage(e)}",
             )
         }
@@ -274,14 +268,19 @@ internal object ImpellerCompatibility {
         } ?: result
     }
 
-    private fun cacheIncompatible(
+    private fun invalidateAndDisable(
         prefs: SharedPreferences,
-        signature: String,
         reason: String,
     ): Result {
         val result = incompatible(reason)
         try {
-            persistResult(prefs, signature, result)
+            prefs.edit()
+                .remove(KEY_SIGNATURE)
+                .remove(KEY_IN_PROGRESS)
+                .remove(KEY_COMPLETE)
+                .remove(KEY_DISABLE)
+                .remove(KEY_REASON)
+                .commit()
         } catch (_: RuntimeException) {
             // The conservative result is still safe for this launch.
         }

--- a/android/app/src/main/kotlin/tech/lolli/toolbox/ImpellerCompatibility.kt
+++ b/android/app/src/main/kotlin/tech/lolli/toolbox/ImpellerCompatibility.kt
@@ -1,0 +1,249 @@
+package tech.lolli.toolbox
+
+import android.content.Context
+import android.opengl.EGL14
+import android.opengl.EGLConfig
+import android.opengl.EGLContext
+import android.opengl.EGLDisplay
+import android.opengl.EGLExt
+import android.opengl.EGLSurface
+import android.opengl.GLES20
+import android.os.Build
+
+internal object ImpellerCompatibility {
+    data class Result(val disableImpeller: Boolean, val reason: String)
+
+    private const val PREFS_NAME = "graphics_compatibility"
+    private const val KEY_SIGNATURE = "impeller_probe_signature"
+    private const val KEY_DISABLE = "impeller_probe_disable"
+    private const val KEY_REASON = "impeller_probe_reason"
+    private const val PROBE_VERSION = 1
+
+    private val adrenoVersionRegex = Regex(
+        pattern = """\bAdreno(?:\s+\(TM\))?\s+(\d{3})\b""",
+        option = RegexOption.IGNORE_CASE,
+    )
+
+    fun check(context: Context): Result {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            return Result(false, "Flutter uses Skia below Android API 29")
+        }
+
+        val signature = "$PROBE_VERSION|${BuildConfig.VERSION_CODE}|${Build.FINGERPRINT}"
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        if (prefs.getString(KEY_SIGNATURE, null) == signature) {
+            return Result(
+                prefs.getBoolean(KEY_DISABLE, false),
+                prefs.getString(KEY_REASON, "cached graphics probe result")
+                    ?: "cached graphics probe result",
+            )
+        }
+
+        val result = probe()
+        prefs.edit()
+            .putString(KEY_SIGNATURE, signature)
+            .putBoolean(KEY_DISABLE, result.disableImpeller)
+            .putString(KEY_REASON, result.reason)
+            .apply()
+        return result
+    }
+
+    private fun probe(): Result {
+        var display: EGLDisplay = EGL14.EGL_NO_DISPLAY
+        var onscreenContext: EGLContext = EGL14.EGL_NO_CONTEXT
+        var offscreenContext: EGLContext = EGL14.EGL_NO_CONTEXT
+        var offscreenSurface: EGLSurface = EGL14.EGL_NO_SURFACE
+
+        try {
+            display = EGL14.eglGetDisplay(EGL14.EGL_DEFAULT_DISPLAY)
+            if (display == EGL14.EGL_NO_DISPLAY) {
+                return incompatible("EGL display is unavailable")
+            }
+            if (!EGL14.eglInitialize(display, null, 0, null, 0)) {
+                return incompatible("EGL initialization failed")
+            }
+
+            var clientVersion = 3
+            var samples = 4
+            var onscreenConfig = chooseConfig(
+                display,
+                clientVersion,
+                EGL14.EGL_WINDOW_BIT,
+                samples,
+            )
+            if (onscreenConfig == null) {
+                clientVersion = 2
+                onscreenConfig = chooseConfig(
+                    display,
+                    clientVersion,
+                    EGL14.EGL_WINDOW_BIT,
+                    samples,
+                )
+            }
+            if (onscreenConfig == null) {
+                samples = 1
+                onscreenConfig = chooseConfig(
+                    display,
+                    clientVersion,
+                    EGL14.EGL_WINDOW_BIT,
+                    samples,
+                )
+            }
+            if (onscreenConfig == null) {
+                return incompatible("Impeller onscreen EGL config is unsupported")
+            }
+
+            val offscreenConfig = chooseConfig(
+                display,
+                clientVersion,
+                EGL14.EGL_PBUFFER_BIT,
+                samples,
+            ) ?: return incompatible("Impeller offscreen EGL config is unsupported")
+
+            val contextAttributes = intArrayOf(
+                EGL14.EGL_CONTEXT_CLIENT_VERSION,
+                clientVersion,
+                EGL14.EGL_NONE,
+            )
+            onscreenContext = EGL14.eglCreateContext(
+                display,
+                onscreenConfig,
+                EGL14.EGL_NO_CONTEXT,
+                contextAttributes,
+                0,
+            )
+            if (onscreenContext == EGL14.EGL_NO_CONTEXT) {
+                return incompatible("Impeller onscreen EGL context creation failed")
+            }
+
+            offscreenContext = EGL14.eglCreateContext(
+                display,
+                offscreenConfig,
+                onscreenContext,
+                contextAttributes,
+                0,
+            )
+            if (offscreenContext == EGL14.EGL_NO_CONTEXT) {
+                return incompatible("Impeller offscreen EGL context creation failed")
+            }
+
+            offscreenSurface = EGL14.eglCreatePbufferSurface(
+                display,
+                offscreenConfig,
+                intArrayOf(
+                    EGL14.EGL_WIDTH,
+                    1,
+                    EGL14.EGL_HEIGHT,
+                    1,
+                    EGL14.EGL_NONE,
+                ),
+                0,
+            )
+            if (offscreenSurface == EGL14.EGL_NO_SURFACE) {
+                return incompatible("Impeller PBuffer surface creation failed")
+            }
+            if (!EGL14.eglMakeCurrent(
+                    display,
+                    offscreenSurface,
+                    offscreenSurface,
+                    offscreenContext,
+                )) {
+                return incompatible("Impeller offscreen EGL context cannot be made current")
+            }
+
+            val renderer = GLES20.glGetString(GLES20.GL_RENDERER)?.trim()
+                ?: return incompatible("OpenGL renderer is unavailable")
+            val glVersion = GLES20.glGetString(GLES20.GL_VERSION)?.trim() ?: "unknown"
+            val adrenoVersion = adrenoVersionRegex.find(renderer)
+                ?.groupValues
+                ?.getOrNull(1)
+                ?.toIntOrNull()
+            if (adrenoVersion != null && adrenoVersion in 300..399) {
+                return incompatible(
+                    "$renderer has a known Impeller shader-linker crash ($glVersion)",
+                )
+            }
+
+            return Result(
+                false,
+                "Impeller EGL probe passed: $renderer ($glVersion), GLES$clientVersion, ${samples}x MSAA",
+            )
+        } catch (e: RuntimeException) {
+            return incompatible("Impeller EGL probe failed: ${e.message ?: e.javaClass.simpleName}")
+        } finally {
+            if (display != EGL14.EGL_NO_DISPLAY) {
+                EGL14.eglMakeCurrent(
+                    display,
+                    EGL14.EGL_NO_SURFACE,
+                    EGL14.EGL_NO_SURFACE,
+                    EGL14.EGL_NO_CONTEXT,
+                )
+                if (offscreenSurface != EGL14.EGL_NO_SURFACE) {
+                    EGL14.eglDestroySurface(display, offscreenSurface)
+                }
+                if (offscreenContext != EGL14.EGL_NO_CONTEXT) {
+                    EGL14.eglDestroyContext(display, offscreenContext)
+                }
+                if (onscreenContext != EGL14.EGL_NO_CONTEXT) {
+                    EGL14.eglDestroyContext(display, onscreenContext)
+                }
+                EGL14.eglTerminate(display)
+                EGL14.eglReleaseThread()
+            }
+        }
+    }
+
+    private fun chooseConfig(
+        display: EGLDisplay,
+        clientVersion: Int,
+        surfaceType: Int,
+        samples: Int,
+    ): EGLConfig? {
+        val attributes = mutableListOf(
+            EGL14.EGL_RENDERABLE_TYPE,
+            if (clientVersion >= 3) {
+                EGLExt.EGL_OPENGL_ES3_BIT_KHR
+            } else {
+                EGL14.EGL_OPENGL_ES2_BIT
+            },
+            EGL14.EGL_SURFACE_TYPE,
+            surfaceType,
+            EGL14.EGL_RED_SIZE,
+            8,
+            EGL14.EGL_GREEN_SIZE,
+            8,
+            EGL14.EGL_BLUE_SIZE,
+            8,
+            EGL14.EGL_ALPHA_SIZE,
+            8,
+            EGL14.EGL_DEPTH_SIZE,
+            24,
+            EGL14.EGL_STENCIL_SIZE,
+            8,
+        )
+        if (samples > 1) {
+            attributes.add(EGL14.EGL_SAMPLE_BUFFERS)
+            attributes.add(1)
+            attributes.add(EGL14.EGL_SAMPLES)
+            attributes.add(samples)
+        }
+        attributes.add(EGL14.EGL_NONE)
+
+        val configs = arrayOfNulls<EGLConfig>(1)
+        val configCount = IntArray(1)
+        val success = EGL14.eglChooseConfig(
+            display,
+            attributes.toIntArray(),
+            0,
+            configs,
+            0,
+            configs.size,
+            configCount,
+            0,
+        )
+        if (!success || configCount[0] < 1) return null
+        return configs[0]
+    }
+
+    private fun incompatible(reason: String) = Result(true, reason)
+}

--- a/android/app/src/main/kotlin/tech/lolli/toolbox/ImpellerCompatibility.kt
+++ b/android/app/src/main/kotlin/tech/lolli/toolbox/ImpellerCompatibility.kt
@@ -1,6 +1,7 @@
 package tech.lolli.toolbox
 
 import android.content.Context
+import android.content.SharedPreferences
 import android.opengl.EGL14
 import android.opengl.EGLConfig
 import android.opengl.EGLContext
@@ -16,9 +17,10 @@ internal object ImpellerCompatibility {
     private const val PREFS_NAME = "graphics_compatibility"
     private const val KEY_SIGNATURE = "impeller_probe_signature"
     private const val KEY_IN_PROGRESS = "impeller_probe_in_progress"
+    private const val KEY_COMPLETE = "impeller_probe_complete"
     private const val KEY_DISABLE = "impeller_probe_disable"
     private const val KEY_REASON = "impeller_probe_reason"
-    private const val PROBE_VERSION = 1
+    private const val PROBE_VERSION = 2
 
     private val adrenoVersionRegex = Regex(
         pattern = """\bAdreno(?:\s+\(TM\))?\s+(\d{3})\b""",
@@ -31,42 +33,75 @@ internal object ImpellerCompatibility {
         }
 
         val signature = "$PROBE_VERSION|${BuildConfig.VERSION_CODE}|${Build.FINGERPRINT}"
-        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
-        if (prefs.getString(KEY_SIGNATURE, null) == signature) {
-            if (prefs.getBoolean(KEY_IN_PROGRESS, false)) {
-                val result = incompatible("Previous Impeller EGL probe did not complete")
-                prefs.edit()
-                    .putBoolean(KEY_IN_PROGRESS, false)
-                    .putBoolean(KEY_DISABLE, result.disableImpeller)
-                    .putString(KEY_REASON, result.reason)
-                    .commit()
-                return result
-            }
-            return Result(
-                prefs.getBoolean(KEY_DISABLE, false),
-                prefs.getString(KEY_REASON, "cached graphics probe result")
-                    ?: "cached graphics probe result",
-            )
+        val prefs = try {
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        } catch (e: RuntimeException) {
+            return incompatible("Impeller EGL probe storage is unavailable: ${errorMessage(e)}")
         }
+        try {
+            if (prefs.getString(KEY_SIGNATURE, null) == signature) {
+                if (prefs.getBoolean(KEY_IN_PROGRESS, false)) {
+                    return cacheIncompatible(
+                        prefs,
+                        signature,
+                        "Previous Impeller EGL probe did not complete",
+                    )
+                }
+                if (!prefs.getBoolean(KEY_COMPLETE, false) ||
+                    !prefs.contains(KEY_DISABLE) ||
+                    !prefs.contains(KEY_REASON)
+                ) {
+                    return cacheIncompatible(
+                        prefs,
+                        signature,
+                        "Cached Impeller EGL probe result is incomplete",
+                    )
+                }
+                val reason = prefs.getString(KEY_REASON, null)
+                    ?: return cacheIncompatible(
+                        prefs,
+                        signature,
+                        "Cached Impeller EGL probe reason is missing",
+                    )
+                return Result(prefs.getBoolean(KEY_DISABLE, true), reason)
+            }
 
-        val markerPersisted = prefs.edit()
-            .putString(KEY_SIGNATURE, signature)
-            .putBoolean(KEY_IN_PROGRESS, true)
-            .remove(KEY_DISABLE)
-            .remove(KEY_REASON)
-            .commit()
-        if (!markerPersisted) {
-            return incompatible("Impeller EGL probe state could not be persisted")
+            val markerPersisted = prefs.edit()
+                .putString(KEY_SIGNATURE, signature)
+                .putBoolean(KEY_IN_PROGRESS, true)
+                .putBoolean(KEY_COMPLETE, false)
+                .remove(KEY_DISABLE)
+                .remove(KEY_REASON)
+                .commit()
+            if (!markerPersisted) {
+                return cacheIncompatible(
+                    prefs,
+                    signature,
+                    "Impeller EGL probe state could not be persisted",
+                )
+            }
+        } catch (e: RuntimeException) {
+            return incompatible("Impeller EGL probe storage failed: ${errorMessage(e)}")
         }
 
         val result = probe()
-        prefs.edit()
-            .putString(KEY_SIGNATURE, signature)
-            .putBoolean(KEY_IN_PROGRESS, false)
-            .putBoolean(KEY_DISABLE, result.disableImpeller)
-            .putString(KEY_REASON, result.reason)
-            .commit()
-        return result
+        return try {
+            if (persistResult(prefs, signature, result)) {
+                result
+            } else {
+                cacheIncompatible(
+                    prefs,
+                    signature,
+                    "Impeller EGL probe result could not be persisted",
+                )
+            }
+        } catch (e: RuntimeException) {
+            cacheIncompatible(
+                prefs,
+                signature,
+                "Impeller EGL probe result persistence failed: ${errorMessage(e)}",
+            )
+        }
     }
 
     private fun probe(): Result {
@@ -75,13 +110,14 @@ internal object ImpellerCompatibility {
         var offscreenContext: EGLContext = EGL14.EGL_NO_CONTEXT
         var offscreenSurface: EGLSurface = EGL14.EGL_NO_SURFACE
 
-        try {
+        val result = try {
+            run probe@ {
             display = EGL14.eglGetDisplay(EGL14.EGL_DEFAULT_DISPLAY)
             if (display == EGL14.EGL_NO_DISPLAY) {
-                return incompatible("EGL display is unavailable")
+                return@probe incompatible("EGL display is unavailable")
             }
             if (!EGL14.eglInitialize(display, null, 0, null, 0)) {
-                return incompatible("EGL initialization failed")
+                return@probe incompatible("EGL initialization failed")
             }
 
             var clientVersion = 3
@@ -111,7 +147,7 @@ internal object ImpellerCompatibility {
                 )
             }
             if (onscreenConfig == null) {
-                return incompatible("Impeller onscreen EGL config is unsupported")
+                return@probe incompatible("Impeller onscreen EGL config is unsupported")
             }
 
             val offscreenConfig = chooseConfig(
@@ -119,7 +155,7 @@ internal object ImpellerCompatibility {
                 clientVersion,
                 EGL14.EGL_PBUFFER_BIT,
                 samples,
-            ) ?: return incompatible("Impeller offscreen EGL config is unsupported")
+            ) ?: return@probe incompatible("Impeller offscreen EGL config is unsupported")
 
             val contextAttributes = intArrayOf(
                 EGL14.EGL_CONTEXT_CLIENT_VERSION,
@@ -134,7 +170,7 @@ internal object ImpellerCompatibility {
                 0,
             )
             if (onscreenContext == EGL14.EGL_NO_CONTEXT) {
-                return incompatible("Impeller onscreen EGL context creation failed")
+                return@probe incompatible("Impeller onscreen EGL context creation failed")
             }
 
             offscreenContext = EGL14.eglCreateContext(
@@ -145,7 +181,7 @@ internal object ImpellerCompatibility {
                 0,
             )
             if (offscreenContext == EGL14.EGL_NO_CONTEXT) {
-                return incompatible("Impeller offscreen EGL context creation failed")
+                return@probe incompatible("Impeller offscreen EGL context creation failed")
             }
 
             offscreenSurface = EGL14.eglCreatePbufferSurface(
@@ -161,7 +197,7 @@ internal object ImpellerCompatibility {
                 0,
             )
             if (offscreenSurface == EGL14.EGL_NO_SURFACE) {
-                return incompatible("Impeller PBuffer surface creation failed")
+                return@probe incompatible("Impeller PBuffer surface creation failed")
             }
             if (!EGL14.eglMakeCurrent(
                     display,
@@ -169,49 +205,105 @@ internal object ImpellerCompatibility {
                     offscreenSurface,
                     offscreenContext,
                 )) {
-                return incompatible("Impeller offscreen EGL context cannot be made current")
+                return@probe incompatible("Impeller offscreen EGL context cannot be made current")
             }
 
             val renderer = GLES20.glGetString(GLES20.GL_RENDERER)?.trim()
-                ?: return incompatible("OpenGL renderer is unavailable")
+                ?: return@probe incompatible("OpenGL renderer is unavailable")
             val glVersion = GLES20.glGetString(GLES20.GL_VERSION)?.trim() ?: "unknown"
             val adrenoVersion = adrenoVersionRegex.find(renderer)
                 ?.groupValues
                 ?.getOrNull(1)
                 ?.toIntOrNull()
             if (adrenoVersion != null && adrenoVersion in 300..399) {
-                return incompatible(
+                return@probe incompatible(
                     "$renderer has a known Impeller shader-linker crash ($glVersion)",
                 )
             }
 
-            return Result(
+            Result(
                 false,
                 "Impeller EGL probe passed: $renderer ($glVersion), GLES$clientVersion, ${samples}x MSAA",
             )
+            }
         } catch (e: RuntimeException) {
-            return incompatible("Impeller EGL probe failed: ${e.message ?: e.javaClass.simpleName}")
-        } finally {
-            if (display != EGL14.EGL_NO_DISPLAY) {
+            incompatible("Impeller EGL probe failed: ${errorMessage(e)}")
+        }
+
+        var cleanupFailure: RuntimeException? = null
+        fun cleanup(action: () -> Unit) {
+            try {
+                action()
+            } catch (e: RuntimeException) {
+                if (cleanupFailure == null) cleanupFailure = e
+            }
+        }
+        if (display != EGL14.EGL_NO_DISPLAY) {
+            cleanup {
                 EGL14.eglMakeCurrent(
                     display,
                     EGL14.EGL_NO_SURFACE,
                     EGL14.EGL_NO_SURFACE,
                     EGL14.EGL_NO_CONTEXT,
                 )
-                if (offscreenSurface != EGL14.EGL_NO_SURFACE) {
+            }
+            if (offscreenSurface != EGL14.EGL_NO_SURFACE) {
+                cleanup {
                     EGL14.eglDestroySurface(display, offscreenSurface)
                 }
-                if (offscreenContext != EGL14.EGL_NO_CONTEXT) {
+            }
+            if (offscreenContext != EGL14.EGL_NO_CONTEXT) {
+                cleanup {
                     EGL14.eglDestroyContext(display, offscreenContext)
                 }
-                if (onscreenContext != EGL14.EGL_NO_CONTEXT) {
+            }
+            if (onscreenContext != EGL14.EGL_NO_CONTEXT) {
+                cleanup {
                     EGL14.eglDestroyContext(display, onscreenContext)
                 }
+            }
+            cleanup {
                 EGL14.eglTerminate(display)
+            }
+            cleanup {
                 EGL14.eglReleaseThread()
             }
         }
+        return cleanupFailure?.let {
+            incompatible("Impeller EGL cleanup failed: ${errorMessage(it)}")
+        } ?: result
+    }
+
+    private fun cacheIncompatible(
+        prefs: SharedPreferences,
+        signature: String,
+        reason: String,
+    ): Result {
+        val result = incompatible(reason)
+        try {
+            persistResult(prefs, signature, result)
+        } catch (_: RuntimeException) {
+            // The conservative result is still safe for this launch.
+        }
+        return result
+    }
+
+    private fun persistResult(
+        prefs: SharedPreferences,
+        signature: String,
+        result: Result,
+    ): Boolean {
+        return prefs.edit()
+            .putString(KEY_SIGNATURE, signature)
+            .putBoolean(KEY_IN_PROGRESS, false)
+            .putBoolean(KEY_COMPLETE, true)
+            .putBoolean(KEY_DISABLE, result.disableImpeller)
+            .putString(KEY_REASON, result.reason)
+            .commit()
+    }
+
+    private fun errorMessage(error: RuntimeException): String {
+        return error.message ?: error.javaClass.simpleName
     }
 
     private fun chooseConfig(

--- a/android/app/src/main/kotlin/tech/lolli/toolbox/ImpellerCompatibility.kt
+++ b/android/app/src/main/kotlin/tech/lolli/toolbox/ImpellerCompatibility.kt
@@ -15,6 +15,7 @@ internal object ImpellerCompatibility {
 
     private const val PREFS_NAME = "graphics_compatibility"
     private const val KEY_SIGNATURE = "impeller_probe_signature"
+    private const val KEY_IN_PROGRESS = "impeller_probe_in_progress"
     private const val KEY_DISABLE = "impeller_probe_disable"
     private const val KEY_REASON = "impeller_probe_reason"
     private const val PROBE_VERSION = 1
@@ -32,6 +33,15 @@ internal object ImpellerCompatibility {
         val signature = "$PROBE_VERSION|${BuildConfig.VERSION_CODE}|${Build.FINGERPRINT}"
         val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         if (prefs.getString(KEY_SIGNATURE, null) == signature) {
+            if (prefs.getBoolean(KEY_IN_PROGRESS, false)) {
+                val result = incompatible("Previous Impeller EGL probe did not complete")
+                prefs.edit()
+                    .putBoolean(KEY_IN_PROGRESS, false)
+                    .putBoolean(KEY_DISABLE, result.disableImpeller)
+                    .putString(KEY_REASON, result.reason)
+                    .commit()
+                return result
+            }
             return Result(
                 prefs.getBoolean(KEY_DISABLE, false),
                 prefs.getString(KEY_REASON, "cached graphics probe result")
@@ -39,12 +49,23 @@ internal object ImpellerCompatibility {
             )
         }
 
+        val markerPersisted = prefs.edit()
+            .putString(KEY_SIGNATURE, signature)
+            .putBoolean(KEY_IN_PROGRESS, true)
+            .remove(KEY_DISABLE)
+            .remove(KEY_REASON)
+            .commit()
+        if (!markerPersisted) {
+            return incompatible("Impeller EGL probe state could not be persisted")
+        }
+
         val result = probe()
         prefs.edit()
             .putString(KEY_SIGNATURE, signature)
+            .putBoolean(KEY_IN_PROGRESS, false)
             .putBoolean(KEY_DISABLE, result.disableImpeller)
             .putString(KEY_REASON, result.reason)
-            .apply()
+            .commit()
         return result
     }
 

--- a/android/app/src/main/kotlin/tech/lolli/toolbox/MainActivity.kt
+++ b/android/app/src/main/kotlin/tech/lolli/toolbox/MainActivity.kt
@@ -38,7 +38,12 @@ class MainActivity: FlutterFragmentActivity() {
 
     override fun provideFlutterEngine(context: Context): FlutterEngine? {
         if (!disableImpeller) return null
-        return FlutterEngine(context, arrayOf(ARG_DISABLE_IMPELLER), true, true)
+        return try {
+            FlutterEngine(context, arrayOf(ARG_DISABLE_IMPELLER), true, true)
+        } catch (e: RuntimeException) {
+            android.util.Log.e("MainActivity", "Failed to create the Skia Flutter engine", e)
+            null
+        }
     }
 
     override fun shouldDestroyEngineWithHost(): Boolean {

--- a/android/app/src/main/kotlin/tech/lolli/toolbox/MainActivity.kt
+++ b/android/app/src/main/kotlin/tech/lolli/toolbox/MainActivity.kt
@@ -38,12 +38,7 @@ class MainActivity: FlutterFragmentActivity() {
 
     override fun provideFlutterEngine(context: Context): FlutterEngine? {
         if (!disableImpeller) return null
-        return try {
-            FlutterEngine(context, arrayOf(ARG_DISABLE_IMPELLER), true, true)
-        } catch (e: RuntimeException) {
-            android.util.Log.e("MainActivity", "Failed to create the Skia Flutter engine", e)
-            null
-        }
+        return FlutterEngine(context, arrayOf(ARG_DISABLE_IMPELLER), true, true)
     }
 
     override fun shouldDestroyEngineWithHost(): Boolean {

--- a/android/app/src/main/kotlin/tech/lolli/toolbox/MainActivity.kt
+++ b/android/app/src/main/kotlin/tech/lolli/toolbox/MainActivity.kt
@@ -22,11 +22,12 @@ class MainActivity: FlutterFragmentActivity() {
     private val ACTION_DISCONNECT_SESSION = "tech.lolli.toolbox.ACTION_DISCONNECT_SESSION"
     private val ACTION_STOP_ALL_CONNECTIONS = "tech.lolli.toolbox.STOP_ALL_CONNECTIONS"
     private var stopAllReceiver: BroadcastReceiver? = null
+    private var disableImpeller = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val graphicsCompatibility = ImpellerCompatibility.check(this)
+        disableImpeller = graphicsCompatibility.disableImpeller
         if (graphicsCompatibility.disableImpeller) {
-            intent.putExtra(EXTRA_ENABLE_IMPELLER, false)
             android.util.Log.w(
                 "MainActivity",
                 "Disabling Impeller: ${graphicsCompatibility.reason}",
@@ -35,8 +36,17 @@ class MainActivity: FlutterFragmentActivity() {
         super.onCreate(savedInstanceState)
     }
 
+    override fun provideFlutterEngine(context: Context): FlutterEngine? {
+        if (!disableImpeller) return null
+        return FlutterEngine(context, arrayOf(ARG_DISABLE_IMPELLER))
+    }
+
+    override fun shouldDestroyEngineWithHost(): Boolean {
+        return disableImpeller || super.shouldDestroyEngineWithHost()
+    }
+
     private companion object {
-        const val EXTRA_ENABLE_IMPELLER = "enable-impeller"
+        const val ARG_DISABLE_IMPELLER = "--enable-impeller=false"
     }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {

--- a/android/app/src/main/kotlin/tech/lolli/toolbox/MainActivity.kt
+++ b/android/app/src/main/kotlin/tech/lolli/toolbox/MainActivity.kt
@@ -23,6 +23,7 @@ class MainActivity: FlutterFragmentActivity() {
     private val ACTION_STOP_ALL_CONNECTIONS = "tech.lolli.toolbox.STOP_ALL_CONNECTIONS"
     private var stopAllReceiver: BroadcastReceiver? = null
     private var disableImpeller = false
+    private var ownsFlutterEngine = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val graphicsCompatibility = ImpellerCompatibility.check(this)
@@ -38,11 +39,13 @@ class MainActivity: FlutterFragmentActivity() {
 
     override fun provideFlutterEngine(context: Context): FlutterEngine? {
         if (!disableImpeller) return null
-        return FlutterEngine(context, arrayOf(ARG_DISABLE_IMPELLER), true, true)
+        val flutterEngine = FlutterEngine(context, arrayOf(ARG_DISABLE_IMPELLER), true, true)
+        ownsFlutterEngine = true
+        return flutterEngine
     }
 
     override fun shouldDestroyEngineWithHost(): Boolean {
-        return disableImpeller || super.shouldDestroyEngineWithHost()
+        return ownsFlutterEngine || super.shouldDestroyEngineWithHost()
     }
 
     private companion object {

--- a/android/app/src/main/kotlin/tech/lolli/toolbox/MainActivity.kt
+++ b/android/app/src/main/kotlin/tech/lolli/toolbox/MainActivity.kt
@@ -3,6 +3,7 @@ package tech.lolli.toolbox
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
+import android.os.Bundle
 import android.Manifest
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -21,6 +22,22 @@ class MainActivity: FlutterFragmentActivity() {
     private val ACTION_DISCONNECT_SESSION = "tech.lolli.toolbox.ACTION_DISCONNECT_SESSION"
     private val ACTION_STOP_ALL_CONNECTIONS = "tech.lolli.toolbox.STOP_ALL_CONNECTIONS"
     private var stopAllReceiver: BroadcastReceiver? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        val graphicsCompatibility = ImpellerCompatibility.check(this)
+        if (graphicsCompatibility.disableImpeller) {
+            intent.putExtra(EXTRA_ENABLE_IMPELLER, false)
+            android.util.Log.w(
+                "MainActivity",
+                "Disabling Impeller: ${graphicsCompatibility.reason}",
+            )
+        }
+        super.onCreate(savedInstanceState)
+    }
+
+    private companion object {
+        const val EXTRA_ENABLE_IMPELLER = "enable-impeller"
+    }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)

--- a/android/app/src/main/kotlin/tech/lolli/toolbox/MainActivity.kt
+++ b/android/app/src/main/kotlin/tech/lolli/toolbox/MainActivity.kt
@@ -38,7 +38,7 @@ class MainActivity: FlutterFragmentActivity() {
 
     override fun provideFlutterEngine(context: Context): FlutterEngine? {
         if (!disableImpeller) return null
-        return FlutterEngine(context, arrayOf(ARG_DISABLE_IMPELLER))
+        return FlutterEngine(context, arrayOf(ARG_DISABLE_IMPELLER), true, true)
     }
 
     override fun shouldDestroyEngineWithHost(): Boolean {


### PR DESCRIPTION
## Summary

- probe the EGL configurations required by Impeller before creating the Flutter engine
- fall back to Skia when the required onscreen or offscreen EGL setup is unavailable
- detect the known Adreno 3xx Impeller shader-linker crash using the actual GL renderer
- cache the probe result per app version and Android build fingerprint

## Background

Flutter enables Impeller on Android API 29 and newer, but custom ROMs and GSIs can report a recent API level while still using legacy or incompatible GPU drivers.

In #980, Vulkan is unavailable and Impeller's OpenGL fallback cannot choose an offscreen EGL config. In #1242, the Adreno 330 driver crashes while linking Impeller shaders. Both failures happen before Dart starts, so they must be handled before the Flutter engine is created.

## Testing

- GitHub Actions Android build passed
- manually smoke-tested on a OnePlus 12 with Impeller remaining enabled
- affected Redmi 6A and OnePlus X devices still require confirmation

Related to #980 and #1242.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added automatic graphics compatibility checks on Android devices.
  * Impeller is disabled when compatibility issues are detected, helping prevent rendering failures.
  * Added GLES and MSAA fallback checks across supported Android configurations.
  * Compatibility results are cached to avoid repeated checks on the same device.
  * Improved handling for affected graphics hardware and compatibility diagnostics.
  * Added safer recovery when compatibility checks are interrupted or cannot be completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- winnowl:summary:begin -->
## Summary

### Changes

- **ImpellerCompatibility EGL probe &amp; result cache**: New object that, on devices with Android API &gt;= 29, runs a real EGL probe (display init, config selection with GLES3-&gt;GLES2 and 4x-&gt;1x MSAA fallbacks, onscreen+offscreen context creation, PBuffer surface, makeCurrent, GL renderer string) to decide whether Impeller must be disabled, caching the result in SharedPreferences keyed by PROBE_VERSION|VERSION_CODE|fingerprint. Includes fail-safe handling for storage errors, incomplete/crashed previous probes, and EGL resource cleanup.
- **MainActivity Impeller-disable engine integration**: MainActivity now runs ImpellerCompatibility.check() in onCreate, caches disableImpeller, overrides provideFlutterEngine to return a FlutterEngine constructed with the '--enable-impeller=false' Dart VM arg when Impeller must be disabled (null otherwise to preserve default engine behavior), and overrides shouldDestroyEngineWithHost to return true when a custom engine is supplied.
<!-- winnowl:summary:end -->