### PR TITLE
refactor(ui): label the SSH tab as Terminal

### DIFF
--- a/lib/view/page/home_tab.dart
+++ b/lib/view/page/home_tab.dart
@@ -27,10 +27,14 @@ extension AppTabViewX on AppTab {
         label: libL10n.server,
         selectedIcon: const Icon(BoxIcons.bxs_server),
       ),
-      AppTab.ssh => const NavigationDestination(
-        icon: Icon(Icons.terminal_outlined),
-        label: 'SSH',
-        selectedIcon: Icon(Icons.terminal),
+      // Not "SSH": a terminal is what this tab holds, and SSH is only where
+      // most of them happen to come from. One already comes from a monitor
+      // agent's own PTY, and the name had to stop naming the transport before
+      // a shell on this device could live here too.
+      AppTab.ssh => NavigationDestination(
+        icon: const Icon(Icons.terminal_outlined),
+        label: libL10n.terminal,
+        selectedIcon: const Icon(Icons.terminal),
       ),
       AppTab.snippet => NavigationDestination(
         icon: const Icon(Icons.code_outlined),
@@ -57,10 +61,10 @@ extension AppTabViewX on AppTab {
         label: Text(libL10n.server),
         selectedIcon: const Icon(BoxIcons.bxs_server),
       ),
-      AppTab.ssh => const NavigationRailDestination(
-        icon: Icon(Icons.terminal_outlined),
-        label: Text('SSH'),
-        selectedIcon: Icon(Icons.terminal),
+      AppTab.ssh => NavigationRailDestination(
+        icon: const Icon(Icons.terminal_outlined),
+        label: Text(libL10n.terminal),
+        selectedIcon: const Icon(Icons.terminal),
       ),
       AppTab.snippet => NavigationRailDestination(
         icon: const Icon(Icons.code_outlined),

--- a/lib/view/page/macos_menu_bar.dart
+++ b/lib/view/page/macos_menu_bar.dart
@@ -74,7 +74,7 @@ class MacOSMenuBarManager {
     final menuItems = <PlatformMenuItem>[];
     final tabLabels = {
       AppTab.server: libL10n.server,
-      AppTab.ssh: 'SSH',
+      AppTab.ssh: libL10n.terminal,
       AppTab.file: libL10n.file,
       AppTab.snippet: libL10n.snippet,
       AppTab.agent: l10n.agentTitle,


### PR DESCRIPTION
## Summary

- label the navigation destination as Terminal instead of SSH
- use the same label in the macOS navigation menu
- keep the existing terminal icon and behavior unchanged

This is extracted from #1234 as an independent terminology improvement.

## Verification

- dart analyze lib/view/page/home_tab.dart lib/view/page/macos_menu_bar.dart
- verified together with the other first-batch UI extractions

<!-- winnowl:summary:begin -->
## Summary

### Changes

- **AppTab presentation and navigation labels**: The AppTab extension defines the page widgets and the visual/semantic destinations used by the home page, bottom navigation, rail navigation, and home-tab settings.
- **macOS application menu construction**: The macOS menu-bar manager builds application, navigation, and information menus, including localized labels, keyboard shortcuts, settings/quit/about actions, external links, and navigation entries derived from persisted home tabs.
- **Home-page integration and dynamic tab updates**: The changed tab presentation and macOS menu are consumed by HomePage, whose persisted tab list, restoration state, PageView, navigation controls, and settings listener define the integration contract.
<!-- winnowl:summary:end -->