### PR TITLE
fix(android): keep split APK builds reproducible

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -34,6 +34,19 @@ jobs:
           channel: 'stable'
           flutter-version: ${{ env.FLUTTER_VERSION }}
 
+      - name: Check Android split-build reproducibility
+        shell: bash
+        run: |
+          grep_status=0
+          git grep -n -F 'BuildConfig.VERSION_CODE' -- android/app/src/main || grep_status=$?
+          if [[ "$grep_status" -eq 0 ]]; then
+            echo "::error::BuildConfig.VERSION_CODE is ABI-specific for split APKs and must not be compiled into shared Android bytecode."
+            exit 1
+          elif [[ "$grep_status" -ne 1 ]]; then
+            echo "::error::git grep failed with status ${grep_status}."
+            exit "$grep_status"
+          fi
+
       - name: Check locked dependencies
         env:
           PUB_HOSTED_URL: https://pub.dev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,9 +66,14 @@ jobs:
       - name: Check Android split-build reproducibility
         shell: bash
         run: |
-          if git grep -n -F 'BuildConfig.VERSION_CODE' -- android/app/src/main; then
+          grep_status=0
+          git grep -n -F 'BuildConfig.VERSION_CODE' -- android/app/src/main || grep_status=$?
+          if [[ "$grep_status" -eq 0 ]]; then
             echo "::error::BuildConfig.VERSION_CODE is ABI-specific for split APKs and must not be compiled into shared Android bytecode."
             exit 1
+          elif [[ "$grep_status" -ne 1 ]]; then
+            echo "::error::git grep failed with status ${grep_status}."
+            exit "$grep_status"
           fi
       - name: Check locked dependencies
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,13 @@ jobs:
             echo "BuildData.build must match tag ${GITHUB_REF_NAME}; got ${build_data}."
             exit 1
           fi
+      - name: Check Android split-build reproducibility
+        shell: bash
+        run: |
+          if git grep -n -F 'BuildConfig.VERSION_CODE' -- android/app/src/main; then
+            echo "::error::BuildConfig.VERSION_CODE is ABI-specific for split APKs and must not be compiled into shared Android bytecode."
+            exit 1
+          fi
       - name: Check locked dependencies
         shell: bash
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,18 +63,6 @@ jobs:
             echo "BuildData.build must match tag ${GITHUB_REF_NAME}; got ${build_data}."
             exit 1
           fi
-      - name: Check Android split-build reproducibility
-        shell: bash
-        run: |
-          grep_status=0
-          git grep -n -F 'BuildConfig.VERSION_CODE' -- android/app/src/main || grep_status=$?
-          if [[ "$grep_status" -eq 0 ]]; then
-            echo "::error::BuildConfig.VERSION_CODE is ABI-specific for split APKs and must not be compiled into shared Android bytecode."
-            exit 1
-          elif [[ "$grep_status" -ne 1 ]]; then
-            echo "::error::git grep failed with status ${grep_status}."
-            exit "$grep_status"
-          fi
       - name: Check locked dependencies
         shell: bash
         env:

--- a/android/app/src/main/kotlin/tech/lolli/toolbox/ImpellerCompatibility.kt
+++ b/android/app/src/main/kotlin/tech/lolli/toolbox/ImpellerCompatibility.kt
@@ -32,7 +32,8 @@ internal object ImpellerCompatibility {
             return Result(false, "Flutter uses Skia below Android API 29")
         }
 
-        val signature = "$PROBE_VERSION|${BuildConfig.VERSION_CODE}|${Build.FINGERPRINT}"
+        // Numeric version codes differ per ABI, while this bytecode is shared by split APKs.
+        val signature = "$PROBE_VERSION|${BuildConfig.VERSION_NAME}|${Build.FINGERPRINT}"
         val prefs = try {
             context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         } catch (e: RuntimeException) {


### PR DESCRIPTION
GitHub release builds create all ABI splits in one Flutter invocation, while F-Droid builds each ABI separately. The per-output version code is therefore not stable in the shared `classes.dex`: the release x86_64 APK contained `148002`, while F-Droid's standalone x86_64 build contained `148001`.

The probe cache only needs to be invalidated between app releases, so `BuildConfig.VERSION_NAME` provides the same behavior without introducing ABI-dependent bytecode.

#1274

## Testing

- `git diff --check`
- existing reproducibility guard command against `android/app/src/main`
- `actionlint .github/workflows/build.yml`
- `flutter analyze --no-pub` was attempted, but the repository-wide run is currently blocked by pre-existing submodule example/test errors such as unsupported `dart:mirrors` imports and missing xterm example dependencies
- Android compilation was not available in the local VM because no Android SDK is installed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility probe cache handling by using the app version name, ensuring cache entries remain consistent across builds.

* **Tests**
  * Added automated checks to prevent use of the ABI-specific Android version code in source.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- winnowl:summary:begin -->
## Summary

### Changes

- **CI analysis and reproducibility workflow**: The GitHub Actions analysis workflow now defines a fixed Flutter toolchain and adds a reproducibility job covering ABI-sensitive Android bytecode, locked dependency resolution, and the JNI build-id patch before the existing analysis and test job.
- **Android Impeller compatibility probe, cache, and engine-selection contract**: The Android compatibility check adds a versioned, fingerprinted SharedPreferences probe cache and performs an EGL/OpenGL ES capability and renderer probe, conservatively disabling Impeller on unsupported, failed, incomplete, or unpersistable states; MainActivity consumes the result before Flutter engine creation.
<!-- winnowl:summary:end -->