### PR TITLE
feat(ui): improve wide-page column layouts

### DIFF
--- a/lib/view/page/container/container.dart
+++ b/lib/view/page/container/container.dart
@@ -18,6 +18,7 @@ import 'package:server_box/data/provider/server/single.dart';
 import 'package:server_box/data/res/store.dart';
 import 'package:server_box/view/page/container/resource_views.dart';
 import 'package:server_box/view/page/ssh/page/page.dart';
+import 'package:server_box/view/widget/page_columns.dart';
 
 part 'actions.dart';
 part 'types.dart';
@@ -257,7 +258,7 @@ extension _ContainerPageWidgets on _ContainerPageState {
   }
 
   Widget _buildSettingsTab(ContainerState containerState) {
-    return AutoMultiList(
+    return PageColumns(
       children: <Widget>[
         ..._SettingsMenuItems.values.map(
           (item) => _buildSettingCard(item, containerState),

--- a/lib/view/page/private_key/edit.dart
+++ b/lib/view/page/private_key/edit.dart
@@ -10,6 +10,7 @@ import 'package:server_box/core/utils/server.dart';
 import 'package:server_box/data/model/server/private_key_info.dart';
 import 'package:server_box/data/provider/private_key.dart';
 import 'package:server_box/data/res/misc.dart';
+import 'package:server_box/view/widget/page_columns.dart';
 
 const _format = 'text/plain';
 final _whitespaceRegex = RegExp(r'\s+');
@@ -196,7 +197,7 @@ class _PrivateKeyEditPageState extends ConsumerState<PrivateKeyEditPage> {
   }
 
   Widget _buildBody() {
-    return AutoMultiList(
+    return PageColumns(
       children: [
         Input(
           autoFocus: true,

--- a/lib/view/page/private_key/list.dart
+++ b/lib/view/page/private_key/list.dart
@@ -9,6 +9,7 @@ import 'package:server_box/data/model/server/private_key_info.dart';
 import 'package:server_box/data/provider/private_key.dart';
 import 'package:server_box/data/res/store.dart';
 import 'package:server_box/view/page/private_key/edit.dart';
+import 'package:server_box/view/widget/page_columns.dart';
 
 class PrivateKeysListPage extends ConsumerStatefulWidget {
   const PrivateKeysListPage({super.key});
@@ -44,7 +45,7 @@ class _PrivateKeyListState extends ConsumerState<PrivateKeysListPage>
     }
 
     final children = pkis.map(_buildKeyItem).toList();
-    return AutoMultiList(children: children);
+    return PageColumns(children: children);
   }
 
   Widget _buildKeyItem(PrivateKeyInfo item) {

--- a/lib/view/page/snippet/edit.dart
+++ b/lib/view/page/snippet/edit.dart
@@ -6,6 +6,7 @@ import 'package:server_box/core/extension/context/locale.dart';
 import 'package:server_box/data/model/server/snippet.dart';
 import 'package:server_box/data/provider/server/all.dart';
 import 'package:server_box/data/provider/snippet.dart';
+import 'package:server_box/view/widget/page_columns.dart';
 
 final class SnippetEditPageArgs {
   final Snippet? snippet;
@@ -119,7 +120,7 @@ class _SnippetEditPageState extends ConsumerState<SnippetEditPage>
   }
 
   Widget _buildBody() {
-    return AutoMultiList(
+    return PageColumns(
       children: [
         Input(
           autoFocus: true,

--- a/lib/view/widget/page_columns.dart
+++ b/lib/view/widget/page_columns.dart
@@ -1,0 +1,79 @@
+import 'package:fl_lib/fl_lib.dart';
+import 'package:flutter/material.dart';
+
+/// A readable, ordered grid for forms and card-based settings pages.
+///
+/// The default adaptive list can create many narrow columns on a wide desktop
+/// window. This grid uses wider columns, caps the layout at three columns, and
+/// keeps children in reading order across rows.
+class PageColumns extends StatelessWidget {
+  const PageColumns({super.key, required this.children});
+
+  final List<Widget> children;
+
+  static const columnWidth = UIs.columnWidth * 1.5;
+  static const _maxColumns = 3;
+  static const _spacing = 10.0;
+  static const _padding = MultiList.kOuterPadding;
+
+  static final maxWidth =
+      _maxColumns * columnWidth +
+      (_maxColumns - 1) * _spacing +
+      _padding.horizontal;
+
+  @visibleForTesting
+  static int columnsFor(double width) {
+    final available = width - _padding.horizontal;
+    if (available <= 0) return 1;
+    return ((available + _spacing) / (columnWidth + _spacing)).floor().clamp(
+      1,
+      _maxColumns,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxWidth: maxWidth),
+        child: SizedBox.expand(
+          child: LayoutBuilder(
+            builder: (_, constraints) {
+              final columns = columnsFor(constraints.maxWidth);
+              return SingleChildScrollView(
+                padding: _padding,
+                child: columns == 1
+                    ? Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        spacing: _spacing,
+                        children: children,
+                      )
+                    : Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        spacing: _spacing,
+                        children: [
+                          for (var column = 0; column < columns; column++)
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.stretch,
+                                spacing: _spacing,
+                                children: [
+                                  for (
+                                    var index = column;
+                                    index < children.length;
+                                    index += columns
+                                  )
+                                    children[index],
+                                ],
+                              ),
+                            ),
+                        ],
+                      ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/page_columns_test.dart
+++ b/test/page_columns_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:server_box/view/widget/page_columns.dart';
+
+void main() {
+  Future<void> pump(
+    WidgetTester tester, {
+    required double width,
+    required int count,
+  }) async {
+    await tester.binding.setSurfaceSize(Size(width, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: PageColumns(
+            children: [
+              for (var index = 0; index < count; index++)
+                SizedBox(
+                  key: ValueKey(index),
+                  height: 40,
+                  child: Text('$index'),
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Offset positionOf(WidgetTester tester, int index) =>
+      tester.getTopLeft(find.byKey(ValueKey(index)));
+
+  test('caps the calculated layout at three columns', () {
+    expect(PageColumns.columnsFor(400), 1);
+    expect(PageColumns.columnsFor(1400), 2);
+    expect(PageColumns.columnsFor(3000), 3);
+  });
+
+  testWidgets('lays out children in reading order', (tester) async {
+    await pump(tester, width: 1400, count: 4);
+
+    expect(positionOf(tester, 0).dx, lessThan(positionOf(tester, 1).dx));
+    expect(positionOf(tester, 2).dx, positionOf(tester, 0).dx);
+    expect(positionOf(tester, 3).dx, positionOf(tester, 1).dx);
+    expect(positionOf(tester, 2).dy, greaterThan(positionOf(tester, 0).dy));
+  });
+
+  testWidgets('uses one ordered column on narrow screens', (tester) async {
+    await pump(tester, width: 320, count: 3);
+
+    expect(positionOf(tester, 0).dx, positionOf(tester, 1).dx);
+    expect(positionOf(tester, 1).dy, greaterThan(positionOf(tester, 0).dy));
+    expect(positionOf(tester, 2).dy, greaterThan(positionOf(tester, 1).dy));
+  });
+}


### PR DESCRIPTION
## Summary

- add an ordered PageColumns layout with wider columns and a three-column cap
- keep form fields in natural reading order across rows
- apply it to container settings, private keys, and snippet editing
- retain a single ordered column on narrow screens

This extracts the reusable wide-screen layout improvement from #1234 without the two-pane architecture.

## Verification

- targeted dart analyze passed
- flutter test --no-pub test/page_columns_test.dart
- all three layout tests passed

<!-- winnowl:summary:begin -->
## Summary

### Changes

- **PageColumns responsive layout component**: Adds a reusable centered, width-capped adaptive column layout that switches between one column and up to three columns while distributing children in row reading order.
- **PageColumns layout and ordering tests**: Adds unit and widget coverage for column-count capping, multi-column reading order, and narrow-screen vertical ordering.
- **Container settings page adoption**: Replaces the settings tab's prior page-list arrangement with PageColumns for container host/provider settings and prune cards.
- **Private-key list and editor layout adoption**: Uses PageColumns for the private-key list and the private-key name/key/file/password form.
- **Snippet editor layout adoption**: Uses PageColumns for the snippet editor's name, note, tags, script, auto-run selection, and help content.
<!-- winnowl:summary:end -->