### PR TITLE
fix(ui): UI improvements

### DIFF
--- a/lib/view/page/server/edit/edit.dart
+++ b/lib/view/page/server/edit/edit.dart
@@ -141,7 +141,7 @@ class _ServerEditPageState extends ConsumerState<ServerEditPage>
 
   @override
   Widget build(BuildContext context) {
-    final actions = <Widget>[];
+    final actions = <Widget>[_buildWriteScriptTip()];
     if (spi != null) actions.add(_buildDelBtn());
 
     return Scaffold(
@@ -155,15 +155,7 @@ class _ServerEditPageState extends ConsumerState<ServerEditPage>
   }
 
   Widget _buildForm() {
-    final topItems = [_buildWriteScriptTip()];
     final children = [
-      SizedBox(
-        height: 50,
-        child: ListView(
-          scrollDirection: Axis.horizontal,
-          children: topItems.joinWith(UIs.width13).toList(),
-        ),
-      ),
       Input(
         autoFocus: true,
         controller: _nameController,

--- a/lib/view/page/server/edit/widget.dart
+++ b/lib/view/page/server/edit/widget.dart
@@ -516,18 +516,16 @@ extension _Widgets on _ServerEditPageState {
   }
 
   Widget _buildWriteScriptTip() {
-    return Btn.tile(
-      text: libL10n.attention,
-      icon: const Icon(Icons.tips_and_updates, color: Colors.grey),
-      onTap: () {
+    return IconButton(
+      tooltip: libL10n.attention,
+      onPressed: () {
         context.showRoundDialog(
           title: libL10n.attention,
           child: SimpleMarkdown(data: l10n.writeScriptTip),
           actions: Btnx.oks,
         );
       },
-      textStyle: UIs.textGrey,
-      mainAxisSize: MainAxisSize.min,
+      icon: const Icon(Icons.tips_and_updates),
     );
   }
 

--- a/lib/view/page/setting/entries/ai.dart
+++ b/lib/view/page/setting/entries/ai.dart
@@ -17,9 +17,10 @@ extension _AI on _AppSettingsPageState {
         subtitle: Text(
           displayBuilder(val),
           style: UIs.textGrey,
-          maxLines: 2,
+          maxLines: 1,
           overflow: TextOverflow.ellipsis,
         ),
+        trailing: const Icon(Icons.keyboard_arrow_right),
         onTap: () => _showAskAiFieldDialog(
           prop: prop,
           title: title,
@@ -33,48 +34,20 @@ extension _AI on _AppSettingsPageState {
 
   Widget _buildAskAiConfig() {
     final l10n = context.l10n;
-    return ExpandTile(
-      leading: const Icon(LineAwesome.robot_solid, size: _kIconSize),
-      title: TipText(l10n.askAi, l10n.askAiUsageHint),
+    return Column(
       children: [
-        _setting.askAiProtocol.listenable().listenVal((value) {
-          final selected = parseAskAiProtocol(value);
-          String label(AskAiProtocol protocol) => switch (protocol) {
-            AskAiProtocol.auto => l10n.askAiProtocolAuto,
-            AskAiProtocol.chatCompletions => l10n.askAiProtocolChatCompletions,
-            AskAiProtocol.responses => l10n.askAiProtocolResponses,
-          };
-          return PopupMenuButton<AskAiProtocol>(
-            initialValue: selected,
-            onSelected: (protocol) => _setting.askAiProtocol.put(protocol.name),
-            itemBuilder: (_) => [
-              for (final protocol in AskAiProtocol.values)
-                PopupMenuItem(value: protocol, child: Text(label(protocol))),
-            ],
-            child: ListTile(
-              leading: const Icon(Icons.swap_calls_outlined),
-              title: Text(l10n.askAiProtocol),
-              subtitle: Text(
-                '${label(selected)}\n${l10n.askAiProtocolTip}',
-                style: UIs.textGrey,
-              ),
-              isThreeLine: true,
-              trailing: const Icon(Icons.arrow_drop_down),
-            ),
-          );
-        }),
-        _setting.askAiAutoRunSafeCommands.listenable().listenVal((enabled) {
-          return SwitchListTile.adaptive(
-            secondary: const Icon(Icons.verified_user_outlined),
-            title: Text(l10n.askAiAutoRunSafeCommands),
-            subtitle: Text(l10n.askAiAutoRunSafeCommandsTip),
-            value: enabled,
-            onChanged: _setting.askAiAutoRunSafeCommands.put,
-          );
-        }),
+        _buildAskAiProtocol(l10n),
+        ListTile(
+          leading: const Icon(Icons.verified_user_outlined, size: _kIconSize),
+          title: TipText(
+            l10n.askAiAutoRunSafeCommands,
+            l10n.askAiAutoRunSafeCommandsTip,
+          ),
+          trailing: StoreSwitch(prop: _setting.askAiAutoRunSafeCommands),
+        ),
         _buildAskAiTextTile(
           prop: _setting.askAiBaseUrl,
-          leading: const Icon(MingCute.link_2_line),
+          leading: const Icon(MingCute.link_2_line, size: _kIconSize),
           title: l10n.askAiBaseUrl,
           hint: 'https://api.openai.com',
           description: l10n.askAiEndpointTip,
@@ -83,7 +56,7 @@ extension _AI on _AppSettingsPageState {
         ),
         _buildAskAiTextTile(
           prop: _setting.askAiModel,
-          leading: const Icon(Icons.view_module),
+          leading: const Icon(Icons.view_module, size: _kIconSize),
           title: libL10n.askAiModel,
           hint: 'gpt-5.4-mini',
           displayBuilder: (val) =>
@@ -91,7 +64,7 @@ extension _AI on _AppSettingsPageState {
         ),
         _buildAskAiTextTile(
           prop: _setting.askAiApiKey,
-          leading: const Icon(MingCute.key_2_line),
+          leading: const Icon(MingCute.key_2_line, size: _kIconSize),
           title: l10n.askAiApiKey,
           hint: 'sk-...',
           obscure: true,
@@ -99,8 +72,41 @@ extension _AI on _AppSettingsPageState {
               ? l10n.configured
               : l10n.askAiApiKeyOptional,
         ),
-      ],
-    ).cardx;
+      ].map((e) => CardX(child: e)).toList(),
+    );
+  }
+
+  Widget _buildAskAiProtocol(AppLocalizations l10n) {
+    String label(AskAiProtocol protocol) => switch (protocol) {
+      AskAiProtocol.auto => l10n.askAiProtocolAuto,
+      AskAiProtocol.chatCompletions => l10n.askAiProtocolChatCompletions,
+      AskAiProtocol.responses => l10n.askAiProtocolResponses,
+    };
+
+    return ListTile(
+      leading: const Icon(Icons.swap_calls_outlined, size: _kIconSize),
+      title: TipText(l10n.askAiProtocol, l10n.askAiProtocolTip),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ValBuilder(
+            listenable: _setting.askAiProtocol.listenable(),
+            builder: (val) =>
+                Text(label(parseAskAiProtocol(val)), style: UIs.text15),
+          ),
+          const Icon(Icons.keyboard_arrow_right),
+        ],
+      ),
+      onTap: () async {
+        final selected = await context.showPickSingleDialog(
+          title: l10n.askAiProtocol,
+          items: AskAiProtocol.values,
+          display: label,
+          initial: parseAskAiProtocol(_setting.askAiProtocol.fetch()),
+        );
+        if (selected != null) _setting.askAiProtocol.put(selected.name);
+      },
+    );
   }
 
   Future<void> _showAskAiFieldDialog({

--- a/lib/view/page/setting/entries/app.dart
+++ b/lib/view/page/setting/entries/app.dart
@@ -307,7 +307,10 @@ extension _App on _AppSettingsPageState {
         );
         if (selected != null) {
           _setting.locale.put(selected.code);
-          context.pop();
+          // No `pop`: the picker has already closed — that is what `await`
+          // returning a selection means — so popping here closed the settings
+          // page behind it. `notify` is what makes the new language take
+          // effect; nothing has to be dismissed for that.
           RNodes.app.notify();
         }
       },

--- a/lib/view/page/snippet/edit.dart
+++ b/lib/view/page/snippet/edit.dart
@@ -26,14 +26,29 @@ class SnippetEditPage extends ConsumerStatefulWidget {
   );
 }
 
-class _SnippetEditPageState extends ConsumerState<SnippetEditPage>
-    with AfterLayoutMixin {
+class _SnippetEditPageState extends ConsumerState<SnippetEditPage> {
   final _nameController = TextEditingController();
   final _scriptController = TextEditingController();
   final _noteController = TextEditingController();
   final _scriptNode = FocusNode();
   final _autoRunOn = ValueNotifier(<String>[]);
   final _tags = <String>{}.vn;
+
+  /// Filled here rather than after the first layout: the page is opened beside
+  /// the list, where its first frame is the one that animates in. Loading the
+  /// snippet a frame later meant that animation started on an empty form and
+  /// the fields appeared in the middle of it.
+  @override
+  void initState() {
+    super.initState();
+    final snippet = widget.args?.snippet;
+    if (snippet == null) return;
+    _nameController.text = snippet.name;
+    _scriptController.text = snippet.script;
+    if (snippet.note != null) _noteController.text = snippet.note!;
+    if (snippet.tags != null) _tags.value = snippet.tags!.toSet();
+    if (snippet.autoRunOn != null) _autoRunOn.value = snippet.autoRunOn!;
+  }
 
   @override
   void dispose() {
@@ -231,25 +246,5 @@ ${libL10n.example}:
         ),
       ),
     );
-  }
-
-  @override
-  void afterFirstLayout(BuildContext context) {
-    final snippet = widget.args?.snippet;
-    if (snippet != null) {
-      _nameController.text = snippet.name;
-      _scriptController.text = snippet.script;
-      if (snippet.note != null) {
-        _noteController.text = snippet.note!;
-      }
-
-      if (snippet.tags != null) {
-        _tags.value = snippet.tags!.toSet();
-      }
-
-      if (snippet.autoRunOn != null) {
-        _autoRunOn.value = snippet.autoRunOn!;
-      }
-    }
   }
 }


### PR DESCRIPTION
## Summary

- prevent selecting a language from closing the settings page
- populate existing snippets before the editor's first frame
- align AI settings with the rest of the settings UI and show a protocol-selection affordance
- move the server edit guide from the form body to the app bar

## Verification

- `flutter analyze lib/view/page/setting/entries/app.dart lib/view/page/snippet/edit.dart lib/view/page/setting/entries/ai.dart lib/view/page/server/edit/edit.dart lib/view/page/server/edit/widget.dart`
- `flutter test test/app_locale_test.dart test/server_edit_logic_test.dart`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a write-script tip button to the app bar with a tooltip and existing guidance dialog.
  * Redesigned Ask AI settings with card-based options, protocol selection, and safe-command auto-run controls.
* **Bug Fixes**
  * Language changes now apply without unexpectedly leaving the settings page.
  * Snippet editor fields now load correctly before the editor is displayed.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->