### PR TITLE
chore(deps): commit the rust-deps lock, scope dependabot to the workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,14 @@
 version: 2
 updates:
-  # Rust workspace (monitor + shared crates + FFI)
+  # Rust workspace (monitor + shared crates + FFI).
+  #
+  # The workspace root, not the member directories: Cargo.lock lives here and
+  # nowhere else, so a run scoped to a member can only widen that member's
+  # manifest and leaves the lock pinning the old version. It also covers every
+  # member without listing them — sbm_native was a member for months that no
+  # listing here ever named.
   - package-ecosystem: cargo
-    directories:
-      - "/monitor"
-      - "/crates/sbm_parser"
-      - "/crates/sbm_ffi"
+    directory: "/"
     schedule:
       interval: weekly
     groups:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,7 +315,7 @@ version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f3c067aa24dd4ed5c79cf222a38f260c8f23d3b82a062fba3f28c6fe563b753"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "blowfish",
  "getrandom 0.4.3",
  "subtle",
@@ -1535,18 +1541,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -1554,7 +1548,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
  "rand_core 0.10.1",
  "wasm-bindgen",
 ]
@@ -1817,7 +1811,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2083,11 +2077,11 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.4.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+checksum = "881733cbc631fc9e472e24447ce32a64bedf2da498d6d8570b08edc87de71f65"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "ed25519-dalek 2.2.0",
  "getrandom 0.2.17",
  "hmac 0.12.1",
@@ -2342,7 +2336,7 @@ version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf010b0d2654465c75355a21295e6c9a66cf83719d324fccf8af1e0c941ab023"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "derive_more",
  "encoding_rs",
@@ -3251,12 +3245,6 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -3361,7 +3349,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3431,9 +3419,12 @@ dependencies = [
 
 [[package]]
 name = "roxmltree"
-version = "0.20.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
+checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "rpassword"
@@ -3763,7 +3754,7 @@ dependencies = [
 name = "sbm_parser"
 version = "0.1.0"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "dotenvy",
  "regex",
  "roxmltree",
@@ -3963,7 +3954,7 @@ dependencies = [
  "clap",
  "dotenvy",
  "futures",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "hostname",
  "jsonwebtoken",
  "libc",
@@ -4229,7 +4220,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "cfg-if",
  "chrono",
@@ -4333,7 +4324,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.13.1",
  "byteorder",
  "chrono",
@@ -5024,15 +5015,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5451,12 +5433,6 @@ checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wnaf"


### PR DESCRIPTION
Follow-up to #1297.

#1297 widened four requirements without touching `Cargo.lock`, which still pinned `roxmltree 0.20.0` / `base64 0.22.1` / `jsonwebtoken 10.4.0`. Nothing in CI or the Dockerfile passes `--locked`, so it stayed green — the cost is that the next `cargo build` rewrites the lock as an unrelated diff, and which versions a release binary is built from is not decided by the commit that bumped them.

Root cause is the dependabot config: the cargo entry listed member directories (`/monitor`, `/crates/sbm_parser`, `/crates/sbm_ffi`) and `Cargo.lock` lives at the workspace root and nowhere else. Scoped to a member, dependabot can only rewrite that member's manifest. The same listing had also never named `crates/sbm_native`, a workspace member since it was added, so its dependencies were never updated.

`directory: "/"` fixes both — the lock moves with the manifests, and every member is covered without being enumerated.

Lock diff is minimal: `+base64 0.23.1`, `roxmltree 0.20.0 → 0.21.1`, `jsonwebtoken 10.4.0 → 11.0.0`, and `getrandom 0.3.4` drops out onto the 0.4.3 already present (taking `r-efi`, `wasip2` and `wit-bindgen` with it).

Verified locally: `cargo test --workspace` passes, including the two suites that lock the behaviour these crates back — `script_compat` (31, base64 `-EncodedCommand` generation) and `dart_compat` (76, parsing). `ssh_e2e` is the opt-in remote suite and is unrelated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated project maintenance coverage across the full workspace.
  * Centralized monitoring to ensure shared project configuration is handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- winnowl:summary:begin -->
## Summary

### Changes

- **Cargo workspace dependency update configuration**: Dependabot is configured to scan the repository-root Cargo workspace weekly and group all Rust dependency updates.
- **Monitor frontend npm dependency update configuration**: Dependabot is configured to scan monitor/frontend weekly and group all npm dependency updates.
- **GitHub Actions dependency update configuration**: Dependabot is configured to scan GitHub Actions references from the repository root weekly.
- **Dependabot configuration as a whole**: The change establishes weekly dependency monitoring for Rust, the monitor frontend, and GitHub Actions in one repository configuration.
<!-- winnowl:summary:end -->