### PR TITLE
feat(ssh): support combined key and password authentication

### DIFF
--- a/lib/core/utils/server.dart
+++ b/lib/core/utils/server.dart
@@ -223,6 +223,7 @@ Future<SSHClient> genClient(
     username: spi.user,
     // Must use [compute] here, instead of [Computer.shared.start]
     identities: await compute(loadIdentity, privateKey),
+    onPasswordRequest: spi.pwd?.isNotEmpty == true ? () => spi.pwd : null,
     onUserInfoRequest: onKeyboardInteractive == null
         ? null
         : (request) => onKeyboardInteractive(spi, request),

--- a/lib/view/page/server/edit/actions.dart
+++ b/lib/view/page/server/edit/actions.dart
@@ -413,9 +413,8 @@ extension _Utils on _ServerEditPageState {
     _ipController.text = spi.ip;
     _portController.text = spi.port.toString();
     _usernameController.text = spi.user;
-    if (spi.keyId == null) {
-      _passwordController.text = spi.pwd ?? '';
-    } else {
+    _passwordController.text = spi.pwd ?? '';
+    if (spi.keyId != null) {
       _keyIdx.value = ref
           .read(privateKeyProvider)
           .keys

--- a/lib/view/page/server/edit/edit.dart
+++ b/lib/view/page/server/edit/edit.dart
@@ -70,7 +70,8 @@ class _ServerEditPageState extends ConsumerState<ServerEditPage>
 
   late FocusScopeNode _focusScope;
 
-  /// -1: non selected, null: password, others: index of private key
+  /// -1: key auth enabled without a selection, null: key auth disabled,
+  /// others: index of private key
   final _keyIdx = ValueNotifier<int?>(null);
   final _autoConnect = ValueNotifier(true);
   final _jumpServers = <String>[].vn;

--- a/lib/view/page/server/edit/widget.dart
+++ b/lib/view/page/server/edit/widget.dart
@@ -17,25 +17,23 @@ extension _Widgets on _ServerEditPageState {
         ),
       ),
     );
+    final password = Input(
+      controller: _passwordController,
+      obscureText: true,
+      type: TextInputType.text,
+      label: libL10n.pwd,
+      icon: Icons.password,
+      suggestion: false,
+      onSubmitted: (_) => _onSave(),
+    );
 
-    /// Put [switch_] out of [ValueBuilder] to avoid rebuild
+    /// Keep static auth fields outside [ValueBuilder] to avoid rebuilding them.
     return _keyIdx.listenVal((v) {
       final children = <Widget>[switch_];
       if (v != null) {
         children.add(_buildKeyAuth());
-      } else {
-        children.add(
-          Input(
-            controller: _passwordController,
-            obscureText: true,
-            type: TextInputType.text,
-            label: libL10n.pwd,
-            icon: Icons.password,
-            suggestion: false,
-            onSubmitted: (_) => _onSave(),
-          ),
-        );
       }
+      children.add(password);
       return Column(children: children);
     });
   }

--- a/test/server_edit_logic_test.dart
+++ b/test/server_edit_logic_test.dart
@@ -1,5 +1,19 @@
+import 'dart:convert';
+
+import 'package:fl_lib/fl_lib.dart';
+import 'package:fl_lib/generated/l10n/lib_l10n.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:server_box/core/extension/context/locale.dart' as app_locale;
+import 'package:server_box/core/route.dart';
+import 'package:server_box/data/model/server/private_key_info.dart';
 import 'package:server_box/data/model/server/server_private_info.dart';
+import 'package:server_box/data/provider/private_key.dart';
+import 'package:server_box/data/provider/server/all.dart';
+import 'package:server_box/generated/l10n/l10n.dart';
+import 'package:server_box/view/page/server/edit/edit.dart';
 
 void main() {
   group('Server Edit Page Logic Tests', () {
@@ -116,20 +130,104 @@ void main() {
       expect(serverWithoutKey.pwd, 'password123');
     });
 
-    test('SSH key and password can be stored together', () {
-      const server = Spi(
+    testWidgets('server editor preserves combined SSH credentials', (
+      tester,
+    ) async {
+      FlutterSecureStorage.setMockInitialValues({});
+
+      var server = const Spi(
         name: 'combined-auth-server',
         ip: '192.168.1.100',
         port: 22,
         user: 'root',
         pwd: 'password123',
-        keyId: '~/.ssh/id_ed25519',
+        keyId: 'test-key',
+        id: 'combined-auth-server-id',
+      );
+      Spi? persisted;
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            serversProvider.overrideWith(
+              () => _PersistingServersNotifier(
+                server,
+                (value) => persisted = value,
+              ),
+            ),
+            privateKeyProvider.overrideWithValue(
+              const PrivateKeyState(
+                keys: [PrivateKeyInfo(id: 'test-key', key: 'unused')],
+              ),
+            ),
+          ],
+          child: MaterialApp(
+            builder: ResponsivePoints.builder,
+            locale: const Locale('en'),
+            localizationsDelegates: const [
+              LibLocalizations.delegate,
+              ...AppLocalizations.localizationsDelegates,
+            ],
+            supportedLocales: AppLocalizations.supportedLocales,
+            home: Builder(
+              builder: (context) {
+                app_locale.l10n = AppLocalizations.of(context)!;
+                context.setLibL10n();
+                return Scaffold(
+                  body: TextButton(
+                    key: const ValueKey('open-server-editor'),
+                    onPressed: () => Navigator.of(context).push(
+                      MaterialPageRoute<void>(
+                        builder: (_) =>
+                            ServerEditPage(args: SpiRequiredArgs(server)),
+                      ),
+                    ),
+                    child: const Text('Open editor'),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
       );
 
-      final restored = Spi.fromJson(server.toJson());
+      await tester.tap(find.byKey(const ValueKey('open-server-editor')));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
 
+      expect(find.text('test-key'), findsOneWidget);
+      expect(
+        tester
+            .widgetList<EditableText>(find.byType(EditableText))
+            .where((field) => field.controller.text == 'password123'),
+        hasLength(1),
+      );
+
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(find.byKey(const ValueKey('open-server-editor')), findsOneWidget);
+      expect(persisted, isNotNull);
+      final restored = persisted!;
       expect(restored.pwd, 'password123');
-      expect(restored.keyId, '~/.ssh/id_ed25519');
+      expect(restored.keyId, 'test-key');
+
+      server = restored;
+      await tester.tap(find.byKey(const ValueKey('open-server-editor')));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      expect(find.text('test-key'), findsOneWidget);
+      expect(
+        tester
+            .widgetList<EditableText>(find.byType(EditableText))
+            .where((field) => field.controller.text == 'password123'),
+        hasLength(1),
+      );
+
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
     });
 
     test('server editing vs creation logic', () {
@@ -352,4 +450,34 @@ void main() {
       );
     });
   });
+}
+
+final class _PersistingServersNotifier extends ServersNotifier {
+  _PersistingServersNotifier(this.initialServer, this.onPersist);
+
+  final Spi initialServer;
+  final ValueChanged<Spi> onPersist;
+
+  @override
+  ServersState build() {
+    return ServersState(
+      servers: {initialServer.id: initialServer},
+      serverOrder: [initialServer.id],
+    );
+  }
+
+  @override
+  Future<void> updateServer(Spi old, Spi newSpi) async {
+    final persisted = Spi.fromJson(
+      jsonDecode(jsonEncode(newSpi)) as Map<String, dynamic>,
+    );
+    onPersist(persisted);
+    final servers = Map<String, Spi>.from(state.servers)
+      ..remove(old.id)
+      ..[persisted.id] = persisted;
+    state = state.copyWith(
+      servers: servers,
+      serverOrder: servers.keys.toList(),
+    );
+  }
 }

--- a/test/server_edit_logic_test.dart
+++ b/test/server_edit_logic_test.dart
@@ -116,6 +116,22 @@ void main() {
       expect(serverWithoutKey.pwd, 'password123');
     });
 
+    test('SSH key and password can be stored together', () {
+      const server = Spi(
+        name: 'combined-auth-server',
+        ip: '192.168.1.100',
+        port: 22,
+        user: 'root',
+        pwd: 'password123',
+        keyId: '~/.ssh/id_ed25519',
+      );
+
+      final restored = Spi.fromJson(server.toJson());
+
+      expect(restored.pwd, 'password123');
+      expect(restored.keyId, '~/.ssh/id_ed25519');
+    });
+
     test('server editing vs creation logic', () {
       // Test logic for distinguishing between editing and creating servers
 

--- a/test/ssh_combined_auth_test.dart
+++ b/test/ssh_combined_auth_test.dart
@@ -1,0 +1,85 @@
+import 'dart:io';
+
+import 'package:dartssh2/dartssh2.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:server_box/core/utils/server.dart';
+import 'package:server_box/data/model/server/server_private_info.dart';
+
+void main() {
+  group('SSH client authentication configuration', () {
+    test('enables public key and password authentication together', () async {
+      final client = await _createClient(
+        const Spi(
+          name: 'combined-auth',
+          ip: '127.0.0.1',
+          port: 22,
+          user: 'tester',
+          pwd: 'account-password',
+          keyId: 'test-key',
+        ),
+        privateKey: _testPrivateKey,
+      );
+
+      expect(client.identities, isNotEmpty);
+      expect(client.onPasswordRequest, isNotNull);
+      expect(await client.onPasswordRequest!(), 'account-password');
+    });
+
+    test('keeps key-only authentication password-free', () async {
+      final client = await _createClient(
+        const Spi(
+          name: 'key-only',
+          ip: '127.0.0.1',
+          port: 22,
+          user: 'tester',
+          pwd: '',
+          keyId: 'test-key',
+        ),
+        privateKey: _testPrivateKey,
+      );
+
+      expect(client.identities, isNotEmpty);
+      expect(client.onPasswordRequest, isNull);
+    });
+
+    test('keeps password-only authentication unchanged', () async {
+      final client = await _createClient(
+        const Spi(
+          name: 'password-only',
+          ip: '127.0.0.1',
+          port: 22,
+          user: 'tester',
+          pwd: 'account-password',
+        ),
+      );
+
+      expect(client.identities, isNull);
+      expect(client.onPasswordRequest, isNotNull);
+      expect(await client.onPasswordRequest!(), 'account-password');
+    });
+  });
+}
+
+Future<SSHClient> _createClient(Spi spi, {String? privateKey}) async {
+  final server = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+  final peerFuture = server.first;
+  final client = await genClient(
+    spi.copyWith(port: server.port),
+    privateKey: privateKey,
+    knownHostFingerprints: const {},
+  );
+  final peer = await peerFuture;
+
+  client.authenticated.ignore();
+  client.done.ignore();
+  addTearDown(() async {
+    client.close();
+    peer.destroy();
+    await server.close();
+  });
+  return client;
+}
+
+final String _testPrivateKey = File(
+  'packages/dartssh2/test/fixtures/ssh-ed25519/id_ed25519',
+).readAsStringSync();


### PR DESCRIPTION
## Summary
- keep the SSH password field available when key authentication is enabled
- preserve both credentials when editing server settings
- provide the saved password alongside the private key so multi-step publickey,password authentication can complete
- keep password-only, key-only, keyboard-interactive, SFTP, jump host, and system SSH behavior compatible

## Testing
- dart format on changed Dart files
- flutter test test/server_edit_logic_test.dart test/ssh_combined_auth_test.dart test/ssh_auth_test.dart
- flutter analyze lib test
- flutter test

Closes #1259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH authentication when both a password and private key are configured.
  * Password authentication now remains available alongside key authentication.
  * Preserved password and key credentials when editing and restoring server configurations.

* **Tests**
  * Added coverage for combined, key-only, and password-only SSH authentication scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- winnowl:summary:begin -->
## Summary

### Changes

- **Combined SSH public-key + password authentication in genClient**: genClient now configures both key-based identities and a password request handler together: in the keyId branch it sets onPasswordRequest when spi.pwd is non-empty, enabling key+password combined auth while keeping key-only auth password-free and password-only auth unchanged. Private keys are still loaded in an isolate via compute(loadIdentity).
- **SSH host key verification &amp; persistence (TOFU / MITM protection)**: Adds a host-key verifier (TOFU): fingerprints are loaded from Stores.setting.sshKnownHostFingerprints into a per-connection cache, new keys trigger a user prompt, mismatches trigger a mismatch prompt, and accepted keys are persisted via persistHostKeyFingerprint. onHostKeyAccepted/onHostKeyPrompt hooks let isolate (SFTP) callers drive prompts across ports.
- **Jump-chain cycle detection &amp; multi-candidate failover in genClient**: genClient recursively connects through jump servers with cycle detection via visitedServerIds (a set threaded through the chain), resolves up to two ordered jump candidates from resolvedJumpIds, tries each candidate on network failure (_isJumpFailoverError), and preloads first-hop jump private keys for isolate mode.
- **ensureKnownHostKey pre-verification (including jump servers)**: ensureKnownHostKey connects to a server (and recursively to each unresolved jump candidate) with knownHostFingerprints to establish/verify trusted host keys before real use, closing the client afterward.
- **Server edit save/validation flow (actions.dart)**: The save path validates host format (_hostReg), requires confirmation when no key and no password, rejects keyIdx -1 (key auth on without a selection), defaults user/port, rejects invalid jump selections and proxyCommand+jump conflicts, enforces ProxyCommand desktop-only, validates WOL config, checks duplicate server id for new servers, persists the sudo password override, then adds/updates the server.
- **Sudo password per-server override (sudo_password.dart + edit page integration)**: Adds per-server sudo password override storage via SecureProp, with dirty-tracked editing state in the edit page (read/persist/clear) and resolveForTerminal fallback from override to spi.pwd.
- **Server edit page UI state &amp; widgets (edit.dart, widget.dart)**: The edit page manages form controllers/listenable state, auth (key switch + key selection choice chips), system type, jump server multi-select (max 2), disabled command types grouped into disk/diskHealth switches, PVE, WOL, custom commands, envs, and delete button.
- **Test coverage alignment (server_edit_logic_test.dart, ssh_combined_auth_test.dart)**: Adds a combined-auth integration test that builds a real genClient over a loopback ServerSocket using a dartssh2 fixture key, and a logic test file covering edit-page validation/import/SSH-import rules.
<!-- winnowl:summary:end -->