### PR TITLE
Fix native asset packaging on Windows

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -81,6 +81,12 @@ if(PLUGIN_BUNDLED_LIBRARIES)
     COMPONENT Runtime)
 endif()
 
+# Copy the native assets provided by build hooks next to the executable.
+set(NATIVE_ASSETS_DIR "${PROJECT_BUILD_DIR}native_assets/windows/")
+install(DIRECTORY "${NATIVE_ASSETS_DIR}"
+  DESTINATION "${INSTALL_BUNDLE_LIB_DIR}"
+  COMPONENT Runtime)
+
 # Fully re-copy the assets directory on each build to avoid having stale files
 # from a previous install.
 set(FLUTTER_ASSET_DIR_NAME "flutter_assets")


### PR DESCRIPTION
## Summary
- install native assets emitted by Dart build hooks beside the Windows executable
- update flutter_pty to skip hook phases that do not build code assets

## Problem
Windows builds generated the native asset manifest but did not copy its DLLs to the runner output directory. This caused RustLib.init() to fail to load sbm_ffi.dll before runApp, leaving a process running without an application window.

## Testing
- flutter run -d windows
- verified the runner output contains sbm_ffi.dll, flutter_pty.dll, and sqlite3mc.dll
- verified the app reaches normal startup without the native-library load error
- flutter analyze lib/main.dart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Windows installations now include required native assets automatically, improving runtime reliability.
  - Updated the embedded terminal component to incorporate the latest fixes and enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->