### PR TITLE
Fix stale iOS Live Activities after app exit

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -55,9 +55,13 @@ import ActivityKit
                 result(nil)
             case "stopLiveActivity":
                 if #available(iOS 16.2, *) {
-                    LiveActivityManager.stop()
+                    Task {
+                        await LiveActivityManager.stop()
+                        result(nil)
+                    }
+                } else {
+                    result(nil)
                 }
-                result(nil)
             default:
                 result(FlutterMethodNotImplemented)
             }
@@ -72,11 +76,20 @@ import ActivityKit
         }
         return true
     }
+
+    override func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // UIScene apps use this callback when the user closes the app from the
+        // app switcher. applicationWillTerminate is not reliable for that path.
+        if #available(iOS 16.2, *) {
+            Task { await LiveActivityManager.stop() }
+        }
+        super.application(application, didDiscardSceneSessions: sceneSessions)
+    }
     
     override func applicationWillTerminate(_ application: UIApplication) {
         // Stop Live Activity when app is about to terminate
         if #available(iOS 16.2, *) {
-            LiveActivityManager.stop()
+            Task { await LiveActivityManager.stop() }
         }
     }
 }

--- a/ios/Runner/LiveActivityManager.swift
+++ b/ios/Runner/LiveActivityManager.swift
@@ -10,7 +10,7 @@ import ActivityKit
 
 @available(iOS 16.2, *)
 class LiveActivityManager {
-    static var current: Activity<TerminalAttributes>?
+    private static var current: Activity<TerminalAttributes>?
 
     struct Payload: Decodable {
         let id: String
@@ -25,6 +25,26 @@ class LiveActivityManager {
     private static func parse(_ json: String) -> Payload? {
         guard let data = json.data(using: .utf8) else { return nil }
         return try? JSONDecoder().decode(Payload.self, from: data)
+    }
+
+    private static func trackedActivities() -> [Activity<TerminalAttributes>] {
+        var activities = Activity<TerminalAttributes>.activities
+        if let current = current, !activities.contains(where: { $0.id == current.id }) {
+            activities.append(current)
+        }
+        return activities
+    }
+
+    private static func updatableActivity() -> Activity<TerminalAttributes>? {
+        if let current = current,
+           current.activityState == .active || current.activityState == .stale {
+            return current
+        }
+        let activity = Activity<TerminalAttributes>.activities.first {
+            $0.activityState == .active || $0.activityState == .stale
+        }
+        current = activity
+        return activity
     }
 
     static func start(json: String) {
@@ -50,6 +70,19 @@ class LiveActivityManager {
             connectionCount: p.connectionCount ?? 1
         )
         let content = ActivityContent(state: state, staleDate: nil)
+
+        if let activity = updatableActivity() {
+            current = activity
+            let duplicates = trackedActivities().filter { $0.id != activity.id }
+            Task {
+                await activity.update(content)
+                for duplicate in duplicates {
+                    await duplicate.end(dismissalPolicy: .immediate)
+                }
+            }
+            return
+        }
+
         do {
             current = try Activity<TerminalAttributes>.request(attributes: attributes, content: content, pushType: nil)
         } catch {
@@ -78,18 +111,26 @@ class LiveActivityManager {
             hasTerminal: p.hasTerminal ?? true,
             connectionCount: p.connectionCount ?? 1
         )
-        if let activity = current {
-            Task { await activity.update(ActivityContent(state: state, staleDate: nil)) }
+        if let activity = updatableActivity() {
+            current = activity
+            let duplicates = trackedActivities().filter { $0.id != activity.id }
+            Task {
+                await activity.update(ActivityContent(state: state, staleDate: nil))
+                for duplicate in duplicates {
+                    await duplicate.end(dismissalPolicy: .immediate)
+                }
+            }
         } else {
             start(json: json)
         }
     }
 
-    static func stop() {
+    static func stop() async {
         guard #available(iOS 16.2, *) else { return }
-        if let activity = current {
-            Task { await activity.end(dismissalPolicy: .immediate) }
-            current = nil
+        let activities = trackedActivities()
+        current = nil
+        for activity in activities {
+            await activity.end(dismissalPolicy: .immediate)
         }
     }
 }

--- a/lib/data/ssh/session_manager.dart
+++ b/lib/data/ssh/session_manager.dart
@@ -51,7 +51,7 @@ abstract final class TermSessionManager {
     seconds: 5,
   ); // 5-second update interval
 
-  static void init() {
+  static Future<void> init() async {
     if (isAndroid) {
       MethodChans.registerHandler(
         (id) async {
@@ -62,6 +62,11 @@ abstract final class TermSessionManager {
           stopAllConnections();
         },
       );
+    }
+    if (isIOS) {
+      // A Live Activity can outlive a killed process. Clear any orphan left
+      // by the previous app run before new sessions can be registered.
+      await MethodChans.stopLiveActivity();
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,8 +46,8 @@ Future<void> _initApp() async {
 
   await _doPlatformRelated();
 
-  // Initialize Android session notification channel/handler
-  TermSessionManager.init();
+  // Initialize platform session notifications and Live Activities.
+  await TermSessionManager.init();
 }
 
 Future<void> _initData() async {

--- a/lib/view/page/setting/entries/server.dart
+++ b/lib/view/page/setting/entries/server.dart
@@ -86,8 +86,9 @@ extension _Server on _AppSettingsPageState {
         );
 
         if (sure != true) return;
+        final notifier = ref.read(serversProvider.notifier);
         for (final key in deleteKeys) {
-          Stores.server.remove(key);
+          await notifier.delServer(key);
         }
         context.showSnackBar(libL10n.success);
       },


### PR DESCRIPTION
## Summary

- end terminal Live Activities when a UIScene session is discarded from the app switcher
- recover and end every ActivityKit activity instead of relying on an in-memory reference
- clear orphaned activities before new terminal sessions are registered after launch
- route bulk server deletion through `ServersNotifier` so connection sessions and Live Activities are cleaned up

## Root cause

The iOS implementation kept only `LiveActivityManager.current`. That reference is lost when the process exits even though ActivityKit intentionally keeps the Live Activity alive. A later stop request therefore had no activity to end and updates could create duplicates.

The project also uses the UIScene lifecycle, where `applicationWillTerminate` is not a reliable callback for a user closing the app from the app switcher. In addition, the settings bulk-delete path removed storage entries directly and bypassed the session cleanup performed by `ServersNotifier.delServer`.

## Impact

Closing ServerBox from the iOS app switcher or deleting the connected server no longer leaves a stale "Connected" Live Activity in the Dynamic Island. Interrupted prior runs are reconciled on the next launch.

## Validation

- `flutter analyze lib test`
- `flutter test` (462 tests passed)
- `git diff --check`

An iOS/Xcode build was not available on the Windows development host.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Live Activities now stop reliably when the app is terminated or dismissed from the app switcher.
  * Prevented duplicate or stale Live Activities from receiving updates.
  * Cleaned up orphaned Live Activities during app startup.
  * Improved server deletion handling to ensure changes are processed consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->