### PR TITLE
refactor(ui): align AI settings with other settings rows

### DIFF
--- a/lib/view/page/setting/entries/ai.dart
+++ b/lib/view/page/setting/entries/ai.dart
@@ -17,9 +17,10 @@ extension _AI on _AppSettingsPageState {
         subtitle: Text(
           displayBuilder(val),
           style: UIs.textGrey,
-          maxLines: 2,
+          maxLines: 1,
           overflow: TextOverflow.ellipsis,
         ),
+        trailing: const Icon(Icons.keyboard_arrow_right),
         onTap: () => _showAskAiFieldDialog(
           prop: prop,
           title: title,
@@ -33,48 +34,20 @@ extension _AI on _AppSettingsPageState {
 
   Widget _buildAskAiConfig() {
     final l10n = context.l10n;
-    return ExpandTile(
-      leading: const Icon(LineAwesome.robot_solid, size: _kIconSize),
-      title: TipText(l10n.askAi, l10n.askAiUsageHint),
+    return Column(
       children: [
-        _setting.askAiProtocol.listenable().listenVal((value) {
-          final selected = parseAskAiProtocol(value);
-          String label(AskAiProtocol protocol) => switch (protocol) {
-            AskAiProtocol.auto => l10n.askAiProtocolAuto,
-            AskAiProtocol.chatCompletions => l10n.askAiProtocolChatCompletions,
-            AskAiProtocol.responses => l10n.askAiProtocolResponses,
-          };
-          return PopupMenuButton<AskAiProtocol>(
-            initialValue: selected,
-            onSelected: (protocol) => _setting.askAiProtocol.put(protocol.name),
-            itemBuilder: (_) => [
-              for (final protocol in AskAiProtocol.values)
-                PopupMenuItem(value: protocol, child: Text(label(protocol))),
-            ],
-            child: ListTile(
-              leading: const Icon(Icons.swap_calls_outlined),
-              title: Text(l10n.askAiProtocol),
-              subtitle: Text(
-                '${label(selected)}\n${l10n.askAiProtocolTip}',
-                style: UIs.textGrey,
-              ),
-              isThreeLine: true,
-              trailing: const Icon(Icons.arrow_drop_down),
-            ),
-          );
-        }),
-        _setting.askAiAutoRunSafeCommands.listenable().listenVal((enabled) {
-          return SwitchListTile.adaptive(
-            secondary: const Icon(Icons.verified_user_outlined),
-            title: Text(l10n.askAiAutoRunSafeCommands),
-            subtitle: Text(l10n.askAiAutoRunSafeCommandsTip),
-            value: enabled,
-            onChanged: _setting.askAiAutoRunSafeCommands.put,
-          );
-        }),
+        _buildAskAiProtocol(l10n),
+        ListTile(
+          leading: const Icon(Icons.verified_user_outlined, size: _kIconSize),
+          title: TipText(
+            l10n.askAiAutoRunSafeCommands,
+            l10n.askAiAutoRunSafeCommandsTip,
+          ),
+          trailing: StoreSwitch(prop: _setting.askAiAutoRunSafeCommands),
+        ),
         _buildAskAiTextTile(
           prop: _setting.askAiBaseUrl,
-          leading: const Icon(MingCute.link_2_line),
+          leading: const Icon(MingCute.link_2_line, size: _kIconSize),
           title: l10n.askAiBaseUrl,
           hint: 'https://api.openai.com',
           description: l10n.askAiEndpointTip,
@@ -83,7 +56,7 @@ extension _AI on _AppSettingsPageState {
         ),
         _buildAskAiTextTile(
           prop: _setting.askAiModel,
-          leading: const Icon(Icons.view_module),
+          leading: const Icon(Icons.view_module, size: _kIconSize),
           title: libL10n.askAiModel,
           hint: 'gpt-5.4-mini',
           displayBuilder: (val) =>
@@ -91,7 +64,7 @@ extension _AI on _AppSettingsPageState {
         ),
         _buildAskAiTextTile(
           prop: _setting.askAiApiKey,
-          leading: const Icon(MingCute.key_2_line),
+          leading: const Icon(MingCute.key_2_line, size: _kIconSize),
           title: l10n.askAiApiKey,
           hint: 'sk-...',
           obscure: true,
@@ -99,8 +72,35 @@ extension _AI on _AppSettingsPageState {
               ? l10n.configured
               : l10n.askAiApiKeyOptional,
         ),
-      ],
-    ).cardx;
+      ].map((e) => CardX(child: e)).toList(),
+    );
+  }
+
+  Widget _buildAskAiProtocol(AppLocalizations l10n) {
+    String label(AskAiProtocol protocol) => switch (protocol) {
+      AskAiProtocol.auto => l10n.askAiProtocolAuto,
+      AskAiProtocol.chatCompletions => l10n.askAiProtocolChatCompletions,
+      AskAiProtocol.responses => l10n.askAiProtocolResponses,
+    };
+
+    return ListTile(
+      leading: const Icon(Icons.swap_calls_outlined, size: _kIconSize),
+      title: TipText(l10n.askAiProtocol, l10n.askAiProtocolTip),
+      trailing: ValBuilder(
+        listenable: _setting.askAiProtocol.listenable(),
+        builder: (val) =>
+            Text(label(parseAskAiProtocol(val)), style: UIs.text15),
+      ),
+      onTap: () async {
+        final selected = await context.showPickSingleDialog(
+          title: l10n.askAiProtocol,
+          items: AskAiProtocol.values,
+          display: label,
+          initial: parseAskAiProtocol(_setting.askAiProtocol.fetch()),
+        );
+        if (selected != null) _setting.askAiProtocol.put(selected.name);
+      },
+    );
   }
 
   Future<void> _showAskAiFieldDialog({


### PR DESCRIPTION
## Summary

- present each AI option as an individual settings card
- show current text values on one line with a navigation affordance
- use the standard picker dialog for protocol selection
- use the shared store switch presentation for the read-only command option

This ports the visual cleanup from #1234 without bringing in its Agent architecture or new settings.

## Verification

- targeted dart analyze passed in the combined first-batch validation tree


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned the Ask AI settings screen with clearer card-based sections.
  - Added a dedicated protocol selection option with a single-choice dialog.
  - Added a switch for enabling safe-command execution.

- **Style**
  - Updated setting icons and refined subtitle display for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- winnowl:summary:begin -->
## Summary

### Changes

- **Ask AI settings section and persisted configuration fields**: Adds an AI configuration section to the app settings page, exposing endpoint, model, and API-key properties through reactive list tiles and edit dialogs.
- **Ask AI protocol selection and request behavior contract**: Adds a reactive protocol picker for Auto, Chat Completions, and Responses and writes the selected enum name to the persisted setting.
- **AI command automation control and credential presentation**: Adds the persisted safe-command auto-run switch and presents API-key configuration status through an obscured input dialog rather than showing the credential value.
<!-- winnowl:summary:end -->