### PR TITLE
chore(deps): bump the four workflow actions together, and group them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,15 @@ updates:
         patterns:
           - "*"
 
+  # Grouped like the other two: the actions in a workflow are bumped for one
+  # reason at a time (a runner's Node version, most of them), and a review that
+  # sees them together is the one that can tell. Ungrouped, a single week's run
+  # opened four PRs against the same two files.
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -281,7 +281,7 @@ jobs:
           rm -f app-*-release.apk
       - name: Upload artifacts
         if: inputs.release != true && github.ref_type != 'tag'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.APP_NAME }}-${{ env.BUILD_TAG }}-android
           path: build/app/outputs/flutter-apk/*.apk
@@ -289,7 +289,7 @@ jobs:
           retention-days: 14
       - name: Create Release
         if: inputs.release == true || github.ref_type == 'tag'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v1.0.${{ env.BUILD_NUMBER }}
           files: |
@@ -338,7 +338,7 @@ jobs:
         run: APP_ASSET_NAME="${APP_NAME}" scripts/release/package-unsigned-ipa.sh
       - name: Upload artifacts
         if: inputs.release != true && github.ref_type != 'tag'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.APP_NAME }}-${{ env.BUILD_TAG }}-ios
           path: build/artifacts/*.ipa
@@ -346,7 +346,7 @@ jobs:
           retention-days: 14
       - name: Create Release
         if: inputs.release == true || github.ref_type == 'tag'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v1.0.${{ env.BUILD_NUMBER }}
           files: |
@@ -406,7 +406,7 @@ jobs:
           mv "${APP_NAME}_v1.0.${BUILD_NUMBER}_amd64.AppImage" "${APP_NAME}_v1.0.${BUILD_NUMBER}${{ matrix.release_suffix }}_amd64.AppImage"
       - name: Upload artifacts
         if: inputs.release != true && github.ref_type != 'tag'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.APP_NAME }}-${{ env.BUILD_TAG }}-linux${{ matrix.artifact_suffix }}
           path: "*.AppImage"
@@ -414,7 +414,7 @@ jobs:
           retention-days: 14
       - name: Create Release
         if: inputs.release == true || github.ref_type == 'tag'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v1.0.${{ env.BUILD_NUMBER }}
           files: |
@@ -454,7 +454,7 @@ jobs:
           done
       - name: Upload artifacts
         if: inputs.release != true && github.ref_type != 'tag'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.APP_NAME }}-${{ env.BUILD_TAG }}-windows
           path: "*_windows_amd64.zip"
@@ -462,7 +462,7 @@ jobs:
           retention-days: 14
       - name: Create Release
         if: inputs.release == true || github.ref_type == 'tag'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v1.0.${{ env.BUILD_NUMBER }}
           files: |

--- a/.github/workflows/monitor-release.yml
+++ b/.github/workflows/monitor-release.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           cache: npm
@@ -86,7 +86,7 @@ jobs:
           npm run build
 
       - name: Upload dist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: monitor-frontend-dist
           path: monitor/frontend/dist
@@ -177,7 +177,7 @@ jobs:
           fi
 
       - name: Upload package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: monitor-pkg-${{ matrix.platform }}-${{ matrix.arch }}
           path: |
@@ -189,7 +189,7 @@ jobs:
       # The Linux musl binary is reused in the Docker image, avoiding a second build
       - name: Upload raw bin for Docker
         if: matrix.platform == 'linux'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: monitor-bin-linux-${{ matrix.arch }}
           path: target/${{ matrix.target }}/release/server_box_monitor
@@ -246,7 +246,7 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # COPY prebuilt artifacts only; multi-arch images without QEMU
       - name: Build and push
@@ -283,7 +283,7 @@ jobs:
         run: sha256sum *.tar.gz *.zip > SHA256SUMS
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.meta.outputs.tag }}
           name: Monitor ${{ needs.meta.outputs.tag }}


### PR DESCRIPTION
Supersedes #1300, #1301, #1302, #1303. One review over the two files all four touch — and the four bumps are one change: every one of these majors is its action moving to the Node 24 runtime.

| Action | | 用到的输入 | 该 major 的破坏性变更 |
| --- | --- | --- | --- |
| `actions/upload-artifact` | v4 → v7 | `name` `path` `if-no-files-found` `retention-days` | v5/v6 Node 24,v7 转 ESM + 新增 `archive`;没有移除输入 |
| `softprops/action-gh-release` | v2 → v3 | `tag_name` `name` `files` | 只有 Node 20 → 24 |
| `docker/setup-buildx-action` | v3 → v4 | 无 | Node 24,并移除了已废弃的输入和输出 |
| `actions/setup-node` | v4 → v7 | `node-version` `cache` `cache-dependency-path` | v5 自动缓存 + Node 24,v6 把自动缓存收窄到 npm,v7 转 ESM |

对本仓库的影响逐条核对过:

- setup-node v6 收窄的是**自动**缓存,这里显式写了 `cache: npm`,不经过那条路径。
- setup-buildx-action v4 移除的输入/输出,这里的 step 一个输入都没传,也没有 `id:`,没有任何地方读它的 output。
- 所有 runner 都是 GitHub 托管的(`ubuntu-22.04` / `ubuntu-24.04-arm` / `ubuntu-latest` / `macos-latest` / `windows-latest`),Node 24 那几个 release 要求的 runner ≥ 2.327.1 早已满足。没有 self-hosted。
- `actionlint` 对这两个文件只报了改动前就存在的 shellcheck info(SC2231 / SC2035),`uses:` 和输入没有问题。

顺带修好一处配错的搭配:`download-artifact` 在 #1292 升到了 v8,而 `upload-artifact` 留在 v4。v8 是为 v7 的直传格式做的那一半——它按 `Content-Type` 决定是否解压,而不再一律解压。

最后把 `github-actions` 这条 dependabot 配置也加上了 `groups`,和 cargo、npm 一致,这样像这周这样的一批更新会以一个 PR 出现,而不是四个。

这两个 workflow 都只在 tag 上跑,PR 上不会执行,所以这里只有静态核对,没有绿灯可以指。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated build and release workflows across supported platforms.
  * Improved artifact uploads and release publishing with refreshed automation tooling.
  * Consolidated weekly automation dependency updates for simpler maintenance.
  * Updated release monitoring workflows to use current tooling versions for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->