### PR TITLE
ci: skip untouched jobs, and fix the Cloudflare build of the site

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -13,11 +13,76 @@ on:
 
 permissions:
   contents: read
+  # For the `changes` job's file list. Read-only, and only for this repo.
+  pull-requests: read
 
 env:
   FLUTTER_VERSION: '3.47.0'
 
 jobs:
+  # Which of the expensive jobs this diff can actually affect.
+  #
+  # The two that cost real time are `iOS Linux engine` (~9 min: brews an LLVM
+  # toolchain, builds the guest engine, then builds the app twice) and `Rust
+  # tests (windows-latest)` (~7-9 min, most of it a cold compile). A docs-only
+  # or Dart-only PR paid both for nothing.
+  #
+  # Asks GitHub for the PR's own file list rather than diffing refs: no
+  # checkout, no fetch depth to get wrong, and no merge-base to compute against
+  # a base branch that may have moved since. On a push to main it answers
+  # "everything" — that is the ref releases are cut from, and narrowing what
+  # runs there trades away the wrong thing.
+  changes:
+    name: What changed
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      ish: ${{ steps.filter.outputs.ish }}
+      dart: ${{ steps.filter.outputs.dart }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - id: filter
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" != 'pull_request' ]]; then
+            printf 'rust=true\nish=true\ndart=true\n' >> "$GITHUB_OUTPUT"
+            echo "not a pull request: running everything"
+            exit 0
+          fi
+
+          files="$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename')"
+          echo "changed files:"
+          echo "$files"
+
+          emit() {
+            if grep -qE "$2" <<< "$files"; then
+              echo "$1=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "$1=false" >> "$GITHUB_OUTPUT"
+              echo "::notice::skipping the $1 jobs: nothing they cover changed"
+            fi
+          }
+
+          # Patterns are grep -E against whole paths. A change to this workflow
+          # turns everything on — the filters are the thing under test then —
+          # and `packages/` are the submodules the app is built from, so a
+          # gitlink move there is a source change to all of it.
+          shared='^\.github/workflows/analysis\.yml$|^pubspec\.(yaml|lock)$|^packages/'
+
+          emit rust "$shared|^crates/|^monitor/|^Cargo\.(toml|lock)$"
+          # The engine, the scripts that build and check it, and everything the
+          # iOS app links: this is the only job that compiles either the engine
+          # or `flutter build ios` at all
+          emit ish "$shared|^third_party/|^scripts/(build-ish-ios|check-ish-linkage)\.sh$|^ios/|^crates/sbm_ffi/"
+          # `crates/` because `flutter test` loads the FFI dylib and the
+          # generated bindings come from there
+          emit dart "$shared|^lib/|^test/|^integration_test/|^crates/|^Cargo\.(toml|lock)$|^analysis_options\.yaml$"
+
   reproducibilityCheck:
     name: Reproducibility check
     runs-on: ubuntu-latest
@@ -57,6 +122,8 @@ jobs:
 
   rustTests:
     name: Rust tests (${{ matrix.os }})
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -86,6 +153,8 @@ jobs:
   # strip turned out to pass on a binary that still had the engine in it.
   ishEngine:
     name: iOS Linux engine
+    needs: changes
+    if: needs.changes.outputs.ish == 'true'
     runs-on: macos-latest
 
     steps:
@@ -133,6 +202,8 @@ jobs:
           scripts/check-ish-linkage.sh build/ios/iphoneos/Runner.app/Runner off
 
   check:
+    needs: changes
+    if: needs.changes.outputs.dart == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/website/package.json
+++ b/website/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "dev": "vite",
     "typesafe-i18n": "typesafe-i18n --no-watch",
+    "_comment_prebuild": "@serverbox/webui is a file: dependency, so an install here only symlinks it — webui's own dependencies (clsx, tailwind-merge, tailwind-variants) are never fetched, and vite bundles from its source. Without them the build dies on `Rolldown failed to resolve import \"clsx\" from packages/webui/src/utils.ts`, which is what Cloudflare Pages hit: it builds from a clean clone, where nothing has installed them already. npm, not bun, because packages/webui is what carries the lockfile. Same prebuild as monitor/frontend, for the same reason.",
+    "prebuild": "npm install --prefix ../packages/webui",
     "build": "bun run typesafe-i18n && vite build",
     "preview": "vite preview"
   },


### PR DESCRIPTION
每个 PR 都要付两笔时间:`iOS Linux engine` 约 9 分钟(brew 装 LLVM 工具链、编译 guest engine、再把 iOS app 编两遍)和 `Rust tests (windows-latest)` 约 7–9 分钟(大部分是冷编译)。只改文档的 PR 也一样付。

新增一个 `changes` job,向 GitHub 要这个 PR 自己的文件列表,再用它 gate 三个构建 job。

用文件列表而不是 diff 两个 ref:不用 checkout、没有 fetch depth 可以搞错、也不用对一个可能已经前进了的 base 分支算 merge-base。

| job | 触发条件 |
| --- | --- |
| `Rust tests` (ubuntu + windows) | `crates/` `monitor/` `Cargo.toml` `Cargo.lock` |
| `iOS Linux engine` | `third_party/` `ios/` `crates/sbm_ffi/` `scripts/build-ish-ios.sh` `scripts/check-ish-linkage.sh` |
| `check`(analyze + flutter test) | `lib/` `test/` `integration_test/` `crates/` `Cargo.*` `analysis_options.yaml` |

三者都额外包含 `pubspec.yaml`/`pubspec.lock`、`packages/`(submodule 的 gitlink 一动就是源码变更),以及这个 workflow 文件本身——改到它的时候,被测的正是这些过滤条件。

**push 到 main 时一律全跑。** 那是发版所依据的 ref,在那里省时间省错了地方。

`Reproducibility check` 保持无条件运行(1m44s),这样任何 PR 至少有一个会报告的 check。

## 验证

把过滤逻辑对着真实文件列表跑过:

| 输入 | rust / ish / dart |
| --- | --- |
| 只改 docs + README + TODOS.md | false / false / false |
| 只改 `lib/` | false / false / true |
| 只改 `monitor/src/` | true / false / false |
| 只改 `Cargo.lock` | true / false / true |
| 只动 `third_party/ish-arm64` gitlink | false / true / false |
| #1309 的完整列表(含 `crates/`) | true / true / true |
| 只改这个 workflow | true / true / true |

`actionlint` 干净。

main 的 ruleset 不要求任何 status check(只要求 1 个 approving review),所以被跳过的 job 不会挡住合并。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated validation workflows by detecting which areas are affected by each change.
  * Relevant platform and language checks now run selectively, reducing unnecessary build and test activity.
  * Changes outside supported areas continue to receive appropriate default validation coverage.
* **Bug Fixes**
  * Website builds now automatically install required web interface dependencies before building, improving clean-build reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->