### PR TITLE
docs: document submodule initialization

### DIFF
--- a/docs/src/content/docs/development/building.md
+++ b/docs/src/content/docs/development/building.md
@@ -12,6 +12,12 @@ Server Box uses a custom build system (`fl_build`) for cross-platform builds.
 - Rust toolchain (required: the status parser is a Rust crate built into the app
   via flutter_rust_bridge/cargokit on every platform)
 
+Initialize the bundled Git submodules before fetching Dart dependencies:
+
+```bash
+git submodule update --init --recursive
+```
+
 ## Development Build
 
 ```bash

--- a/docs/src/content/docs/zh/development/building.md
+++ b/docs/src/content/docs/zh/development/building.md
@@ -11,6 +11,12 @@ Server Box 使用自定义构建系统 (`fl_build`) 进行跨平台构建。
 - 平台特定工具 (iOS 需要 Xcode，Android 需要 Android Studio)
 - Rust 工具链（必需：状态解析库是 Rust crate,经 flutter_rust_bridge/cargokit 构建进各平台的 App）
 
+获取 Dart 依赖前，请先初始化项目内置的 Git 子模块：
+
+```bash
+git submodule update --init --recursive
+```
+
 ## 开发版构建
 
 ```bash


### PR DESCRIPTION
## Summary

- document Git submodule initialization before fetching Dart dependencies
- keep the English and Chinese build guides in sync

## Validation

- `git diff --check`

Closes #1326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added build instructions to initialize and recursively update bundled Git submodules before fetching Dart dependencies.
  * Updated the same guidance in the Chinese development documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->