### PR TITLE
Improve onboarding localization and settings UI

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -25,6 +25,10 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
   late final Future<List<IntroPageBuilder>> _introFuture = _IntroPage.builders;
+  late final Listenable _appListenable = Listenable.merge([
+    RNodes.app,
+    Stores.setting.locale.listenable(),
+  ]);
   bool _transparentNavBarConfigured = false;
 
   @override
@@ -41,7 +45,7 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     return ListenableBuilder(
-      listenable: RNodes.app,
+      listenable: _appListenable,
       builder: (context, _) {
         if (!Stores.setting.useSystemPrimaryColor.fetch()) {
           return _build(context);

--- a/lib/generated/l10n/l10n.dart
+++ b/lib/generated/l10n/l10n.dart
@@ -969,6 +969,12 @@ abstract class AppLocalizations {
   /// **'Remove unused data to free up disk space'**
   String get dockerPruneTip;
 
+  /// No description provided for @dockerStatistics.
+  ///
+  /// In en, this message translates to:
+  /// **'Docker Statistics'**
+  String get dockerStatistics;
+
   /// No description provided for @dockerStatusRunningAndStoppedFmt.
   ///
   /// In en, this message translates to:

--- a/lib/generated/l10n/l10n_de.dart
+++ b/lib/generated/l10n/l10n_de.dart
@@ -480,6 +480,9 @@ class AppLocalizationsDe extends AppLocalizations {
       'Nicht verwendete Daten entfernen, um Speicherplatz freizugeben';
 
   @override
+  String get dockerStatistics => 'Docker-Statistiken';
+
+  @override
   String dockerStatusRunningAndStoppedFmt(
     Object runningCount,
     Object stoppedCount,

--- a/lib/generated/l10n/l10n_en.dart
+++ b/lib/generated/l10n/l10n_en.dart
@@ -480,6 +480,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get dockerPruneTip => 'Remove unused data to free up disk space';
 
   @override
+  String get dockerStatistics => 'Docker Statistics';
+
+  @override
   String dockerStatusRunningAndStoppedFmt(
     Object runningCount,
     Object stoppedCount,

--- a/lib/generated/l10n/l10n_es.dart
+++ b/lib/generated/l10n/l10n_es.dart
@@ -481,6 +481,9 @@ class AppLocalizationsEs extends AppLocalizations {
       'Elimina los datos no utilizados para liberar espacio en disco';
 
   @override
+  String get dockerStatistics => 'Estadísticas de Docker';
+
+  @override
   String dockerStatusRunningAndStoppedFmt(
     Object runningCount,
     Object stoppedCount,

--- a/lib/generated/l10n/l10n_fr.dart
+++ b/lib/generated/l10n/l10n_fr.dart
@@ -481,6 +481,9 @@ class AppLocalizationsFr extends AppLocalizations {
       'Supprimez les données inutilisées pour libérer de l\'espace disque';
 
   @override
+  String get dockerStatistics => 'Statistiques Docker';
+
+  @override
   String dockerStatusRunningAndStoppedFmt(
     Object runningCount,
     Object stoppedCount,

--- a/lib/generated/l10n/l10n_id.dart
+++ b/lib/generated/l10n/l10n_id.dart
@@ -479,6 +479,9 @@ class AppLocalizationsId extends AppLocalizations {
       'Hapus data yang tidak digunakan untuk mengosongkan ruang disk';
 
   @override
+  String get dockerStatistics => 'Statistik Docker';
+
+  @override
   String dockerStatusRunningAndStoppedFmt(
     Object runningCount,
     Object stoppedCount,

--- a/lib/generated/l10n/l10n_it.dart
+++ b/lib/generated/l10n/l10n_it.dart
@@ -480,6 +480,9 @@ class AppLocalizationsIt extends AppLocalizations {
       'Rimuovi i dati inutilizzati per liberare spazio su disco';
 
   @override
+  String get dockerStatistics => 'Statistiche Docker';
+
+  @override
   String dockerStatusRunningAndStoppedFmt(
     Object runningCount,
     Object stoppedCount,

--- a/lib/generated/l10n/l10n_ja.dart
+++ b/lib/generated/l10n/l10n_ja.dart
@@ -470,6 +470,9 @@ class AppLocalizationsJa extends AppLocalizations {
   String get dockerPruneTip => '未使用のデータを削除してディスク容量を解放します';
 
   @override
+  String get dockerStatistics => 'Docker 統計';
+
+  @override
   String dockerStatusRunningAndStoppedFmt(
     Object runningCount,
     Object stoppedCount,

--- a/lib/generated/l10n/l10n_ko.dart
+++ b/lib/generated/l10n/l10n_ko.dart
@@ -470,6 +470,9 @@ class AppLocalizationsKo extends AppLocalizations {
   String get dockerPruneTip => '사용하지 않는 데이터를 제거하여 디스크 공간을 확보합니다';
 
   @override
+  String get dockerStatistics => 'Docker 통계';
+
+  @override
   String dockerStatusRunningAndStoppedFmt(
     Object runningCount,
     Object stoppedCount,

--- a/lib/generated/l10n/l10n_nl.dart
+++ b/lib/generated/l10n/l10n_nl.dart
@@ -480,6 +480,9 @@ class AppLocalizationsNl extends AppLocalizations {
       'Verwijder ongebruikte gegevens om schijfruimte vrij te maken';
 
   @override
+  String get dockerStatistics => 'Docker-statistieken';
+
+  @override
   String dockerStatusRunningAndStoppedFmt(
     Object runningCount,
     Object stoppedCount,

--- a/lib/generated/l10n/l10n_pt.dart
+++ b/lib/generated/l10n/l10n_pt.dart
@@ -479,6 +479,9 @@ class AppLocalizationsPt extends AppLocalizations {
       'Remova os dados não utilizados para liberar espaço em disco';
 
   @override
+  String get dockerStatistics => 'Estatísticas do Docker';
+
+  @override
   String dockerStatusRunningAndStoppedFmt(
     Object runningCount,
     Object stoppedCount,

--- a/lib/generated/l10n/l10n_ru.dart
+++ b/lib/generated/l10n/l10n_ru.dart
@@ -480,6 +480,9 @@ class AppLocalizationsRu extends AppLocalizations {
       'Удалите неиспользуемые данные, чтобы освободить место на диске';
 
   @override
+  String get dockerStatistics => 'Статистика Docker';
+
+  @override
   String dockerStatusRunningAndStoppedFmt(
     Object runningCount,
     Object stoppedCount,

--- a/lib/generated/l10n/l10n_tr.dart
+++ b/lib/generated/l10n/l10n_tr.dart
@@ -480,6 +480,9 @@ class AppLocalizationsTr extends AppLocalizations {
       'Disk alanını boşaltmak için kullanılmayan verileri kaldırın';
 
   @override
+  String get dockerStatistics => 'Docker İstatistikleri';
+
+  @override
   String dockerStatusRunningAndStoppedFmt(
     Object runningCount,
     Object stoppedCount,

--- a/lib/generated/l10n/l10n_uk.dart
+++ b/lib/generated/l10n/l10n_uk.dart
@@ -480,6 +480,9 @@ class AppLocalizationsUk extends AppLocalizations {
       'Видаліть невикористані дані, щоб звільнити місце на диску';
 
   @override
+  String get dockerStatistics => 'Статистика Docker';
+
+  @override
   String dockerStatusRunningAndStoppedFmt(
     Object runningCount,
     Object stoppedCount,

--- a/lib/generated/l10n/l10n_zh.dart
+++ b/lib/generated/l10n/l10n_zh.dart
@@ -455,6 +455,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get dockerPruneTip => '清理未使用的数据以释放磁盘空间';
 
   @override
+  String get dockerStatistics => 'Docker 统计';
+
+  @override
   String dockerStatusRunningAndStoppedFmt(
     Object runningCount,
     Object stoppedCount,
@@ -1692,6 +1695,9 @@ class AppLocalizationsZhTw extends AppLocalizationsZh {
 
   @override
   String get dockerPruneTip => '清理未使用的資料以釋放磁碟空間';
+
+  @override
+  String get dockerStatistics => 'Docker 統計';
 
   @override
   String dockerStatusRunningAndStoppedFmt(

--- a/lib/intro.dart
+++ b/lib/intro.dart
@@ -17,6 +17,7 @@ final class _IntroPage extends StatelessWidget {
         final padTop = cons.maxHeight * .16;
         final pages_ = pages.map((e) => e(context, padTop)).toList();
         return IntroPage(
+          key: ValueKey(Localizations.localeOf(context)),
           args: IntroPageArgs(
             pages: pages_,
             onDone: (ctx) {
@@ -32,61 +33,227 @@ final class _IntroPage extends StatelessWidget {
   }
 
   static Widget _buildAppSettings(BuildContext ctx, double padTop) {
+    final theme = Theme.of(ctx);
+    final scheme = theme.colorScheme;
+    final libL10n = ctx.libL10n;
+    final l10n = ctx.l10n;
+
     return ListView(
       padding: _introListPad,
       children: [
-        SizedBox(height: padTop),
-        IntroPage.title(text: libL10n.init, big: true),
-        SizedBox(height: padTop),
-        ListTile(
-          leading: const Icon(IonIcons.language),
-          title: Text(libL10n.language),
-          onTap: () async {
-            final selected = await ctx.showPickSingleDialog(
-              title: libL10n.language,
-              items: AppLocalizations.supportedLocales,
-              display: (p0) => p0.nativeName,
-              initial: _setting.locale.fetch().toLocale,
-            );
-            if (selected != null) {
-              _setting.locale.put(selected.code);
-              RNodes.app.notify();
-            }
-          },
-          trailing: Text(
-            ctx.localeNativeName,
-            style: const TextStyle(fontSize: 15, color: Colors.grey),
+        Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 720),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                SizedBox(height: padTop * .38),
+                _buildWelcomeHeader(ctx),
+                const SizedBox(height: 26),
+                Text(
+                  libL10n.setting,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    color: scheme.onSurfaceVariant,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 10),
+                CardX(
+                  color: scheme.surfaceContainerLow,
+                  child: Column(
+                    children: [
+                      ListTile(
+                        leading: _buildSettingIcon(ctx, IonIcons.language),
+                        title: Text(libL10n.language),
+                        subtitle: Text(
+                          ctx.localeNativeName,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: scheme.onSurfaceVariant,
+                          ),
+                        ),
+                        trailing: const Icon(Icons.chevron_right),
+                        onTap: () => _selectLocale(ctx),
+                      ),
+                      Divider(height: 1, color: scheme.outlineVariant),
+                      ListTile(
+                        leading: _buildSettingIcon(ctx, Icons.update),
+                        title: Text(libL10n.checkUpdate),
+                        subtitle: isAndroid
+                            ? Text(l10n.fdroidReleaseTip, style: UIs.textGrey)
+                            : null,
+                        trailing: StoreSwitch(
+                          prop: _setting.autoCheckAppUpdate,
+                        ),
+                      ),
+                      Divider(height: 1, color: scheme.outlineVariant),
+                      ListTile(
+                        leading: _buildSettingIcon(
+                          ctx,
+                          MingCute.delete_2_fill,
+                        ),
+                        title: TipText('rm -r', l10n.sftpRmrDirSummary),
+                        trailing: StoreSwitch(prop: _setting.sftpRmrDir),
+                      ),
+                      Divider(height: 1, color: scheme.outlineVariant),
+                      ListTile(
+                        leading: _buildSettingIcon(
+                          ctx,
+                          MingCute.chart_line_line,
+                          size: _kIconSize,
+                        ),
+                        title: TipText(
+                          'Docker ${l10n.stat}',
+                          l10n.parseContainerStatsTip,
+                        ),
+                        trailing: StoreSwitch(
+                          prop: _setting.containerParseStat,
+                        ),
+                      ),
+                      Divider(height: 1, color: scheme.outlineVariant),
+                      ListTile(
+                        leading: _buildSettingIcon(
+                          ctx,
+                          Bootstrap.alphabet,
+                        ),
+                        title: TipText(
+                          l10n.letterCache,
+                          l10n.letterCacheTip,
+                        ),
+                        trailing: StoreSwitch(prop: _setting.letterCache),
+                      ),
+                    ],
+                  ),
+                ),
+                UIs.height77,
+              ],
+            ),
           ),
-        ).cardx,
-        ListTile(
-          leading: const Icon(Icons.update),
-          title: Text(libL10n.checkUpdate),
-          subtitle: isAndroid
-              ? Text(l10n.fdroidReleaseTip, style: UIs.textGrey)
-              : null,
-          trailing: StoreSwitch(prop: _setting.autoCheckAppUpdate),
-        ).cardx,
-        ListTile(
-          leading: const Icon(MingCute.delete_2_fill),
-          title: TipText('rm -r', l10n.sftpRmrDirSummary),
-          trailing: StoreSwitch(prop: _setting.sftpRmrDir),
-        ).cardx,
-        ListTile(
-          leading: const Icon(MingCute.chart_line_line, size: _kIconSize),
-          title: TipText('Docker ${l10n.stat}', l10n.parseContainerStatsTip),
-          trailing: StoreSwitch(prop: _setting.containerParseStat),
-        ).cardx,
-        ListTile(
-          leading: const Icon(Bootstrap.alphabet),
-          title: TipText(l10n.letterCache, l10n.letterCacheTip),
-          trailing: StoreSwitch(prop: _setting.letterCache),
-        ).cardx,
-        UIs.height77,
+        ),
       ],
     );
   }
 
+  static Widget _buildWelcomeHeader(BuildContext ctx) {
+    final theme = Theme.of(ctx);
+    final scheme = theme.colorScheme;
+    final libL10n = ctx.libL10n;
+    final l10n = ctx.l10n;
+
+    return Column(
+      children: [
+        Container(
+          width: 112,
+          height: 112,
+          padding: const EdgeInsets.all(17),
+          decoration: BoxDecoration(
+            color: scheme.primaryContainer.withValues(alpha: .55),
+            borderRadius: BorderRadius.circular(30),
+            border: Border.all(color: scheme.primary.withValues(alpha: .16)),
+            boxShadow: [
+              BoxShadow(
+                color: scheme.primary.withValues(alpha: .12),
+                blurRadius: 28,
+                offset: const Offset(0, 12),
+              ),
+            ],
+          ),
+          child: Image.asset('assets/app_icon.png'),
+        ),
+        const SizedBox(height: 20),
+        Text(
+          BuildData.name,
+          textAlign: TextAlign.center,
+          style: theme.textTheme.headlineMedium?.copyWith(
+            fontWeight: FontWeight.w700,
+            letterSpacing: -.5,
+          ),
+        ),
+        const SizedBox(height: 6),
+        Text(
+          libL10n.init,
+          textAlign: TextAlign.center,
+          style: theme.textTheme.titleMedium?.copyWith(
+            color: scheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 18),
+        Wrap(
+          alignment: WrapAlignment.center,
+          spacing: 8,
+          runSpacing: 8,
+          children: [
+            _buildFeatureChip(ctx, Icons.dns_outlined, libL10n.server),
+            _buildFeatureChip(ctx, Icons.terminal, l10n.ssh),
+            _buildFeatureChip(ctx, Icons.folder_outlined, l10n.sftp),
+            _buildFeatureChip(
+              ctx,
+              Icons.inventory_2_outlined,
+              libL10n.container,
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  static Widget _buildFeatureChip(
+    BuildContext ctx,
+    IconData icon,
+    String label,
+  ) {
+    final scheme = Theme.of(ctx).colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+      decoration: BoxDecoration(
+        color: scheme.surfaceContainerHigh,
+        borderRadius: BorderRadius.circular(100),
+        border: Border.all(color: scheme.outlineVariant),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 17, color: scheme.primary),
+          const SizedBox(width: 7),
+          Text(label, style: Theme.of(ctx).textTheme.labelLarge),
+        ],
+      ),
+    );
+  }
+
+  static Widget _buildSettingIcon(
+    BuildContext ctx,
+    IconData icon, {
+    double? size,
+  }) {
+    final scheme = Theme.of(ctx).colorScheme;
+
+    return Container(
+      width: 40,
+      height: 40,
+      decoration: BoxDecoration(
+        color: scheme.primaryContainer,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Icon(icon, size: size ?? 21, color: scheme.onPrimaryContainer),
+    );
+  }
+
+  static Future<void> _selectLocale(BuildContext ctx) async {
+    final selected = await ctx.showPickSingleDialog(
+      title: ctx.libL10n.language,
+      items: AppLocalizations.supportedLocales,
+      display: (locale) => locale.nativeName,
+      initial: _setting.locale.fetch().toLocale,
+    );
+    if (selected == null || !ctx.mounted) return;
+
+    _setting.locale.put(selected.code);
+  }
+
   static Widget _buildBackupPasswordMigration(BuildContext ctx, double padTop) {
+    final l10n = ctx.l10n;
+
     return ListView(
       padding: _introListPad,
       children: [

--- a/lib/intro.dart
+++ b/lib/intro.dart
@@ -102,7 +102,7 @@ final class _IntroPage extends StatelessWidget {
                           size: _kIconSize,
                         ),
                         title: TipText(
-                          'Docker ${l10n.stat}',
+                          l10n.dockerStatistics,
                           l10n.parseContainerStatsTip,
                         ),
                         trailing: StoreSwitch(

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -68,6 +68,7 @@
   "dockerImagesFmt": "{count} Image(s)",
   "dockerProjectOther": "Andere",
   "dockerPruneTip": "Nicht verwendete Daten entfernen, um Speicherplatz freizugeben",
+  "dockerStatistics": "Docker-Statistiken",
   "dockerStatusRunningAndStoppedFmt": "{runningCount} aktiv, {stoppedCount} container gestoppt.",
   "dockerStatusRunningFmt": "{count} Container aktiv",
   "doubleColumnMode": "Doppelspaltiger Modus",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -141,6 +141,7 @@
   "dockerImagesFmt": "{count} images",
   "dockerProjectOther": "Other",
   "dockerPruneTip": "Remove unused data to free up disk space",
+  "dockerStatistics": "Docker Statistics",
   "dockerStatusRunningAndStoppedFmt": "{runningCount} running, {stoppedCount} container stopped.",
   "dockerStatusRunningFmt": "{count} container running.",
   "doubleColumnMode": "Double column mode",

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -68,6 +68,7 @@
   "dockerImagesFmt": "Total de {count} imágenes",
   "dockerProjectOther": "Otros",
   "dockerPruneTip": "Elimina los datos no utilizados para liberar espacio en disco",
+  "dockerStatistics": "Estadísticas de Docker",
   "dockerStatusRunningAndStoppedFmt": "{runningCount} en ejecución, {stoppedCount} detenidos",
   "dockerStatusRunningFmt": "{count} contenedores en ejecución",
   "doubleColumnMode": "Modo de doble columna",

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -68,6 +68,7 @@
   "dockerImagesFmt": "{count} images",
   "dockerProjectOther": "Autres",
   "dockerPruneTip": "Supprimez les données inutilisées pour libérer de l'espace disque",
+  "dockerStatistics": "Statistiques Docker",
   "dockerStatusRunningAndStoppedFmt": "{runningCount} en cours d'exécution, {stoppedCount} conteneur arrêté.",
   "dockerStatusRunningFmt": "{count} conteneur en cours d'exécution.",
   "doubleColumnMode": "Mode double colonne",

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -68,6 +68,7 @@
   "dockerImagesFmt": "{count} gambar",
   "dockerProjectOther": "Lainnya",
   "dockerPruneTip": "Hapus data yang tidak digunakan untuk mengosongkan ruang disk",
+  "dockerStatistics": "Statistik Docker",
   "dockerStatusRunningAndStoppedFmt": "{runningCount} running, {stoppedCount} container stopped.",
   "dockerStatusRunningFmt": "{count} wadah berjalan.",
   "doubleColumnMode": "Mode kolom ganda",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -68,6 +68,7 @@
   "dockerImagesFmt": "{count} immagini",
   "dockerProjectOther": "Altri",
   "dockerPruneTip": "Rimuovi i dati inutilizzati per liberare spazio su disco",
+  "dockerStatistics": "Statistiche Docker",
   "dockerStatusRunningAndStoppedFmt": "{runningCount} in esecuzione, {stoppedCount} container fermati.",
   "dockerStatusRunningFmt": "{count} container in esecuzione.",
   "doubleColumnMode": "Modalità a doppia colonna",

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -68,6 +68,7 @@
   "dockerImagesFmt": "合計{count}イメージ",
   "dockerProjectOther": "その他",
   "dockerPruneTip": "未使用のデータを削除してディスク容量を解放します",
+  "dockerStatistics": "Docker 統計",
   "dockerStatusRunningAndStoppedFmt": "{runningCount}個が実行中、{stoppedCount}個が停止中",
   "dockerStatusRunningFmt": "{count}個のコンテナが実行中",
   "doubleColumnMode": "ダブルカラムモード",

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -80,6 +80,7 @@
   "dockerImagesFmt": "이미지 {count}개",
   "dockerProjectOther": "기타",
   "dockerPruneTip": "사용하지 않는 데이터를 제거하여 디스크 공간을 확보합니다",
+  "dockerStatistics": "Docker 통계",
   "dockerStatusRunningAndStoppedFmt": "{runningCount}개 실행 중, {stoppedCount}개 중지됨.",
   "dockerStatusRunningFmt": "컨테이너 {count}개 실행 중.",
   "doubleColumnMode": "이중 열 모드",

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -68,6 +68,7 @@
   "dockerImagesFmt": "{count} afbeeldingen",
   "dockerProjectOther": "Overig",
   "dockerPruneTip": "Verwijder ongebruikte gegevens om schijfruimte vrij te maken",
+  "dockerStatistics": "Docker-statistieken",
   "dockerStatusRunningAndStoppedFmt": "{runningCount} actief, {stoppedCount} container gestopt.",
   "dockerStatusRunningFmt": "{count} container actief.",
   "doubleColumnMode": "Dubbele kolommodus",

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -68,6 +68,7 @@
   "dockerImagesFmt": "Total de {count} imagens",
   "dockerProjectOther": "Outros",
   "dockerPruneTip": "Remova os dados não utilizados para liberar espaço em disco",
+  "dockerStatistics": "Estatísticas do Docker",
   "dockerStatusRunningAndStoppedFmt": "{runningCount} em execução, {stoppedCount} parados",
   "dockerStatusRunningFmt": "{count} contêiner(es) em execução",
   "doubleColumnMode": "Modo de coluna dupla",

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -68,6 +68,7 @@
   "dockerImagesFmt": "Всего {count} образов",
   "dockerProjectOther": "Другое",
   "dockerPruneTip": "Удалите неиспользуемые данные, чтобы освободить место на диске",
+  "dockerStatistics": "Статистика Docker",
   "dockerStatusRunningAndStoppedFmt": "{runningCount} запущено, {stoppedCount} остановлено",
   "dockerStatusRunningFmt": "{count} контейнеров запущено",
   "doubleColumnMode": "Режим двойной колонки",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -68,6 +68,7 @@
   "dockerImagesFmt": "{count} görüntü",
   "dockerProjectOther": "Diğer",
   "dockerPruneTip": "Disk alanını boşaltmak için kullanılmayan verileri kaldırın",
+  "dockerStatistics": "Docker İstatistikleri",
   "dockerStatusRunningAndStoppedFmt": "{runningCount} çalışıyor, {stoppedCount} konteyner durdurulmuş.",
   "dockerStatusRunningFmt": "{count} konteyner çalışıyor.",
   "doubleColumnMode": "Çift sütun modu",

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -68,6 +68,7 @@
   "dockerImagesFmt": "Всього {count} образів",
   "dockerProjectOther": "Інші",
   "dockerPruneTip": "Видаліть невикористані дані, щоб звільнити місце на диску",
+  "dockerStatistics": "Статистика Docker",
   "dockerStatusRunningAndStoppedFmt": "{runningCount} запущено, {stoppedCount} контейнерів зупинено.",
   "dockerStatusRunningFmt": "{count} контейнер(и) запущено.",
   "doubleColumnMode": "Режим подвійної колонки",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -140,6 +140,7 @@
   "dockerImagesFmt": "{count} 个镜像",
   "dockerProjectOther": "其他",
   "dockerPruneTip": "清理未使用的数据以释放磁盘空间",
+  "dockerStatistics": "Docker 统计",
   "dockerStatusRunningAndStoppedFmt": "{runningCount} 个正在运行, {stoppedCount} 个已停止",
   "dockerStatusRunningFmt": "{count} 个容器正在运行",
   "doubleColumnMode": "双列模式",

--- a/lib/l10n/app_zh_tw.arb
+++ b/lib/l10n/app_zh_tw.arb
@@ -139,6 +139,7 @@
   "dockerImagesFmt": "{count} 個映像檔",
   "dockerProjectOther": "其他",
   "dockerPruneTip": "清理未使用的資料以釋放磁碟空間",
+  "dockerStatistics": "Docker 統計",
   "dockerStatusRunningAndStoppedFmt": "{runningCount} 個正在執行, {stoppedCount} 個已停止",
   "dockerStatusRunningFmt": "{count} 個容器正在執行",
   "doubleColumnMode": "雙列模式",

--- a/test/app_locale_test.dart
+++ b/test/app_locale_test.dart
@@ -1,0 +1,60 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive_ce/hive.dart';
+import 'package:server_box/app.dart';
+import 'package:server_box/data/res/store.dart';
+import 'package:server_box/data/store/setting.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  late Box<dynamic> box;
+  late SettingStore setting;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('server-box-app-test-');
+    Hive.init(tempDir.path);
+    box = await Hive.openBox<dynamic>('setting_test');
+    setting = SettingStore.forBox(box);
+    getIt.registerSingleton<SettingStore>(setting);
+    FlutterSecureStorage.setMockInitialValues({});
+  });
+
+  tearDown(() async {
+    await getIt.reset();
+  });
+
+  testWidgets('updates the onboarding locale when the setting changes', (
+    tester,
+  ) async {
+    await tester.pumpWidget(const MyApp());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Initialize'), findsOneWidget);
+    expect(tester.widget<MaterialApp>(find.byType(MaterialApp)).locale, isNull);
+
+    setting.locale.put('zh');
+    await tester.pumpAndSettle(
+      const Duration(milliseconds: 100),
+      EnginePhase.sendSemanticsUpdate,
+      const Duration(seconds: 5),
+    );
+
+    expect(
+      tester.widget<MaterialApp>(find.byType(MaterialApp)).locale,
+      const Locale('zh'),
+    );
+    expect(
+      Localizations.localeOf(tester.element(find.byType(ListView).first)),
+      const Locale('zh'),
+    );
+    expect(find.text('Initialize'), findsNothing);
+    expect(find.text('初始化'), findsOneWidget);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+  });
+}


### PR DESCRIPTION
## Summary

- Rebuild the onboarding settings screen with a welcome header, feature chips, grouped settings, and themed icons.
- Update the app and onboarding widgets when the locale setting changes.
- Add a widget test covering live locale updates and translated onboarding content.

## Testing

- Added and ran a widget test validating locale changes from English to Chinese.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic language updates across the app when the selected locale changes.
  * Refreshed the onboarding experience with a centered layout, welcome header, app icon, feature highlights, themed cards, and clearer setting sections.
  * Improved locale selection so changes are applied safely and reflected immediately.
  * Added localized “Docker Statistics” text across supported languages.

* **Bug Fixes**
  * Fixed onboarding content and application localization not consistently refreshing after language changes.

* **Tests**
  * Added coverage verifying locale changes update app localization and onboarding text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- winnowl:summary:begin -->
## Summary

### Changes

- **Application locale propagation and MaterialApp rebuild**: The app root now observes the persisted locale setting, supplies an explicit locale to MaterialApp, keys the app by the resolved locale, and resolves localization delegates/supported locales for the application.
- **Localized onboarding content and locale-selection flow**: The introductory/onboarding UI uses application and library localization context, rebuilds its intro pages when the locale changes, and exposes the supported application locales through a picker.
- **Localization source and generated API contract**: The ARB sources and generated localization base/delegate classes are updated together across the supported language set, adding or revising application messages and locale metadata.
- **ARB translation catalog coverage**: The English and translated ARB catalogs are modified for the application’s supported locales, including the zh_TW catalog.
- **Locale propagation widget test and test-environment setup**: A widget test initializes an isolated settings store and verifies that changing the persisted locale updates MaterialApp and onboarding localization.
<!-- winnowl:summary:end -->