### PR TITLE
feat(ci): publish unsigned ipa in releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,6 +139,61 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  buildIOS:
+    name: Build ios
+    needs: reproducibilityCheck
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: "stable"
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+      - name: Resolve build number
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          build="$(sed -n -E 's/.*static const int build = ([0-9]+);/\1/p' lib/data/res/build_data.dart | head -n 1)"
+          if [[ -z "$build" ]]; then
+            echo "BuildData.build not found in lib/data/res/build_data.dart"
+            exit 1
+          fi
+
+          echo "BUILD_NUMBER=$build" >> "$GITHUB_ENV"
+      - name: Build (unsigned)
+        shell: bash
+        run: |
+          flutter build ios --release --no-codesign \
+            --build-number="${BUILD_NUMBER}" \
+            --build-name="1.0.${BUILD_NUMBER}"
+      - name: Package ipa
+        shell: bash
+        run: APP_ASSET_NAME="${APP_NAME}" scripts/release/package-unsigned-ipa.sh
+      - name: Upload artifacts
+        if: inputs.release != true && github.ref_type != 'tag'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.APP_NAME }}-${{ env.BUILD_TAG }}-ios
+          path: build/artifacts/*.ipa
+          if-no-files-found: error
+          retention-days: 14
+      - name: Create Release
+        if: inputs.release == true || github.ref_type == 'tag'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v1.0.${{ env.BUILD_NUMBER }}
+          files: |
+            build/artifacts/${{ env.APP_NAME }}_v1.0.${{ env.BUILD_NUMBER }}_NoSign.ipa
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   buildLinux:
     name: Build linux
     needs: reproducibilityCheck

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ TAP_REPO_PATH ?=
 
 .PHONY: help deps pub-get run run-device analyze test test-one coverage \
 	gen gen-build gen-build-clean gen-l10n build build-android build-ios \
-	build-macos build-linux build-windows clean release-macos-dmg package-dmg \
-	sync-homebrew-cask
+	build-ios-nosign build-macos build-linux build-windows clean \
+	release-macos-dmg package-dmg sync-homebrew-cask
 
 help:
 	@printf '%s\n' \
@@ -41,6 +41,7 @@ help:
 		'  build              Build via fl_build: make build PLATFORM=<android|ios|macos|linux|windows>' \
 		'  build-android      Build Android package' \
 		'  build-ios          Build iOS package' \
+		'  build-ios-nosign   Build an unsigned iOS ipa (_NoSign.ipa, needs re-signing)' \
 		'  build-macos        Build macOS package' \
 		'  build-linux        Build Linux package' \
 		'  build-windows      Build Windows package' \
@@ -109,6 +110,10 @@ build-android:
 
 build-ios:
 	$(DART) run fl_build -p ios
+
+build-ios-nosign:
+	$(FLUTTER) build ios --release --no-codesign
+	bash scripts/release/package-unsigned-ipa.sh
 
 build-macos:
 	$(DART) run fl_build -p macos

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Especially thanks to <a href="https://github.com/TerminalStudio/dartssh2">dartss
 
 |Platform| From|
 |--|--|
-| iOS | [AppStore](https://apps.apple.com/app/id1586449703) |
-| macOS | [AppStore](https://apps.apple.com/app/id1586449703) / brew install --cask server-box |
+| iOS | [AppStore](https://apps.apple.com/app/id1586449703) / [GitHub](https://github.com/lollipopkit/flutter_server_box/releases) (`_NoSign.ipa`, unsigned, you need to sign it yourself) |
+| macOS | [AppStore](https://apps.apple.com/app/id1586449703) / [GitHub](https://github.com/lollipopkit/flutter_server_box/releases) (`.dmg`) / brew install --cask server-box |
 | Android | [GitHub](https://github.com/lollipopkit/flutter_server_box/releases) / [CDN](https://cdn.lpkt.cn/serverbox/pkg/?sort=time&order=desc&layout=grid) / [F-Droid](https://f-droid.org/packages/tech.lolli.toolbox) / [OpenAPK](https://www.openapk.net/serverbox/tech.lolli.toolbox/) |
 | Linux / Windows | [GitHub](https://github.com/lollipopkit/flutter_server_box/releases) / [CDN](https://cdn.lpkt.cn/serverbox/pkg/?sort=time&order=desc&layout=grid) |
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -30,8 +30,8 @@
 
 平台|下载
 --|--
-| iOS | [AppStore](https://apps.apple.com/app/id1586449703) |
-| macOS | [AppStore](https://apps.apple.com/app/id1586449703) / brew install --cask server-box |
+| iOS | [AppStore](https://apps.apple.com/app/id1586449703) / [GitHub](https://github.com/lollipopkit/flutter_server_box/releases)（`_NoSign.ipa`，未签名，需自行签名后安装） |
+| macOS | [AppStore](https://apps.apple.com/app/id1586449703) / [GitHub](https://github.com/lollipopkit/flutter_server_box/releases)（`.dmg`） / brew install --cask server-box |
 Android | [GitHub](https://github.com/lollipopkit/flutter_server_box/releases) / [CDN](https://cdn.lpkt.cn/serverbox/pkg/?sort=time&order=desc&layout=grid) / [F-Droid](https://f-droid.org/packages/tech.lolli.toolbox) / [OpenAPK](https://www.openapk.net/serverbox/tech.lolli.toolbox/)
 Linux / Windows | [GitHub](https://github.com/lollipopkit/flutter_server_box/releases) / [CDN](https://cdn.lpkt.cn/serverbox/pkg/?sort=time&order=desc&layout=grid)
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -30,8 +30,8 @@
 
 平台|下载
 --|--
-| iOS | [AppStore](https://apps.apple.com/app/id1586449703) / [GitHub](https://github.com/lollipopkit/flutter_server_box/releases)（`_NoSign.ipa`，未签名，需自行签名后安装） |
-| macOS | [AppStore](https://apps.apple.com/app/id1586449703) / [GitHub](https://github.com/lollipopkit/flutter_server_box/releases)（`.dmg`） / brew install --cask server-box |
+iOS | [AppStore](https://apps.apple.com/app/id1586449703) / [GitHub](https://github.com/lollipopkit/flutter_server_box/releases)（`_NoSign.ipa`，未签名，需自行签名后安装）
+macOS | [AppStore](https://apps.apple.com/app/id1586449703) / [GitHub](https://github.com/lollipopkit/flutter_server_box/releases)（`.dmg`） / brew install --cask server-box
 Android | [GitHub](https://github.com/lollipopkit/flutter_server_box/releases) / [CDN](https://cdn.lpkt.cn/serverbox/pkg/?sort=time&order=desc&layout=grid) / [F-Droid](https://f-droid.org/packages/tech.lolli.toolbox) / [OpenAPK](https://www.openapk.net/serverbox/tech.lolli.toolbox/)
 Linux / Windows | [GitHub](https://github.com/lollipopkit/flutter_server_box/releases) / [CDN](https://cdn.lpkt.cn/serverbox/pkg/?sort=time&order=desc&layout=grid)
 

--- a/scripts/release/package-unsigned-ipa.sh
+++ b/scripts/release/package-unsigned-ipa.sh
@@ -30,9 +30,14 @@ fi
 # installable without re-signing.
 IPA_PATH="${IPA_PATH:-$ARTIFACTS_PATH/${APP_ASSET_NAME}_v1.0.${BUILD_NUMBER}_NoSign.ipa}"
 
+# zip runs from the staging dir, so resolve the output to an absolute path
+# first: a relative IPA_PATH or ARTIFACTS_PATH would otherwise land inside the
+# staging dir and be deleted with it.
+mkdir -p "$(dirname "$IPA_PATH")"
+IPA_PATH="$(cd "$(dirname "$IPA_PATH")" && pwd)/$(basename "$IPA_PATH")"
+
 rm -rf "$PAYLOAD_STAGING_PATH"
 mkdir -p "$PAYLOAD_STAGING_PATH/Payload"
-mkdir -p "$ARTIFACTS_PATH"
 rm -f "$IPA_PATH"
 
 STAGED_APP_PATH="$PAYLOAD_STAGING_PATH/Payload/$(basename "$APP_PATH")"

--- a/scripts/release/package-unsigned-ipa.sh
+++ b/scripts/release/package-unsigned-ipa.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+APP_ASSET_NAME="${APP_ASSET_NAME:-ServerBox}"
+BUILD_DATA_PATH="${BUILD_DATA_PATH:-$REPO_ROOT/lib/data/res/build_data.dart}"
+APP_PATH="${1:-${APP_PATH:-$REPO_ROOT/build/ios/iphoneos/Runner.app}}"
+ARTIFACTS_PATH="${ARTIFACTS_PATH:-$REPO_ROOT/build/artifacts}"
+PAYLOAD_STAGING_PATH="${PAYLOAD_STAGING_PATH:-$REPO_ROOT/build/ipa-root}"
+
+if [[ ! -d "$APP_PATH" ]]; then
+  echo "app bundle not found: $APP_PATH" >&2
+  echo "Run 'flutter build ios --release --no-codesign' first." >&2
+  exit 1
+fi
+
+BUILD_NUMBER="${BUILD_NUMBER:-}"
+if [[ -z "$BUILD_NUMBER" ]]; then
+  BUILD_NUMBER="$(sed -n -E 's/.*static const int build = ([0-9]+);/\1/p' "$BUILD_DATA_PATH" | head -n 1)"
+fi
+
+if [[ -z "$BUILD_NUMBER" ]]; then
+  echo "build number not found in $BUILD_DATA_PATH" >&2
+  exit 1
+fi
+
+# The artifact carries no signature, so the name must say so: it is not
+# installable without re-signing.
+IPA_PATH="${IPA_PATH:-$ARTIFACTS_PATH/${APP_ASSET_NAME}_v1.0.${BUILD_NUMBER}_NoSign.ipa}"
+
+rm -rf "$PAYLOAD_STAGING_PATH"
+mkdir -p "$PAYLOAD_STAGING_PATH/Payload"
+mkdir -p "$ARTIFACTS_PATH"
+rm -f "$IPA_PATH"
+
+STAGED_APP_PATH="$PAYLOAD_STAGING_PATH/Payload/$(basename "$APP_PATH")"
+cp -R "$APP_PATH" "$STAGED_APP_PATH"
+
+# Drop signing leftovers of the app and of every embedded bundle (extensions,
+# watch app, frameworks) so the payload is uniformly unsigned.
+find "$STAGED_APP_PATH" -name '_CodeSignature' -type d -prune -exec rm -rf {} +
+find "$STAGED_APP_PATH" -name 'embedded.mobileprovision' -type f -delete
+
+(cd "$PAYLOAD_STAGING_PATH" && zip -qry "$IPA_PATH" Payload)
+rm -rf "$PAYLOAD_STAGING_PATH"
+
+echo "unsigned ipa: $IPA_PATH"
+shasum -a 256 "$IPA_PATH"


### PR DESCRIPTION
Closes #1276.

## What

Releases now carry an unsigned iOS package, `ServerBox_v1.0.<build>_NoSign.ipa`.

- `scripts/release/package-unsigned-ipa.sh`: wraps the app bundle produced by `flutter build ios --no-codesign` into `Payload/` and zips it. `_CodeSignature` dirs and `embedded.mobileprovision` are removed from the staged copy — including the embedded extension, watch app and frameworks — so the artifact matches its `NoSign` name. Paths, asset name and build number are overridable via env vars; a sha256 is printed.
- `buildIOS` job in `.github/workflows/build.yml`: builds unsigned on `macos-latest`, uploads the ipa as a workflow artifact for test builds, attaches it to the GitHub Release for tag builds. `fl_build` is not used. The build number is read from `lib/data/res/build_data.dart`, which `reproducibilityCheck` already pins to the tag, so it stays in sync with the other platforms' filenames.
- `make build-ios-nosign` reproduces the artifact locally.
- README / README_zh: document the ipa, plus the macOS `.dmg` that is already uploaded to Releases manually.

The ipa is not installable as is — users have to sign it themselves (AltStore / Sideloadly / …). That is what the `NoSign` suffix is for.

## Verification

- Ran `flutter build ios --release --no-codesign` plus the packaging script locally: produced a 23M `ServerBox_v1.0.1480_NoSign.ipa`; the archive contains no `_CodeSignature` or `mobileprovision` entries, `CFBundleVersion=1480`, `CFBundleShortVersionString=1.0.1480`.
- `actionlint` reports nothing on the new job (only three pre-existing SC2231 hits in the android/linux/windows rename steps); `shellcheck` is clean on the new script.

Note: `flutter build ios` runs migrators that touch `analysis_options.yaml` and `ios/Runner.xcodeproj/project.pbxproj` (iOS deployment target 13.0 → 15.0). Those are unrelated to this change and were reverted; accepting them should be a separate commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added downloadable unsigned iOS IPA release packages.
  * Added macOS DMG download options to the installation instructions.
  * Added support for building an unsigned iOS release package locally.

* **Release Improvements**
  * iOS packages can now be automatically prepared and published for eligible releases.
  * Packages include build information and integrity checks for reliable downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- winnowl:summary:begin -->
## Summary

### Changes

- **Cross-platform GitHub Actions build and release orchestration**: The workflow now validates release tags and source versions, enforces the dependency lockfile, patches JNI build IDs, builds Android/iOS/Linux/Windows, renames artifacts, and uploads or publishes platform outputs.
- **Unsigned iOS IPA packaging contract**: A new packaging script converts the unsigned Flutter iOS app bundle into a NoSign IPA, strips signing leftovers, and derives the build number and output path from environment variables or repository metadata.
- **Makefile developer build and release entry points**: The Makefile adds a build-ios-nosign target and documents it alongside existing Flutter, fl_build, generation, and packaging targets.
- **User-facing installation and development documentation**: The English and Chinese READMEs document the unsigned iOS release artifact and retain platform installation/development guidance.
<!-- winnowl:summary:end -->