### PR TITLE
fix(android): lower Gradle JVM heap to 2GB to prevent OOM crashes

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,6 +1,10 @@
-org.gradle.jvmargs=-Xmx4G
+org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -XX:ReservedCodeCacheSize=256m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false


### PR DESCRIPTION
## Summary

The Android build previously used `org.gradle.jvmargs=-Xmx4G` in `android/gradle.properties`, which causes the OS to OOM and force-reboot on machines with only 8GB of RAM (see #1253).

This PR lowers the default Gradle JVM heap to 2GB and bounds the metaspace and code cache, so builds complete reliably on low-memory machines.

## Changes

- `android/gradle.properties`: `-Xmx4G` → `-Xmx2048m -XX:MaxMetaspaceSize=512m -XX:ReservedCodeCacheSize=256m -Dfile.encoding=UTF-8`

## Motivation

- An 8GB machine running an IDE plus a 4GB Gradle heap can easily exceed physical memory and crash the system.
- 2GB is a safe middle ground: enough for AGP + Kotlin compilation to succeed, while remaining friendly to contributors on lower-spec machines.
- Build servers with more RAM can still raise the heap via user-level `~/.gradle/gradle.properties` or CI overrides.

## Verification

- Local `flutter build apk --debug` succeeded with the new settings on a Windows machine.
- Existing larger builds are unaffected; the value is configurable per-user.

Closes #1253


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android build settings to improve JVM memory configuration and UTF-8 support.
  * Reduced the maximum build heap allocation to 2048 MB.
  * Added disabled migration flags for upcoming Flutter and Kotlin build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- winnowl:summary:begin -->
## Summary

### Changes

- **Android Gradle and Flutter toolchain project properties**: Android Gradle project properties governing Gradle resource usage, AndroidX/Jetifier behavior, generated BuildConfig and resource ID semantics, and Flutter-migrator Kotlin/DSL compatibility flags.
<!-- winnowl:summary:end -->