### PR TITLE
refactor(ui): move server edit guidance to the app bar

### DIFF
--- a/lib/view/page/server/edit/edit.dart
+++ b/lib/view/page/server/edit/edit.dart
@@ -141,7 +141,7 @@ class _ServerEditPageState extends ConsumerState<ServerEditPage>
 
   @override
   Widget build(BuildContext context) {
-    final actions = <Widget>[];
+    final actions = <Widget>[_buildWriteScriptTip()];
     if (spi != null) actions.add(_buildDelBtn());
 
     return Scaffold(
@@ -155,15 +155,7 @@ class _ServerEditPageState extends ConsumerState<ServerEditPage>
   }
 
   Widget _buildForm() {
-    final topItems = [_buildWriteScriptTip()];
     final children = [
-      SizedBox(
-        height: 50,
-        child: ListView(
-          scrollDirection: Axis.horizontal,
-          children: topItems.joinWith(UIs.width13).toList(),
-        ),
-      ),
       Input(
         autoFocus: true,
         controller: _nameController,

--- a/lib/view/page/server/edit/widget.dart
+++ b/lib/view/page/server/edit/widget.dart
@@ -516,18 +516,16 @@ extension _Widgets on _ServerEditPageState {
   }
 
   Widget _buildWriteScriptTip() {
-    return Btn.tile(
-      text: libL10n.attention,
-      icon: const Icon(Icons.tips_and_updates, color: Colors.grey),
-      onTap: () {
+    return IconButton(
+      tooltip: libL10n.attention,
+      onPressed: () {
         context.showRoundDialog(
           title: libL10n.attention,
           child: SimpleMarkdown(data: l10n.writeScriptTip),
           actions: Btnx.oks,
         );
       },
-      textStyle: UIs.textGrey,
-      mainAxisSize: MainAxisSize.min,
+      icon: const Icon(Icons.tips_and_updates),
     );
   }
 


### PR DESCRIPTION
## Summary

- move the write-script guidance from the form body to an app-bar action
- keep the existing explanatory dialog and localization
- remove the otherwise dedicated first row from the server form

This extracts the focused server-edit UI cleanup from #1234.

## Verification

- targeted dart analyze passed in the combined first-batch validation tree

<!-- winnowl:summary:begin -->
## Summary

### Changes

- **Server editor lifecycle, routing, and form composition**: The page state owns the server-edit form, controllers/notifiers, initialization from optional route arguments, first-layout behavior, and disposal; the widget extension composes the form and save/delete actions.
- **Authentication and secret-state editing**: The editor exposes password/key authentication controls and a separate sudo-password dialog backed by asynchronous secure-storage state.
- **Connection topology and save validation**: The form edits host credentials, alternate destination, proxy command, and ordered jump-server candidates, with cycle/conflict checks before constructing and persisting Spi.
- **Optional server capabilities and command controls**: The expanded form edits environment variables, custom commands, system type, storage/health command enablement, device hints, script paths, PVE settings, logo, and Wake-on-LAN configuration.
<!-- winnowl:summary:end -->