### PR TITLE
fix(monitor): collect on NixOS, a NixOS module, and an onboarding skill

### DIFF
--- a/.claude/skills/serverbox-onboarding/SKILL.md
+++ b/.claude/skills/serverbox-onboarding/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: serverbox-onboarding
+description: Orientation for ServerBox (flutter_server_box) — installing and using the app, deploying and configuring the ServerBox Monitor agent on a server, bootstrapping the Flutter + Rust + Node development environment, and explaining how the project actually works (SSH vs monitor HTTP, the shared Rust parser, SQLite storage, Riverpod state). Use this whenever someone asks how to install, set up, run, build, deploy, configure, contribute to, or understand any part of ServerBox or its monitor agent — including questions that never name the project outright, such as "how do I get this repo running", "pub get fails after cloning", "why is the terminal button missing on this server", "what does full_access actually grant", "where does the status data come from", or a first-time contributor asking where to start.
+---
+
+# ServerBox onboarding
+
+ServerBox is a Flutter app (iOS, Android, macOS, Linux, Windows, watchOS) for
+managing Linux, BSD and Windows servers: status charts, SSH terminal, SFTP,
+containers, processes, systemd. The repository is a monorepo:
+
+| Path | What it is |
+|---|---|
+| `lib/` | The Flutter app |
+| `crates/sbm_parser` | Shared status parser — one source of truth for the command manifest and the parsing, used by the app over FFI and by the monitor |
+| `crates/sbm_ffi` | flutter_rust_bridge binding crate, built into the app by `hook/build.dart` |
+| `crates/sbm_native` | Native per-platform sampler, monitor only |
+| `monitor/` | ServerBox Monitor: a Rust agent installed on a server, plus its Svelte panel |
+| `packages/` | Vendored Dart forks, each a submodule, referenced by path from `pubspec.yaml` |
+| `docs/` | The documentation site (Astro Starlight), English with a `zh/` mirror |
+
+A server is reached over **SSH or through a monitor agent's HTTP API, never
+both**. That single fact explains most "why can't I do X on this server"
+questions — see `references/principles.md`.
+
+## Work out which question this is first
+
+People arrive at this project from two directions, and the answers barely
+overlap. Read the one reference that matches, not all of them.
+
+| The person wants to | Read |
+|---|---|
+| Install the app and connect it to a server | `references/app-usage.md` |
+| Install, configure or secure the monitor agent on a server | `references/monitor-deploy.md` |
+| Build and run the project from source, or contribute | `references/dev-setup.md` |
+| Understand how something works, or why it was built that way | `references/principles.md` |
+
+Mixed asks are common and the wording rarely says which is which. "The
+terminal button disappeared" is the agent's capability model
+(`monitor-deploy.md`), not a bug. "`flutter pub get` fails right after
+cloning" is almost always uninitialised submodules (`dev-setup.md`). When it is
+genuinely ambiguous, ask whether they are running ServerBox or working on it.
+
+## The repository outranks this skill
+
+Versions, ports and command names drift; a skill file that quietly disagrees
+with the repo is worse than no skill. Inside a checkout, prefer these:
+
+| Question | Authoritative file |
+|---|---|
+| What commands exist | `make help` (the `Makefile`) |
+| Flutter / Dart minimum | `environment:` in `pubspec.yaml` |
+| Rust channel and shipped targets | `crates/sbm_ffi/rust-toolchain.toml` |
+| Node version | `monitor/frontend/.node-version` |
+| Every agent config key | `monitor/config.example.toml` |
+| Contribution rules and checks | `CONTRIBUTING.md` |
+| Working rules for agents | `CLAUDE.md`, `monitor/CLAUDE.md` |
+| User-facing documentation | `docs/src/content/docs/**` |
+
+Outside a checkout the reference files here are the fallback. Say so when you
+are answering from them — the numbers below were true when this was written and
+nothing keeps them current.
+
+`scripts/check-env.sh` reports what is installed against what the repo asks
+for, and changes nothing. Run it before diagnosing a build failure by hand;
+most first-run failures are one of the four things it checks.
+
+## The commands that cover most of it
+
+```sh
+make deps        # flutter pub get
+make run         # flutter run
+make gen         # build_runner + gen-l10n — after touching any annotated model
+make analyze     # flutter analyze lib test integration_test
+make test        # flutter test
+cargo test --workspace          # parser, native sampler, FFI, monitor
+make monitor-dev                # agent API on :3770 + panel dev server on :3000
+make build PLATFORM=<android|ios|macos|linux|windows>
+```
+
+Values as of writing: Flutter >= 3.44.9, Dart SDK >= 3.11.0, Rust pinned to
+1.97.1 for the FFI crate, Node 24 for the monitor panel and the docs site.
+
+## What costs people an afternoon
+
+Each of these has bitten someone. The reason matters more than the fix, because
+the symptom rarely names the cause.
+
+- **Initialise submodules before fetching Dart dependencies.** `packages/*` are
+  path dependencies, so `flutter pub get` fails on a missing directory rather
+  than on anything that mentions submodules:
+  `git submodule update --init --recursive`.
+- **Rust is not optional, even for `flutter run`.** `hook/build.dart` compiles
+  `crates/sbm_ffi` into every app build as a code asset. No Rust toolchain, no
+  app.
+- **`flutter_rust_bridge` is pinned to the same prerelease in two files** —
+  `pubspec.yaml` and `crates/sbm_ffi/Cargo.toml`. When they disagree,
+  `RustLib.init` throws at startup and the message does not mention versions.
+- **Regenerate after changing an annotated model** (`freezed`,
+  `json_serializable`, `riverpod`, hive): `make gen`. Never hand-edit
+  `*.g.dart`, `*.freezed.dart` or anything under `lib/src/rust/`.
+- **Never run a formatter.** The formatting in this codebase is deliberate, and
+  a reformat buries the actual change in noise.
+- **Do not start a second `flutter run`** when the user already has the app
+  running from their IDE. Two debug builds compete for the same window and you
+  end up inspecting an instance nobody is looking at. Hot reload through the
+  dart MCP server instead (`CLAUDE.md` has the sequence).
+- **`flutter clean` deletes the out-of-tree iSH engine build** and leaves a
+  checkout that looks fine, so the next iOS build dies in the linker on three
+  missing `.a` files. Only affects a checkout that turned `SBM_ISH` on.
+
+## Answering "how does X work"
+
+The deep explanations already exist in `docs/src/content/docs/principles/`
+(architecture, ssh, sftp, terminal, state) — 250 to 400 lines each, and worth
+reading rather than paraphrasing from memory. `references/principles.md` is the
+map: what each one answers, plus the handful of design decisions that explain
+the most behaviour, so you can route in one step instead of grepping.
+
+When the answer is about code rather than design, read the code. The docs
+describe intent; `lib/data/provider/`, `lib/data/store/` and
+`monitor/src/api/` are what actually runs.
+
+## Reference files
+
+| File | Covers |
+|---|---|
+| `references/dev-setup.md` | Toolchain bootstrap, the run/test/build loop, monitor development, and a symptom-to-cause table for first-run failures |
+| `references/monitor-deploy.md` | Installing the agent, `config.toml`, the security switches and what each one really grants, connecting the app, troubleshooting |
+| `references/app-usage.md` | Where to download the app per platform, adding a server over SSH or through an agent, what each feature needs, where the advanced guides are |
+| `references/principles.md` | How the app is put together and which document answers which question |
+| `scripts/check-env.sh` | Read-only environment check: toolchain versions, submodules, dependency state, FFI version parity |

--- a/.claude/skills/serverbox-onboarding/references/app-usage.md
+++ b/.claude/skills/serverbox-onboarding/references/app-usage.md
@@ -41,10 +41,16 @@ depends on what the agent's operator enabled.
 |---|---|---|
 | Status, charts | yes | yes, plus stored history |
 | Terminal | yes | `full_access` **and** `[remote_access.terminal] enabled` **and** secure transport |
-| Commands, processes, systemd, containers, snippets, power | yes | the same three |
+| Commands, processes, systemd, containers, snippets, power | yes | `full_access` **and** secure transport |
 | File browsing | SFTP | `[remote_access.fs]` with `roots` set |
 | SFTP transfers, port forwarding | yes | never — add the same machine over SSH as a second server |
 | Push alerts, home widgets, watch app | not available | yes |
+
+Those are two different gates, not one. The terminal is a websocket
+(`/api/v1/terminal/ws`) and is the only thing `[remote_access.terminal]`
+governs; everything else goes through `POST /api/v1/exec`, which asks for
+`full_access` and nothing more. So an agent with `full_access` on and the
+terminal switch off runs commands and refuses shells.
 
 A button that is not on screen usually means the agent said it would refuse —
 the app does not show controls that would answer 403. `monitor-deploy.md`

--- a/.claude/skills/serverbox-onboarding/references/app-usage.md
+++ b/.claude/skills/serverbox-onboarding/references/app-usage.md
@@ -1,0 +1,75 @@
+# Installing and using the app
+
+For someone who wants to run ServerBox, not build it. Deploying the agent is
+`monitor-deploy.md`; building from source is `dev-setup.md`.
+
+The user documentation is `docs/src/content/docs/` (`installation.mdx`,
+`quick-start.mdx`, `advanced/*`), published as the project's docs site, with a
+`zh/` mirror of everything.
+
+## Where to download
+
+| Platform | Sources |
+|---|---|
+| iOS | App Store; or the unsigned `_NoSign.ipa` from GitHub Releases, which you sign yourself |
+| macOS | App Store, `brew install --cask server-box`, or the `.dmg` from GitHub Releases |
+| Android | GitHub Releases, the CDN mirror, F-Droid (`tech.lolli.toolbox`), OpenAPK |
+| Linux | AppImage from GitHub Releases or the CDN |
+| Windows | zip from GitHub Releases or the CDN |
+| watchOS | Part of the iOS app |
+
+App Store link: <https://apps.apple.com/app/id1586449703>. Releases:
+<https://github.com/lollipopkit/flutter_server_box/releases>.
+
+## Adding a server
+
+The selector at the top of the add-server form chooses the connection method,
+and a server is one or the other, never both.
+
+**SSH** — name, host, port (22), user, and a password or a private key. This is
+the default and the one to use unless something makes it impossible.
+
+**Monitor HTTP** — the agent's URL (`https://1.2.3.4:3770`), its panel user and
+password, and **Monitor Ignore certificate** for a self-signed certificate. The
+server then carries no SSH credentials at all. Status and charts work
+immediately, with history from before the app ever connected; everything else
+depends on what the agent's operator enabled.
+
+## What each feature needs
+
+| Feature | Over SSH | Through an agent |
+|---|---|---|
+| Status, charts | yes | yes, plus stored history |
+| Terminal | yes | `full_access` **and** `[remote_access.terminal] enabled` **and** secure transport |
+| Commands, processes, systemd, containers, snippets, power | yes | the same three |
+| File browsing | SFTP | `[remote_access.fs]` with `roots` set |
+| SFTP transfers, port forwarding | yes | never — add the same machine over SSH as a second server |
+| Push alerts, home widgets, watch app | not available | yes |
+
+A button that is not on screen usually means the agent said it would refuse —
+the app does not show controls that would answer 403. `monitor-deploy.md`
+covers which switch turns which one on.
+
+## The guides worth knowing about
+
+Each is a file under `docs/src/content/docs/advanced/` (and `zh/advanced/`):
+
+| Topic | File | What it is for |
+|---|---|---|
+| Monitor agent | `monitor-agent.md` | The agent, end to end, from a user's side |
+| Home screen widgets | `widgets.md` | iOS, Android and watchOS widgets; needs an agent |
+| Agent (the assistant) | `agent.md` | Diagnosing or operating a server through an LLM, with the approval model |
+| Terminal on this device | `local-terminal.md` | A local shell, and the bundled Alpine userland |
+| Bulk import | `bulk-import.md` | The JSON format for adding many servers at once |
+| Custom commands | `custom-commands.md` | Extra status commands, stored in `~/.config/server_box/custom_cmds` on the server |
+| Custom server logo | `custom-logo.md` | URL placeholders, distribution matching |
+| Hidden settings | `json-settings.md` | The raw settings editor, and how to recover from a bad edit |
+| Common issues | `troubleshooting.md` | Connection, input, widget and performance problems |
+
+## Reporting a problem
+
+The wiki collects the recurring ones:
+<https://github.com/lollipopkit/flutter_server_box/wiki>. An issue should carry
+the **entire log** — the button is at the top right of the home page — and
+should establish that the app is what is failing. Subjective requests may be
+declined; anything with a concrete argument is open to discussion.

--- a/.claude/skills/serverbox-onboarding/references/dev-setup.md
+++ b/.claude/skills/serverbox-onboarding/references/dev-setup.md
@@ -56,9 +56,15 @@ flutter_rust_bridge version parity — without changing anything.
 make run                    # or run from the IDE
 make gen                    # after touching @freezed / @JsonSerializable / @riverpod / ARB
 make analyze                # flutter analyze lib test integration_test
+cargo build -p sbm_ffi      # before `make test`: one suite loads this dylib
 make test                   # flutter test
 cargo test --workspace      # sbm_parser, sbm_native, sbm_ffi, monitor
 ```
+
+`cargo build -p sbm_ffi` is not optional before `flutter test`, and it is not
+skipped when missing: `test/frb_parser_test.dart` throws
+`sbm_ffi native library not found` and the suite fails. CI builds it between
+analyzing and testing for the same reason.
 
 `make gen` is `build_runner build --delete-conflicting-outputs` followed by
 `flutter gen-l10n`. New user-facing strings go into `lib/l10n/app_en.arb`
@@ -168,6 +174,7 @@ make build PLATFORM=<android|ios|macos|linux|windows>   # dart run fl_build -p .
 
 ```sh
 make analyze
+cargo build -p sbm_ffi
 make test
 cargo test --workspace
 cd monitor/frontend && npm run test && npm run check   # only if you touched the panel

--- a/.claude/skills/serverbox-onboarding/references/dev-setup.md
+++ b/.claude/skills/serverbox-onboarding/references/dev-setup.md
@@ -1,0 +1,187 @@
+# Development setup
+
+For building and running ServerBox from source. The user-facing install is
+`app-usage.md`; deploying the agent on a server is `monitor-deploy.md`.
+
+`CONTRIBUTING.md` is the short authoritative version of this file, and
+`docs/src/content/docs/development/` (`building`, `codegen`, `testing`,
+`structure`, `architecture`, `state`) is the long one. Prefer both over what is
+written here whenever the checkout is available.
+
+## Prerequisites
+
+| Tool | Needed for | Where the requirement is written |
+|---|---|---|
+| Flutter (stable) >= 3.44.9 | Everything in the app | `environment:` in `pubspec.yaml` |
+| Dart SDK >= 3.11.0 | Ships with Flutter | same |
+| Rust 1.97.1 via rustup | `crates/sbm_ffi` is compiled into **every** app build | `crates/sbm_ffi/rust-toolchain.toml` |
+| Node 24 | Monitor panel, docs site, project website | `monitor/frontend/.node-version` |
+| Xcode / Android Studio / Visual Studio | Only the platform you build for | — |
+
+Rust is the one people skip because the project looks like a pure Flutter app.
+It is not: `hook/build.dart` builds the FFI crate through
+`flutter_rust_bridge_hooks` and hands the library to the SDK as a code asset,
+on all five platforms. `rustup` reads `rust-toolchain.toml` and installs the
+pinned channel on first use, so the pin needs rustup rather than a distro
+`rustc`.
+
+Regenerating the FFI bindings additionally needs the codegen binary at the
+matching version:
+
+```sh
+cargo install flutter_rust_bridge_codegen --version 2.13.0-beta.6
+```
+
+## Bootstrap
+
+```sh
+git clone https://github.com/lollipopkit/flutter_server_box
+cd flutter_server_box
+git submodule update --init --recursive   # packages/* are path dependencies
+make deps                                 # flutter pub get
+make run                                  # flutter run
+```
+
+Generated files (`*.g.dart`, `*.freezed.dart`, `lib/generated/l10n/`,
+`lib/src/rust/`) are committed, so a fresh clone does not need `make gen`
+before it will run. You need it after *changing* an annotated model.
+
+`scripts/check-env.sh` in this skill verifies the four things that go wrong
+here — toolchain versions, submodule state, whether `pub get` has run, and the
+flutter_rust_bridge version parity — without changing anything.
+
+## The loop
+
+```sh
+make run                    # or run from the IDE
+make gen                    # after touching @freezed / @JsonSerializable / @riverpod / ARB
+make analyze                # flutter analyze lib test integration_test
+make test                   # flutter test
+cargo test --workspace      # sbm_parser, sbm_native, sbm_ffi, monitor
+```
+
+`make gen` is `build_runner build --delete-conflicting-outputs` followed by
+`flutter gen-l10n`. New user-facing strings go into `lib/l10n/app_en.arb`
+first; other locales are edited by hand and partial translations are fine.
+
+**Do not run formatters.** Match the style of the file you are editing.
+
+**Do not start a second `flutter run`** when the app is already running from
+the user's IDE — a second debug build competes for the same window. Connect
+through the dart MCP server (`dtd` → `listDtdUris` → `connect` → `hot_reload`).
+Anything running before `runApp` needs `hot_restart`, since a reload does not
+re-run it.
+
+### Tests that need something extra
+
+| Suite | Needs |
+|---|---|
+| `flutter test test/frb_parser_test.dart` | `cargo build -p sbm_ffi` first — the test loads the dylib out of `target/` |
+| `integration_test/*` | A connected device or simulator; `flutter test` alone never runs them |
+| `cargo test -p sbm_parser --test ssh_e2e` | `SBM_E2E_SSH_HOST` in the workspace-root `.env`; silently skipped without it |
+| `cargo test -p server_box_monitor --test terminal_ws` | `SBM_E2E_TERMINAL_*` for the real-sshd case; the in-process fake sshd covers the rest |
+| `cd monitor/frontend && npm run test` | `npm ci` once; `npm run check` is the type gate |
+
+Two traps specific to this suite, both of which produce a hang rather than a
+failure:
+
+- A widget test whose tree writes to a store must open the database **in
+  memory** (`openTestDb()` from `test/helpers/test_db.dart`, `SqliteDb.close`
+  in `tearDown`, the store's `forTest()` constructor). Widgets that persist on
+  their own — the floating Agent, resizable panes — write without the test
+  asking them to, so this applies to more trees than it looks like.
+- `pumpAndSettle` never returns on a tree containing a text field or anything
+  else that always schedules a frame; it gives up after its ten-minute default.
+  Count frames with `pump(duration)` instead, and pass `--timeout 30s`.
+
+### Storage migrations
+
+A migration gets one pass over a user's records and is not repeatable, so a bug
+there is silence rather than a crash. Every one keeps a permanent regression
+test fed by bytes the release being migrated *from* actually wrote — the
+fixtures in `test/fixtures/hive_v{1466,1480,1491}/`, read by
+`test/hive_release_migration_test.dart`. Seeding through today's adapters only
+proves today's code agrees with itself. Never regenerate a fixture to make a
+failing test pass. `docs/src/content/docs/development/testing.md` has the
+recipe for adding one.
+
+## Monitor development
+
+```sh
+make monitor-dev     # backend on :3770, panel vite dev server on :3000
+```
+
+The first run installs the panel's dependencies. Run the two halves separately
+when you need to:
+
+```sh
+cd monitor && cargo run -p server_box_monitor -- serve
+cd monitor/frontend && npm run dev
+```
+
+- Config is `monitor/config.toml`, every key documented in
+  `config.example.toml`; `cargo run -- config` prints the resolved values.
+- The panel is served by the agent itself when `frontend/dist` exists, so a
+  production build is `npm run build` in `monitor/frontend`.
+- `npm run build` runs a `prebuild` that installs `packages/webui`'s own
+  dependencies. `@serverbox/webui` is a `file:` dependency, so an ordinary
+  install only symlinks it and `svelte-check` then cannot resolve anything
+  under its `src/`. Run the npm script rather than calling vite directly.
+- sqlx verifies queries at compile time: set `DATABASE_URL`, or refresh the
+  offline cache with `cargo sqlx prepare`.
+- `monitor/CLAUDE.md` is the detailed map of that side, including the remote
+  access model and what its tests lock down.
+
+## Building releases
+
+```sh
+make build PLATFORM=<android|ios|macos|linux|windows>   # dart run fl_build -p ...
+```
+
+- **Android release builds use the real keystore from `key.properties`.** The
+  debug-signing fallback exists for local verification and has to be asked for
+  explicitly with `-PallowDebugReleaseSigning=true`. Never use it for a release
+  artifact.
+- CI splits Android releases per ABI, so a local fat APK is not a fair size
+  comparison. `dart run fl_build -p android` reproduces the CI shape.
+- macOS DMG, notarisation and the Homebrew cask are `make release-macos-dmg`,
+  `make package-dmg`, `make sync-homebrew-cask`; secrets come from
+  `.env.release` (see `.env.release.example`).
+- The monitor is released separately by the `workflow_dispatch`-only
+  `monitor-release.yml`, under `monitor-v*` tags.
+
+## Symptom to cause
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `flutter pub get` fails on a missing path under `packages/` | Submodules not initialised | `git submodule update --init --recursive` |
+| App throws in `RustLib.init` at startup | `flutter_rust_bridge` versions differ between `pubspec.yaml` and `crates/sbm_ffi/Cargo.toml` | Make them equal; both are pinned deliberately |
+| `test/frb_parser_test.dart` cannot load the dylib | The FFI crate was never built | `cargo build -p sbm_ffi` |
+| iOS link fails on `build/ish/build-ios-arm64/lib{ish,ish_emu,fakefs}.a` | `flutter clean` removed the out-of-tree engine build; the checkout still looks clean | `scripts/build-ish-ios.sh device` (also `simulator`, `macos`) |
+| A Rust target silently builds for the host | That target is missing from `crates/sbm_ffi/rust-toolchain.toml` — not an error, a fallback | Add it to `targets` |
+| `svelte-check` reports `Cannot find module` for `packages/webui/src/*` | vite or svelte-check was run directly, skipping the `prebuild` | `npm run build` in `monitor/frontend` |
+| sqlx macros fail to compile | No `DATABASE_URL` and a stale offline cache | Set it, or `cargo sqlx prepare` |
+| `flutter test` hangs with no output naming a file | A widget test wrote to a real on-disk database inside the fake-async zone | Use `openTestDb()` and `forTest()` |
+| Changing a model breaks the Hive import | Generated adapters emit `fields[n] as String` for a new non-nullable field, so a box written before it fails to open | Freeze the type in `lib/hive/legacy_adapters.dart` instead of regenerating |
+
+## Before pushing
+
+```sh
+make analyze
+make test
+cargo test --workspace
+cd monitor/frontend && npm run test && npm run check   # only if you touched the panel
+```
+
+Commit messages are one lowercase prefix and an imperative description:
+`feat:`, `fix:`, `docs:`, `opt.:`, `rm:`, `migrate:`, `refactor:`, `test:`,
+`chore:`. Commit messages and code comments are written in English.
+
+Editing the documentation site means editing both `docs/src/content/docs/**`
+and its `zh/` mirror — the build runs `scripts/check-locale-parity.mjs` and
+fails on a missing counterpart.
+
+Every contributor signs the CLA once, by leaving a single comment on their
+first pull request. `CONTRIBUTING.md` explains the two things that trip the
+automated check: commits authored by an email not attached to the GitHub
+account, and co-authored commits, where everyone signs.

--- a/.claude/skills/serverbox-onboarding/references/monitor-deploy.md
+++ b/.claude/skills/serverbox-onboarding/references/monitor-deploy.md
@@ -1,0 +1,190 @@
+# Deploying and configuring the monitor agent
+
+ServerBox Monitor is a small Rust service installed on a server. The app talks
+to it over HTTP, which makes it a second way to reach that machine, and it is
+the only way to get anything that has to work while the app is closed.
+
+Authoritative sources, in this order: `monitor/config.example.toml` (every key,
+with the comment explaining it), `monitor/README.md`,
+`docs/src/content/docs/advanced/monitor-agent.md`, `monitor/CLAUDE.md` for the
+implementation.
+
+## When it is the right answer
+
+| | SSH | Monitor agent |
+|---|---|---|
+| Install anything on the server | no | yes |
+| Status and charts | yes | yes |
+| History from before the app connected | no | yes |
+| Terminal, commands, file browsing | yes | only what the operator enables |
+| SFTP transfers, port forwarding | yes | **no** |
+| Push alerts, home widgets, watch app | no | yes |
+
+Use SSH unless there is a reason not to. Reach for the agent when the SSH port
+is not reachable from where the phone is, when charts should already be filled
+in on open, or when alerts need to arrive with the app closed. Both at once is
+fine — a server added over SSH and an agent on the same machine feeding the
+widgets are independent records.
+
+## Install
+
+```sh
+# systemd: a `systemctl --user` service, running as your own account
+./install.sh install
+
+# OpenRC (Alpine): needs root to write /etc/init.d, but still runs the agent
+# as the account you sudo'd from
+sudo ./install.sh install
+
+# Either init system, root-owned service
+sudo ./install.sh install --system
+
+# Offline, or before a release exists for this build
+SBM_INSTALL_PKG=/path/to/server-box-monitor ./install.sh install
+```
+
+`install.sh install` fetches the newest `monitor-v*` release of the monorepo.
+Those releases are cut by a `workflow_dispatch`-only workflow, so there may be
+no current one; `SBM_INSTALL_PKG` with a locally built package and Docker are
+the alternatives. `uninstall` and `upgrade` are the other subcommands.
+
+**It installs a user service on purpose.** With `full_access` on — the default
+on Linux — a panel login opens a shell as whoever the agent runs as. As root
+that is the whole machine.
+
+Docker is `monitor/Dockerfile` and `monitor/docker-compose.yaml`: port 3770,
+`./data` and `./config` mounted, and a read-only bind of `/etc/hostname` so the
+agent reports the host's name rather than the container's random one.
+
+Building it by hand:
+
+```sh
+cd monitor
+cargo build --release
+cd frontend && npm run build     # the panel; the agent serves it if frontend/dist exists
+./target/release/server_box_monitor serve
+```
+
+## Configuration
+
+`config.toml` sits next to the binary. `cargo run -- config` (or the binary's
+`config` subcommand) prints the resolved values, which is the fastest way to
+tell whether a key is being read at all. The agent listens on `0.0.0.0:3770`.
+
+Environment variables override the file: `SBM_HOST`, `SBM_PORT`,
+`SBM_TLS_CERT`, `SBM_TLS_KEY`, `SBM_FULL_ACCESS`, `SBM_CORS_ORIGINS`,
+`SBM_HOSTNAME`, `DATABASE_URL`, `JWT_SECRET`, `RUST_LOG`. `JWT_SECRET` can be
+omitted — one is generated on first start and persisted next to the database at
+mode 0600.
+
+Sections are grouped by what they act on, not by a name prefix:
+`[server]`, `[server.tls]`, `[monitoring]`, `[monitoring.extended]`,
+`[monitoring.extended.idle_pause]`, `[monitoring.data_retention]`,
+`[[monitoring.rules]]`, `[[push]]`, `[remote_access]`,
+`[remote_access.terminal]`, `[remote_access.fs]`. Where a key lives is a claim
+about its scope: `allow_insecure` sits under `terminal` because the terminal is
+the only endpoint it gates.
+
+**A config file written before August 2026 has its flat keys ignored
+entirely** (`fs_enabled`, `terminal_enabled`, `idle_pause_enabled`, ...). serde
+skips unknown keys, so the file parses and every switch in it silently reverts
+to off. That is deliberate — the safe direction is "disabled" — but it means an
+upgraded agent can go quiet without erroring. Rewrite the file against
+`config.example.toml`.
+
+## What each switch grants
+
+The agent reports what it accepts on `GET /api/v1/capabilities` and the app
+offers exactly that, so a missing button in the app is a configuration answer
+rather than a bug. None of these can be widened from the panel.
+
+**Status, charts and stored history** need nothing beyond the panel login.
+
+**`full_access`** lets a panel login reach the machine directly: a shell, a
+command, a connection out, all as the account the agent runs as, with no sshd
+involved and therefore none of sshd's authentication, logging or second factor.
+It backs the app's process list, systemd units, containers, snippets, power
+controls and terminal. Unset follows the platform — on for Linux, off for macOS
+and Windows. The panel's first-run prompt can turn it off and has no way to
+turn it on; `DELETE /api/v1/remote-access/full-access` is likewise one-way.
+
+**`full_access` on its own grants the app nothing, and this is what a fresh
+install trips over.** What the agent reports is
+`terminal.available(secure) && full_access`, and `[remote_access.terminal]
+enabled` defaults to **false** — so an agent that was installed and never
+configured reports `full_access: false` however Linux's own default reads, and
+the app shows charts with none of the buttons. The transport half of that
+expression is evaluated per request, so the same agent can answer `true` to a
+`curl` from loopback and `false` to the phone reaching it over plaintext HTTP
+on the LAN. Diagnose it against the address the app actually uses.
+
+It is one switch rather than one per feature because there is only one decision
+in it: anyone who can open a shell can run anything in that shell, so granting
+the terminal while withholding commands withholds nothing.
+
+**Your panel password is then worth a shell on that machine.** Run the agent as
+an ordinary account, or turn this off.
+
+**`[remote_access.fs]`** serves the app's file browser, confined to the
+directories in `roots`. It has its own switch because `full_access` means "a
+shell" and this means "these directories" — folding them together would make
+the narrower feature cost the wider permission. `roots` has no default. Every
+request is resolved to a canonical path first, symlinks followed and `..`
+refused, then checked against the roots, so a link inside a root pointing at
+`/etc` is a refusal rather than a way out. A path outside the roots reports as
+absent, so the endpoint cannot be used to map the filesystem one status code at
+a time. `roots = ["/"]` is equivalent to a shell — anyone who can write
+`~/.ssh/authorized_keys` has one — and the agent warns about it at startup.
+
+**`[remote_access.terminal]`** enables the terminal endpoint used by both the
+app and the panel. The panel's session makes the agent an SSH *client* to
+`ssh_addr`, so it carries the privileges of the SSH account the browser signs
+in as; the app's passwordless session uses a local PTY and needs `full_access`.
+Sessions outlive the WebSocket for a few minutes, so a phone changing networks
+rejoins the same shell.
+
+**Plaintext is a double opt-in.** The terminal and the file API refuse a
+plaintext listener, because the terminal's first message carries an SSH
+password and the file API carries bearer tokens and file contents. Configure
+TLS (`[server.tls]`) or put a reverse proxy on the same host — loopback counts
+as secure. On a network that is already encrypted outside HTTP (Tailscale and
+similar) the operator may set `allow_insecure = true` on the section, *and* the
+app must enable **Allow insecure HTTP** for that individual connection. Both
+are required, deliberately.
+
+## Adding it in the app
+
+1. Tap **+** to add a server
+2. Switch the selector at the top of the form from **SSH** to **Monitor HTTP**
+3. Fill in the URL (e.g. `https://1.2.3.4:3770`), the panel user and password,
+   and **Monitor Ignore certificate** only for a self-signed certificate
+
+Such a server carries **no SSH credentials at all**, and there is nothing to
+fall back to. That is the point: the app has been given no way into the machine
+beyond what the agent allows.
+
+SFTP and port forwarding are not offered, because the agent has no endpoint
+that relays a connection to an address the app names. File *browsing* is a
+different mechanism — the file API moves contents through the agent. Add the
+server over SSH if the transfers or the tunnels are what you need.
+
+## Widgets, push and the watch
+
+These read the agent directly, with the app closed.
+
+- Home screen widgets take a URL ending in `/status`
+  (`docs/src/content/docs/advanced/widgets.md`)
+- The watch app reads the agent itself, so it can only show servers that have one
+- Push alerts are configured on the agent, in `[[monitoring.rules]]` and `[[push]]`
+
+## Troubleshooting
+
+| Symptom | Where to look |
+|---|---|
+| Buttons missing on the server page | The app is showing what the agent reported. Commands and the terminal need `full_access` **and** `[remote_access.terminal] enabled` **and** secure transport, all three; the second defaults to false, so this is the usual answer on a fresh install. Files need `[remote_access.fs]` plus `roots`. The agent re-reads its config on restart |
+| Certificate errors | Configure TLS, front it with a reverse proxy, or enable **Monitor Ignore certificate** for that server |
+| Panel hosted on another origin cannot reach the agent | `cors_allowed_origins` in `config.toml`, or `SBM_CORS_ORIGINS` (comma-separated) |
+| Switches turned themselves off after an upgrade | A pre-August-2026 flat config; its keys are not read |
+| Terminal refuses to start | Plaintext transport without the double opt-in, or `[remote_access.terminal] enabled = false` |
+| Host key changed and the terminal refuses | The agent pins the sshd's key on first use. Clearing it is deliberate: delete the row from `ssh_known_hosts` |
+| Nothing at all | Check the process and the port, then `access_log` in its database — who opened what, from where, whether it worked. It never records a credential |

--- a/.claude/skills/serverbox-onboarding/references/principles.md
+++ b/.claude/skills/serverbox-onboarding/references/principles.md
@@ -1,0 +1,148 @@
+# How ServerBox works
+
+A map, not a replacement for the documentation. The long explanations are in
+`docs/src/content/docs/principles/` and `docs/src/content/docs/development/`;
+the working rules for changing the code are in `CLAUDE.md` and
+`monitor/CLAUDE.md`. What follows is the handful of decisions that explain the
+most behaviour, so you can route to the right file in one step.
+
+## The shape of it
+
+The app is Flutter, layered: `lib/view/` renders, `lib/data/provider/` holds
+Riverpod state, `lib/data/model/` and `lib/data/store/` are the data layer.
+Status parsing is not Dart at all — it is a Rust crate shared with the
+server-side agent, so both always agree about what a command's output means.
+
+## A server is reached one way, and features ask rather than test
+
+`ServerConnectCredential.fromSpi` picks by whether `Spi.monitorHttp` is set. A
+monitor server carries no `SshCredential`; the edit page enforces the same
+exclusivity with one switch.
+
+What a transport can do is asked through `ServerCapabilities`, so a feature
+needing a shell never has to know that "SSH" is the thing that provides one:
+
+- `SshCapabilities` answers yes to everything except `storedHistory` — one
+  connection already carries a shell, a PTY and a channel, and sampling starts
+  when the app connects, so a page opened now starts with an empty buffer.
+- `MonitorHttpCapabilities` answers with what the agent reported on
+  `GET /api/v1/capabilities`. `byteStream` is false, which is why SFTP and port
+  forwarding are absent: the agent has no endpoint that relays a connection to
+  an address the app names. `storedHistory` is true, since the agent was
+  sampling before the app asked.
+
+`ServerNotifier.ensureExec()` is the single place that decides how a command
+reaches a server. A monitor server never falls back to sshd — falling back
+would mean asking for credentials the user deliberately did not give.
+`ensureShellClient()` is the SSH path only, and uses a separate `TryLimiter`
+key so a shell that will not open does not also stop the status page
+refreshing.
+
+Where the SSH byte stream comes from is a separate axis, resolved in `genClient`
+(`lib/core/utils/server.dart`): direct, through a jump server, or through a
+`ProxyCommand`. The last two are mutually exclusive. Everything above
+`SSHSocket` is identical either way, and the app verifies the host key itself in
+every case.
+
+## Status parsing lives in Rust, and is pure
+
+`crates/sbm_parser` owns the command manifest (command name → per-platform
+command, `SrvBoxSep.<cmd>` segmenting), the parsers, and the script generation.
+The app calls it through `crates/sbm_ffi` / flutter_rust_bridge; the monitor
+links it directly. Parsers emit raw counters; anything windowed, such as
+network speed, is a pure function over two samples, and the mutable time series
+stays on the caller's side. **No mutable state crosses the FFI boundary.**
+
+`commands::EXTENDED` (smartctl, AMD GPU) is split out of the fast path and run
+minutes apart, because polling smartctl keeps a disk from ever spinning down.
+The monitor additionally has `crates/sbm_native`, which samples cpu, memory,
+disks, network and uptime through syscalls instead of shell commands — an
+option the app does not have, since it is always looking at a remote host.
+
+`crates/sbm_parser/tests/dart_compat.rs` locks the behaviour against the
+original Dart implementation's fixtures. When porting anything else to Rust,
+the rule is test-as-spec: port the fixtures first, assert the FFI result is
+identical, delete the Dart last.
+
+## Storage is one encrypted SQLite file
+
+`store.db`, opened through `package:sqlite3` with the `sqlite3mc` cipher. Two
+shapes, and which one a store uses is a decision:
+
+- **`kv(store, key, value, updated_at)`** holds settings and history — a
+  hundred unrelated preferences where adding one should stay a one-line change.
+  `value` is JSON, so anything written here needs a `toJson`; `SqliteStore.set`
+  answers `false` rather than throwing when it has none, which makes a missing
+  one silent.
+- **Entity tables** hold servers, private keys, snippets, port forwards,
+  connection statistics and agent conversations, with foreign keys and indexes.
+
+Conventions worth knowing before touching the schema:
+
+- **A primary key is an id, never something the user typed.** A private key's id
+  used to be its name, so renaming one detached every server pointing at it.
+- **A list or map field is a child table**, not a JSON array in a column. A
+  child carries no sync columns and moves with its parent.
+- **`INSERT OR REPLACE` is wrong** on a row with sync columns or children: it
+  deletes and reinserts, resetting `rev` and cascading the children away.
+- **Enums are stored by name**, because an index silently changes meaning when
+  a case is inserted and these values outlive the build that wrote them.
+- **Drift owns the DDL and only the DDL.** Queries are hand-written and
+  synchronous, because the UI reads a store while building.
+
+`Tables.syncRoots` names what sync moves as a unit; each root carries
+`updated_at` and `rev`, and a delete leaves a `tombstone` row, without which a
+peer reads the absence as an addition and puts the record back.
+
+Migrations are covered in `dev-setup.md` and, at length, in
+`docs/src/content/docs/development/testing.md`. The short version: a migration
+gets one pass over real user data and a bug there is silence, so each one keeps
+a permanent test fed by bytes an older release actually wrote.
+
+## State, and one navigator trap
+
+Riverpod with code generation for providers, freezed for immutable models,
+GetIt for service location. `docs/src/content/docs/principles/state.md` is the
+long form.
+
+The trap that has produced the most bugs: **`showRoundDialog` puts the dialog on
+the root navigator**, while a page's `context` finds the navigator holding the
+page — and inside a pane or a tab those differ. A `context.pop()` reached from a
+dialog button closes the *page* and leaves the dialog on screen, and the awaited
+future never completes. Close a dialog with `context.popDialog()`, or better,
+let it answer: `await context.showRoundDialog<bool>(...)` with `Btnx.cancelOk`.
+Passing an `onTap` to `Btn.ok` is what breaks it, because that replaces the
+button's own correct navigator resolution.
+
+## Cross-platform
+
+Five platforms from one codebase, with two pieces of native machinery worth
+knowing about:
+
+- **`third_party/ish-arm64`** is a fork of iSH, the Linux userland the iOS build
+  can run locally. It is off by default (`SBM_ISH=0`) and built out of tree by
+  `scripts/build-ish-ios.sh`, which is why `flutter clean` breaks it.
+- **CocoaPods is gone from iOS and macOS.** `hook/build.dart` and the
+  `packages/flutter_pty` fork replaced the per-platform build integrations with
+  Dart build hooks, so there is no `Podfile` and nothing to add one back to.
+
+Localization is ARB files in `lib/l10n/`, reached through `l10n` for this
+project and `libL10n` for the strings `fl_lib` already has. Prefer an existing
+`libL10n` string even when the meaning is not an exact match.
+
+## Which document answers which question
+
+| Question | File |
+|---|---|
+| How the layers, connection methods and core systems fit together | `docs/src/content/docs/principles/architecture.md` |
+| Connection flow, authentication, host key verification, session lifecycle | `docs/src/content/docs/principles/ssh.md` |
+| File operations, path handling, transfers, editing | `docs/src/content/docs/principles/sftp.md` |
+| Where terminal bytes come from, tabs, virtual keyboard, selection | `docs/src/content/docs/principles/terminal.md` |
+| Provider types, update patterns, persistence, testing with Riverpod | `docs/src/content/docs/principles/state.md` |
+| Where a file belongs in the tree | `docs/src/content/docs/development/structure.md` |
+| Which generator to run and why an adapter is frozen | `docs/src/content/docs/development/codegen.md` |
+| Test strategy, fixtures, integration tests | `docs/src/content/docs/development/testing.md` |
+| The agent's API surface, remote access model, panel | `monitor/CLAUDE.md` |
+| Rules for changing this codebase | `CLAUDE.md` |
+
+Every path above has a `zh/` counterpart under `docs/src/content/docs/zh/`.

--- a/.claude/skills/serverbox-onboarding/references/principles.md
+++ b/.claude/skills/serverbox-onboarding/references/principles.md
@@ -145,4 +145,7 @@ project and `libL10n` for the strings `fl_lib` already has. Prefer an existing
 | The agent's API surface, remote access model, panel | `monitor/CLAUDE.md` |
 | Rules for changing this codebase | `CLAUDE.md` |
 
-Every path above has a `zh/` counterpart under `docs/src/content/docs/zh/`.
+The `docs/src/content/docs/` pages above each have a `zh/` counterpart, and
+`scripts/check-locale-parity.mjs` fails the build when one is missing. The two
+`CLAUDE.md` files are not documentation pages and have no translation — they
+are instructions for whoever is changing the code.

--- a/.claude/skills/serverbox-onboarding/scripts/check-env.sh
+++ b/.claude/skills/serverbox-onboarding/scripts/check-env.sh
@@ -35,9 +35,23 @@ ok()   { printf '%s  ok  %s %s\n' "$C_OK" "$C_OFF" "$1"; }
 warn() { printf '%s warn %s %s\n' "$C_WARN" "$C_OFF" "$1"; }
 bad()  { printf '%s FAIL %s %s\n' "$C_BAD" "$C_OFF" "$1"; FAILED=1; }
 
-# Numeric dotted-version comparison; missing components count as 0.
+# Dotted-version comparison, missing components counting as 0, and a
+# prerelease ranking below the release it precedes.
+#
+# The last part is the whole reason this is not three lines. `pub` reads these
+# constraints as semver, where 3.44.9-0.1.pre is *older* than 3.44.9 — so a
+# beta-channel Flutter fails `pub get` against `flutter: ">=3.44.9"`. Comparing
+# only the numeric part reports that install as ok and leaves the actual
+# failure to be met later, with a message about version solving rather than
+# about the channel.
 ver_ge() {
     [ "$(awk -v a="$1" -v b="$2" 'BEGIN {
+        # Split the prerelease suffix off each side; what is left is numeric.
+        ia = index(a, "-"); pa = (ia > 0) ? substr(a, ia + 1) : ""
+        ib = index(b, "-"); pb = (ib > 0) ? substr(b, ib + 1) : ""
+        if (ia > 0) a = substr(a, 1, ia - 1)
+        if (ib > 0) b = substr(b, 1, ib - 1)
+
         na = split(a, x, "."); nb = split(b, y, ".")
         n = (na > nb) ? na : nb
         for (i = 1; i <= n; i++) {
@@ -46,6 +60,9 @@ ver_ge() {
             if (va > vb) { print 1; exit }
             if (va < vb) { print 0; exit }
         }
+        # Numerically equal. A prerelease loses to a release; two prereleases
+        # are not ranked against each other, which no check here needs.
+        if (pa != "" && pb == "") { print 0; exit }
         print 1
     }')" = "1" ]
 }
@@ -61,7 +78,9 @@ want_flutter=$(sed -n 's/^ *flutter: *">= *\([0-9.]*\)".*/\1/p' "$ROOT/pubspec.y
 want_dart=$(sed -n 's/^ *sdk: *">= *\([0-9.]*\)".*/\1/p' "$ROOT/pubspec.yaml" | head -1)
 
 if command -v flutter >/dev/null 2>&1; then
-    have_flutter=$(flutter --version 2>/dev/null | sed -n 's/^Flutter \([0-9][0-9.]*\).*/\1/p' | head -1)
+    # The prerelease suffix is kept: `ver_ge` needs it, and dropping it here is
+    # what made a beta SDK compare equal to the stable release it precedes.
+    have_flutter=$(flutter --version 2>/dev/null | sed -n 's/^Flutter \([0-9][0-9.]*\(-[0-9A-Za-z.]*\)\{0,1\}\).*/\1/p' | head -1)
     if [ -z "$have_flutter" ]; then
         warn "flutter found but its version could not be parsed"
     elif [ -n "$want_flutter" ] && ! ver_ge "$have_flutter" "$want_flutter"; then
@@ -74,7 +93,7 @@ else
 fi
 
 if command -v dart >/dev/null 2>&1; then
-    have_dart=$(dart --version 2>&1 | sed -n 's/.*version: *\([0-9][0-9.]*\).*/\1/p' | head -1)
+    have_dart=$(dart --version 2>&1 | sed -n 's/.*version: *\([0-9][0-9.]*\(-[0-9A-Za-z.]*\)\{0,1\}\).*/\1/p' | head -1)
     if [ -n "$want_dart" ] && [ -n "$have_dart" ] && ! ver_ge "$have_dart" "$want_dart"; then
         bad "dart $have_dart is older than the required $want_dart"
     else

--- a/.claude/skills/serverbox-onboarding/scripts/check-env.sh
+++ b/.claude/skills/serverbox-onboarding/scripts/check-env.sh
@@ -1,0 +1,174 @@
+#!/bin/sh
+# Read-only check of a ServerBox development environment.
+#
+# Reports what is installed against what the repository asks for. It installs
+# nothing, writes nothing and never touches the network, so it is safe to run
+# before diagnosing a build failure by hand — most first-run failures are one
+# of the things below, and the symptom rarely names the cause.
+#
+# Usage: sh .claude/skills/serverbox-onboarding/scripts/check-env.sh [repo-root]
+# Exit:  0 = nothing blocking, 1 = at least one FAIL
+
+set -u
+
+ROOT="${1:-}"
+if [ -z "$ROOT" ]; then
+    ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || ROOT=$(pwd)
+fi
+
+if [ ! -f "$ROOT/pubspec.yaml" ] || [ ! -d "$ROOT/crates/sbm_ffi" ]; then
+    echo "Not a flutter_server_box checkout: $ROOT"
+    echo "Pass the repository root as the first argument."
+    exit 1
+fi
+
+FAILED=0
+
+if [ -t 1 ]; then
+    C_OK=$(printf '\033[32m'); C_WARN=$(printf '\033[33m')
+    C_BAD=$(printf '\033[31m'); C_OFF=$(printf '\033[0m')
+else
+    C_OK=''; C_WARN=''; C_BAD=''; C_OFF=''
+fi
+
+ok()   { printf '%s  ok  %s %s\n' "$C_OK" "$C_OFF" "$1"; }
+warn() { printf '%s warn %s %s\n' "$C_WARN" "$C_OFF" "$1"; }
+bad()  { printf '%s FAIL %s %s\n' "$C_BAD" "$C_OFF" "$1"; FAILED=1; }
+
+# Numeric dotted-version comparison; missing components count as 0.
+ver_ge() {
+    [ "$(awk -v a="$1" -v b="$2" 'BEGIN {
+        na = split(a, x, "."); nb = split(b, y, ".")
+        n = (na > nb) ? na : nb
+        for (i = 1; i <= n; i++) {
+            va = (i <= na) ? x[i] + 0 : 0
+            vb = (i <= nb) ? y[i] + 0 : 0
+            if (va > vb) { print 1; exit }
+            if (va < vb) { print 0; exit }
+        }
+        print 1
+    }')" = "1" ]
+}
+
+echo "ServerBox environment check"
+echo "  root: $ROOT"
+echo
+
+# --- Flutter and Dart -------------------------------------------------------
+# Both minimums come from `environment:` in pubspec.yaml, which is what pub
+# enforces; anything older fails at resolution rather than at build time.
+want_flutter=$(sed -n 's/^ *flutter: *">= *\([0-9.]*\)".*/\1/p' "$ROOT/pubspec.yaml" | head -1)
+want_dart=$(sed -n 's/^ *sdk: *">= *\([0-9.]*\)".*/\1/p' "$ROOT/pubspec.yaml" | head -1)
+
+if command -v flutter >/dev/null 2>&1; then
+    have_flutter=$(flutter --version 2>/dev/null | sed -n 's/^Flutter \([0-9][0-9.]*\).*/\1/p' | head -1)
+    if [ -z "$have_flutter" ]; then
+        warn "flutter found but its version could not be parsed"
+    elif [ -n "$want_flutter" ] && ! ver_ge "$have_flutter" "$want_flutter"; then
+        bad "flutter $have_flutter is older than the required $want_flutter"
+    else
+        ok "flutter $have_flutter (needs >= ${want_flutter:-?})"
+    fi
+else
+    bad "flutter not on PATH"
+fi
+
+if command -v dart >/dev/null 2>&1; then
+    have_dart=$(dart --version 2>&1 | sed -n 's/.*version: *\([0-9][0-9.]*\).*/\1/p' | head -1)
+    if [ -n "$want_dart" ] && [ -n "$have_dart" ] && ! ver_ge "$have_dart" "$want_dart"; then
+        bad "dart $have_dart is older than the required $want_dart"
+    else
+        ok "dart ${have_dart:-?} (needs >= ${want_dart:-?})"
+    fi
+else
+    bad "dart not on PATH"
+fi
+
+# --- Rust -------------------------------------------------------------------
+# crates/sbm_ffi is compiled into every app build by hook/build.dart, so this
+# is required even for `flutter run`. The channel is pinned per-crate; rustup
+# installs it on first use, which a distro rustc will not do.
+want_rust=$(sed -n 's/^ *channel *= *"\([^"]*\)".*/\1/p' "$ROOT/crates/sbm_ffi/rust-toolchain.toml" | head -1)
+
+if command -v cargo >/dev/null 2>&1; then
+    have_rust=$(rustc --version 2>/dev/null | awk '{print $2}')
+    ok "cargo present, rustc ${have_rust:-?} (crates/sbm_ffi pins ${want_rust:-?})"
+    if command -v rustup >/dev/null 2>&1; then
+        if [ -n "$want_rust" ] && rustup toolchain list 2>/dev/null | grep -q "^$want_rust"; then
+            ok "pinned toolchain $want_rust installed"
+        elif [ -n "$want_rust" ]; then
+            warn "pinned toolchain $want_rust not installed yet; rustup fetches it on the first build"
+        fi
+    else
+        warn "rustup not on PATH — rust-toolchain.toml's pin will be ignored by a bare rustc"
+    fi
+else
+    bad "cargo not on PATH — the app cannot build without a Rust toolchain"
+fi
+
+# --- Node -------------------------------------------------------------------
+# Only the monitor panel, the docs site and the website need it. Absent is
+# fine for app-only work, hence a warning rather than a failure.
+node_pin="$ROOT/monitor/frontend/.node-version"
+want_node=$([ -f "$node_pin" ] && head -1 "$node_pin" || echo "")
+if command -v node >/dev/null 2>&1; then
+    have_node=$(node --version 2>/dev/null | sed 's/^v//')
+    if [ -n "$want_node" ] && ! ver_ge "$have_node" "${want_node%%.*}"; then
+        warn "node $have_node is older than the pinned $want_node (monitor panel, docs, website)"
+    else
+        ok "node $have_node (pinned ${want_node:-?})"
+    fi
+else
+    warn "node not on PATH — needed only for the monitor panel, docs site and website"
+fi
+
+echo
+
+# --- Submodules -------------------------------------------------------------
+# packages/* are path dependencies, so an uninitialised submodule makes
+# `flutter pub get` fail on a missing directory without mentioning submodules.
+if [ -f "$ROOT/.gitmodules" ]; then
+    uninit=$(git -C "$ROOT" submodule status 2>/dev/null | grep -c '^-' || true)
+    if [ "${uninit:-0}" -gt 0 ]; then
+        bad "$uninit submodule(s) not initialised — run: git submodule update --init --recursive"
+        git -C "$ROOT" submodule status 2>/dev/null | grep '^-' | awk '{print "        " $2}'
+    else
+        ok "submodules initialised"
+    fi
+fi
+
+# --- Dependencies fetched ---------------------------------------------------
+if [ -f "$ROOT/.dart_tool/package_config.json" ]; then
+    ok "dart dependencies fetched (.dart_tool/package_config.json present)"
+else
+    warn "dart dependencies not fetched yet — run: make deps"
+fi
+
+if [ -d "$ROOT/monitor/frontend/node_modules" ]; then
+    ok "monitor panel dependencies installed"
+else
+    warn "monitor panel dependencies not installed — 'make monitor-dev' installs them on first run"
+fi
+
+# --- flutter_rust_bridge parity ---------------------------------------------
+# The Dart and Rust halves are pinned separately. When they disagree,
+# RustLib.init throws at startup and the message says nothing about versions.
+frb_dart=$(sed -n 's/^  flutter_rust_bridge: *\([^ ]*\).*/\1/p' "$ROOT/pubspec.yaml" | head -1)
+frb_rust=$(sed -n 's/^flutter_rust_bridge *= *"=\{0,1\}\([^"]*\)".*/\1/p' "$ROOT/crates/sbm_ffi/Cargo.toml" | head -1)
+if [ -n "$frb_dart" ] && [ -n "$frb_rust" ]; then
+    if [ "$frb_dart" = "$frb_rust" ]; then
+        ok "flutter_rust_bridge $frb_dart matches on both sides"
+    else
+        bad "flutter_rust_bridge mismatch: pubspec.yaml $frb_dart vs crates/sbm_ffi/Cargo.toml $frb_rust"
+    fi
+else
+    warn "could not read the flutter_rust_bridge version from both sides"
+fi
+
+echo
+if [ "$FAILED" -eq 0 ]; then
+    echo "No blocking problems. Next: make deps, then make run."
+else
+    echo "Fix the FAIL lines above before building."
+fi
+exit "$FAILED"

--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ Please only download pkgs from the source that **you trust**!
 
 - [ServerBox Monitor](https://github.com/lollipopkit/flutter_server_box/tree/main/monitor) is an agent you install on your servers. It is required for anything that has to work while the app is closed — **message push**, **home widgets** and the **watch app** — and it is also a second way to add a server: the app can reach it over HTTP instead of SSH, which suits hosts whose SSH port you would rather not expose, and gives charts a history from before the app ever connected. It serves a web panel of its own too. See its [README](https://github.com/lollipopkit/flutter_server_box/blob/main/monitor/README.md) for setup and for what each remote-access switch grants.
 - **Common issues** can be found in [app wiki](https://github.com/lollipopkit/flutter_server_box/wiki).
+- **Asking an AI agent?** This repository ships a skill that orients one: installing and using the app, deploying and configuring the monitor agent, bootstrapping the Flutter + Rust + Node environment, and the few facts that explain most "why can't I do X on this server" questions. Add it to whichever agent you use with
+
+  ```sh
+  npx skills add lollipopkit/flutter_server_box
+  ```
+
+  The source is [`.claude/skills/serverbox-onboarding`](.claude/skills/serverbox-onboarding), so you can read what it will tell your agent before installing it.
 
 Before you open an issue, please read the following:
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -57,6 +57,13 @@ Linux / Windows | [GitHub](https://github.com/lollipopkit/flutter_server_box/rel
 
 - [ServerBox Monitor](https://github.com/lollipopkit/flutter_server_box/tree/main/monitor) 是安装在你服务器上的 agent。不打开 ServerBox app 时仍需工作的功能都依赖它 —— **推送服务**、**桌面小部件** 和 **手表 app**；它同时也是添加服务器的第二种方式：app 可以经 HTTP 而不是 SSH 访问它，适用于不便暴露 SSH 端口的主机，并且图表在 app 首次连接前就已有历史数据。它自己还提供一个网页面板。安装方法和各个远程访问开关的含义详见其[中文文档](https://github.com/lollipopkit/flutter_server_box/blob/main/monitor/README_zh.md)。  
 - **常见问题** 可以在 [app wiki](https://github.com/lollipopkit/flutter_server_box/wiki/主页) 查看。
+- **让 AI agent 帮你？** 本仓库带了一份 skill：安装和使用 app、部署与配置 monitor agent、搭建 Flutter + Rust + Node 开发环境，以及能解释掉大部分「这台服务器为什么不能做 X」的那几条事实。用下面的命令装进你用的 agent：
+
+  ```sh
+  npx skills add lollipopkit/flutter_server_box
+  ```
+
+  内容在 [`.claude/skills/serverbox-onboarding`](.claude/skills/serverbox-onboarding)，装之前可以先读它到底会告诉你的 agent 什么。
 
 反馈前须知：
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -298,6 +298,10 @@ agent 的那条完整路径。
 跑一次那个 workflow 就能解开。在那之前,离线包那条路(`SBM_INSTALL_PKG=<目录或 tarball>`)
 是唯一能装成的方式,它本身也是内网服务器需要的。
 
+2026-08-23 在一台 NixOS 25.11 aarch64 上实跑确认了这条:`./install.sh install` 第一句
+就是那个错,连发行版兼容性都没机会暴露。所以任何"monitor 在 X 上能不能装"的问题,
+现在都问不出结果 —— 先发一次 release,或者先构一个离线包。
+
 ## macOS 两套产物:App Store 版什么时候停更
 
 自动导入已在真机上验过:keychain 两个 build 通用,容器读取不弹窗。剩下的是一个决定

--- a/lib/core/service/ssh_discovery.dart
+++ b/lib/core/service/ssh_discovery.dart
@@ -302,7 +302,11 @@ class SshDiscoveryService {
         );
       }
     } else if (_isLinux) {
-      final s = await _run('/usr/bin/avahi-browse', ['-rat', '_ssh._tcp']);
+      // By name, resolved on PATH, the way `ip` above is. An absolute
+      // /usr/bin is a guess about the filesystem rather than about the tool —
+      // and it is wrong on NixOS, where nothing but /bin/sh and /usr/bin/env
+      // live at an FHS path.
+      final s = await _run('avahi-browse', ['-rat', '_ssh._tcp']);
       if (s != null) {
         for (final ip in _avahiAddressRegExp.allMatches(s).map((m) => m.group(1)!).where((e) => e.isNotEmpty)) {
           final parsed = InternetAddress.tryParse(ip);

--- a/monitor/install.sh
+++ b/monitor/install.sh
@@ -72,6 +72,22 @@ detect_init
 # it even for the default mode.
 resolve_target() {
 if [ "$INIT" = "systemd" ]; then
+    if [ "$MODE" = "system" ] && [ -e /etc/NIXOS ]; then
+        # /etc/systemd/system is a read-only symlink into the store here, so a
+        # system service cannot be installed imperatively by anyone, root
+        # included. Said before the attempt rather than after: the failure is
+        # otherwise a bare "Read-only file system" from the unit write, which
+        # reads as a broken installer rather than as the wrong tool.
+        echo "NixOS keeps /etc/systemd/system in the read-only store, so a"
+        echo "system service cannot be installed this way."
+        echo
+        echo "  Use the module in monitor/nix/module.nix instead:"
+        echo "    imports = [ /path/to/monitor/nix/module.nix ];"
+        echo "    services.server-box-monitor.enable = true;"
+        echo
+        echo "  Or drop --system: the user service works here unchanged."
+        exit 1
+    fi
     if [ "$MODE" = "system" ]; then
         APP_DIR="/opt/server-box-monitor"
         UNIT="/etc/systemd/system/$SERVICE"
@@ -380,6 +396,19 @@ install_service() {
         # remote-access summary and its security warnings. docker-compose.yaml
         # already defaults to info.
         echo "Environment=RUST_LOG=info"
+        # The agent collects by running ordinary tools — `sh` first, then
+        # whatever the command manifest asks for: cat, df, uptime, lsblk.
+        # A unit that sets no PATH gets systemd's compiled-in one, and that is
+        # a per-distribution value: on most it is the FHS list below and this
+        # line changes nothing, but NixOS builds systemd with its own store
+        # path instead, so the service saw *only* systemd's own bin directory.
+        # `sh` was then not on PATH at all and every cycle failed with
+        # "Status script error: No such file or directory (os error 2)" —
+        # measured on NixOS 25.11, where /bin/sh exists but /bin does not.
+        #
+        # The NixOS entry first and the rest unchanged: a directory that does
+        # not exist costs nothing to have on PATH.
+        echo "Environment=PATH=/run/current-system/sw/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
         if [ "$MODE" = "system" ]; then
             echo "User=root"
         fi

--- a/monitor/nix/module.nix
+++ b/monitor/nix/module.nix
@@ -1,0 +1,171 @@
+# A NixOS module for the monitor agent.
+#
+# `install.sh` cannot work here and is not meant to: its `--system` mode writes
+# a unit into /etc/systemd/system, which on NixOS is a read-only symlink into
+# the store. Its default (user) mode does work — everything it touches is under
+# $HOME — so this module is for the system-wide service, which is the half that
+# has no imperative equivalent on this distribution.
+#
+# Enable with, in configuration.nix:
+#
+#     imports = [ /path/to/monitor/nix/module.nix ];
+#     services.server-box-monitor.enable = true;
+#
+# ## Why there is a state directory and a symlink in it
+#
+# The agent resolves three things relative to its *working directory*, and one
+# of them it writes:
+#
+#   config.toml              read, and written when absent or migrated
+#   serverbox_monitor.db     the SQLite file
+#   frontend/dist            the panel's static files
+#
+# So the working directory cannot be the package — that is in the store and
+# read-only — and it cannot be a plain directory either, because the panel has
+# to be found from it. StateDirectory gives the first two a writable home, and
+# `preStart` links the third in from the package. Migrations need nothing:
+# `sqlx::migrate!` embeds them at compile time.
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.server-box-monitor;
+in
+{
+  options.services.server-box-monitor = {
+    enable = lib.mkEnableOption "the ServerBox monitor agent";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.callPackage ./package.nix { };
+      defaultText = lib.literalExpression "pkgs.callPackage ./package.nix { }";
+      description = "The monitor package to run.";
+    };
+
+    user = lib.mkOption {
+      type = lib.types.str;
+      default = "server-box-monitor";
+      description = ''
+        The account the agent runs as.
+
+        Not root by default, and the reason is not tidiness: with
+        `remote_access.full_access` on, a panel login opens a shell as whoever
+        this is. `install.sh` makes the same choice for the same reason.
+      '';
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "server-box-monitor";
+      description = "The group the agent runs as.";
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to open the configured port.
+
+        Off by default. The agent's own config decides whether it listens on
+        anything but loopback, and opening a port here for a service that is
+        not reachable anyway would be a firewall hole with nothing behind it.
+      '';
+    };
+
+    port = lib.mkOption {
+      type = lib.types.port;
+      default = 3770;
+      description = ''
+        The port to open when [](#opt-services.server-box-monitor.openFirewall)
+        is set. This does *not* configure the agent — that is config.toml's
+        job, and duplicating it here would give two answers to one question.
+      '';
+    };
+
+    settings = lib.mkOption {
+      type = lib.types.nullOr lib.types.attrs;
+      default = null;
+      example = lib.literalExpression ''
+        { server = { host = "127.0.0.1"; port = 3770; }; }
+      '';
+      description = ''
+        config.toml, declared. Null leaves the file alone, which is what a
+        machine configured through the panel wants: the agent writes its own
+        settings there, and a declarative file would be overwritten on every
+        rebuild and then rewritten by the agent.
+
+        Set this and the file becomes generated and read-only, so the panel's
+        settings page stops being able to persist anything.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.users = lib.mkIf (cfg.user == "server-box-monitor") {
+      server-box-monitor = {
+        isSystemUser = true;
+        group = cfg.group;
+        description = "ServerBox monitor agent";
+      };
+    };
+
+    users.groups = lib.mkIf (cfg.group == "server-box-monitor") {
+      server-box-monitor = { };
+    };
+
+    networking.firewall = lib.mkIf cfg.openFirewall {
+      allowedTCPPorts = [ cfg.port ];
+    };
+
+    systemd.services.server-box-monitor = {
+      description = "ServerBox monitor agent";
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      # The collection script shells out to ordinary tools. Giving it the
+      # system profile rather than a curated list on purpose: which tools are
+      # asked for is `sbm_parser`'s command manifest, and it changes there.
+      path = with pkgs; [ coreutils procps util-linux ];
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${cfg.package}/bin/server_box_monitor serve";
+        Restart = "on-failure";
+        RestartSec = 5;
+
+        User = cfg.user;
+        Group = cfg.group;
+
+        StateDirectory = "server-box-monitor";
+        StateDirectoryMode = "0750";
+        WorkingDirectory = "/var/lib/server-box-monitor";
+
+        # Modest, and honest about why it is not more: with full_access on, the
+        # agent's whole purpose is to run commands the user asked for, so a
+        # sandbox that stopped it would stop the feature. These are the ones
+        # that cost nothing.
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ProtectKernelTunables = true;
+        ProtectControlGroups = true;
+        RestrictSUIDSGID = true;
+      };
+
+      preStart = ''
+        # The panel, found relative to the working directory. A symlink rather
+        # than a copy so that a rebuild moves it without leaving the old one.
+        ln -sfn ${cfg.package}/share/server-box-monitor/frontend \
+          /var/lib/server-box-monitor/frontend
+      ''
+      + lib.optionalString (cfg.settings != null) ''
+        # Declared config wins, every start. Deliberately clobbering: with
+        # `settings` set the file is this module's, and the panel's settings
+        # page cannot persist over it.
+        install -m 0640 ${
+          (pkgs.formats.toml { }).generate "config.toml" cfg.settings
+        } /var/lib/server-box-monitor/config.toml
+      '';
+    };
+  };
+}

--- a/monitor/nix/module.nix
+++ b/monitor/nix/module.nix
@@ -121,10 +121,16 @@ in
       after = [ "network.target" ];
       wantedBy = [ "multi-user.target" ];
 
-      # The collection script shells out to ordinary tools. Giving it the
-      # system profile rather than a curated list on purpose: which tools are
-      # asked for is `sbm_parser`'s command manifest, and it changes there.
-      path = with pkgs; [ coreutils procps util-linux ];
+      # The collection script shells out to ordinary tools, and `bash` is here
+      # because it is the one that provides `sh` — coreutils does not. Without
+      # it the agent fails every cycle with "Status script error: No such file
+      # or directory", which is exactly the failure `install.sh` had on this
+      # distribution: the interpreter, not the script.
+      #
+      # The rest is what `sbm_parser`'s command manifest asks for. It is a list
+      # rather than the whole system profile so that a service does not quietly
+      # depend on whatever the operator happens to have installed.
+      path = with pkgs; [ bash coreutils procps util-linux ];
 
       serviceConfig = {
         Type = "simple";

--- a/monitor/nix/package.nix
+++ b/monitor/nix/package.nix
@@ -1,0 +1,99 @@
+# The monitor agent, built from this repository.
+#
+# Two builds, because the agent is two things in one directory: a Rust binary
+# and the panel it serves. `server.rs` reads `frontend/dist` relative to its
+# working directory, so the panel has to be somewhere the module can link to —
+# hence `share/server-box-monitor/frontend`, and hence a `frontend` symlink in
+# the state directory rather than a copy.
+#
+# ## The two hashes, and why only one of them is here
+#
+# `cargoLock.lockFile` points at the workspace lock, so Cargo's side needs no
+# vendor hash at all — a guessed or stale one is a class of breakage this
+# avoids entirely.
+#
+# npm has no equivalent, so `npmDepsHash` has to be a hash of the fetched tree.
+# Get it with, from the repository root:
+#
+#     nix run nixpkgs#prefetch-npm-deps -- monitor/frontend/package-lock.json
+#
+# and paste the result below. It changes whenever that lock file does.
+{ lib
+, stdenv
+, rustPlatform
+, buildNpmPackage
+, pkg-config
+, sqlite
+, nix-update-script
+}:
+
+let
+  # The monorepo root: `monitor` is a workspace member, and the crate it
+  # depends on (`crates/sbm_parser`) is a sibling, so the source cannot be
+  # `monitor/` alone.
+  src = lib.cleanSource ../..;
+
+  panel = buildNpmPackage {
+    pname = "server-box-monitor-panel";
+    version = "0-unstable";
+    inherit src;
+
+    sourceRoot = "source/monitor/frontend";
+
+    # Computed with the command at the top of this file, against
+    # monitor/frontend/package-lock.json as of 2026-08-23.
+    npmDepsHash = "sha256-6BtSAJfCCrxoRHbySnlPHS5cxnjsbVWgqxhAoGkw19M=";
+
+    # `@serverbox/webui` is a `file:` dependency, so installing here only
+    # symlinks it and its own devDependencies are never fetched. The package's
+    # `prebuild` script does that install; it is repeated here because
+    # buildNpmPackage runs `npm run build` directly.
+    preBuild = ''
+      npm install --prefix ../../packages/webui
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out
+      cp -r dist $out/dist
+      runHook postInstall
+    '';
+  };
+in
+rustPlatform.buildRustPackage {
+  pname = "server-box-monitor";
+  version = "0-unstable";
+  inherit src;
+
+  cargoLock.lockFile = ../../Cargo.lock;
+
+  buildAndTestSubdir = "monitor";
+
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ sqlite ];
+
+  # sqlx's macros read `monitor/.sqlx` rather than a live database, which is
+  # what makes an offline build possible at all.
+  SQLX_OFFLINE = "true";
+
+  # The tests want a database and a network. Left off rather than patched
+  # around: `cargo test --workspace` on a developer's machine is where they
+  # belong, and a package that pretends to run them is worse than one that
+  # says it does not.
+  doCheck = false;
+
+  postInstall = ''
+    mkdir -p $out/share/server-box-monitor
+    ln -s ${panel}/dist $out/share/server-box-monitor/frontend
+  '';
+
+  passthru.updateScript = nix-update-script { };
+
+  meta = with lib; {
+    description = "Server-side monitoring agent for ServerBox";
+    homepage = "https://github.com/lollipopkit/flutter_server_box";
+    license = licenses.agpl3Only;
+    mainProgram = "server_box_monitor";
+    platforms = platforms.linux;
+  };
+}

--- a/monitor/nix/package.nix
+++ b/monitor/nix/package.nix
@@ -83,6 +83,18 @@ let
 
     nativeBuildInputs = [ nodejs npmHooks.npmConfigHook ];
 
+    # `npm run build` otherwise runs the panel's own `prebuild`, `npm install
+    # --prefix ../../packages/webui`, immediately after the offline install
+    # below has already produced that directory. Measured in the sandbox it
+    # reports "up to date" and does not fail, since `npm ci` has already written
+    # the tree the lock file describes — so this flag is about not depending on
+    # npm reaching that conclusion, with no registry to fall back on the day it
+    # does not. `--ignore-scripts` on `npm run` drops only `prebuild`/
+    # `postbuild`; `build` itself still runs, and the `npm run typesafe-i18n`
+    # inside it inherits the flag through `npm_config_ignore_scripts` and has no
+    # pre/post script of its own.
+    npmBuildFlags = [ "--ignore-scripts" ];
+
     # Offline, from the cache above, standing in for the `prebuild` script.
     preBuild = ''
       # Writable first: the source arrives from the store, and buildNpmPackage

--- a/monitor/nix/package.nix
+++ b/monitor/nix/package.nix
@@ -3,25 +3,48 @@
 # Two builds, because the agent is two things in one directory: a Rust binary
 # and the panel it serves. `server.rs` reads `frontend/dist` relative to its
 # working directory, so the panel has to be somewhere the module can link to —
-# hence `share/server-box-monitor/frontend`, and hence a `frontend` symlink in
-# the state directory rather than a copy.
+# hence `share/server-box-monitor/frontend/dist`, and hence a `frontend`
+# symlink in the state directory rather than a copy.
 #
-# ## The two hashes, and why only one of them is here
+# ## The hashes
 #
 # `cargoLock.lockFile` points at the workspace lock, so Cargo's side needs no
 # vendor hash at all — a guessed or stale one is a class of breakage this
 # avoids entirely.
 #
-# npm has no equivalent, so `npmDepsHash` has to be a hash of the fetched tree.
-# Get it with, from the repository root:
+# npm has no equivalent, and there are *two* lock files: the panel's, and
+# `packages/webui`'s, which the panel depends on through a `file:` link. Get
+# either with, from the repository root:
 #
 #     nix run nixpkgs#prefetch-npm-deps -- monitor/frontend/package-lock.json
+#     nix run nixpkgs#prefetch-npm-deps -- packages/webui/package-lock.json
 #
-# and paste the result below. It changes whenever that lock file does.
+# Each changes whenever its own lock file does.
+#
+# ## What has actually been built, and what has not
+#
+# Measured on NixOS 25.11 aarch64, 2026-08-23:
+#
+# - The panel half **builds**. Both npm dependency sets install offline and
+#   `npm run build` completes, which is what the `chmod -R u+w` below and the
+#   second `fetchNpmDeps` were added for.
+# - The Rust half **needs a newer rustc than nixpkgs 25.11 ships**. That
+#   channel has 1.91.1; `sqlx` asks for 1.94 and `sysinfo` for 1.95, so cargo
+#   refuses before compiling anything. nixpkgs-unstable has 1.97.1 — the same
+#   version `crates/sbm_ffi/rust-toolchain.toml` pins — and is accepted.
+# - Against unstable the Rust build then proceeds and was **not seen to
+#   finish**: the machine it ran on exhausted its disk while compiling
+#   `libsqlite3-sys`. That is a property of that machine, not of this file, and
+#   it means `postInstall` below has never run.
+#
+# So: not a package anyone should assume works. It is as far as one afternoon
+# on one VM got, written down rather than rounded up.
 { lib
-, stdenv
 , rustPlatform
 , buildNpmPackage
+, fetchNpmDeps
+, npmHooks
+, nodejs
 , pkg-config
 , sqlite
 , nix-update-script
@@ -33,6 +56,22 @@ let
   # `monitor/` alone.
   src = lib.cleanSource ../..;
 
+  # `@serverbox/webui` is a `file:` dependency of the panel, so an install in
+  # `monitor/frontend` only symlinks it and fetches none of its own packages.
+  # The panel needs both halves: `clsx` / `tailwind-merge` /
+  # `tailwind-variants` because vite bundles webui's source, and `svelte` /
+  # `typescript` because `npm run build` runs `svelte-check` first.
+  #
+  # A second dependency set rather than one, because `npmDepsHash` below hashes
+  # exactly one lock file and this is a different one. The repository solves the
+  # same problem with a `prebuild` script that runs `npm install` — which cannot
+  # work here, since a Nix build has no network.
+  webuiDeps = fetchNpmDeps {
+    name = "serverbox-webui-npm-deps";
+    src = ../../packages/webui;
+    hash = "sha256-XkjHnnOw/WVci9Z8zpKtK42TefzdbEmmlbewoCpFUlg=";
+  };
+
   panel = buildNpmPackage {
     pname = "server-box-monitor-panel";
     version = "0-unstable";
@@ -40,16 +79,19 @@ let
 
     sourceRoot = "source/monitor/frontend";
 
-    # Computed with the command at the top of this file, against
-    # monitor/frontend/package-lock.json as of 2026-08-23.
     npmDepsHash = "sha256-6BtSAJfCCrxoRHbySnlPHS5cxnjsbVWgqxhAoGkw19M=";
 
-    # `@serverbox/webui` is a `file:` dependency, so installing here only
-    # symlinks it and its own devDependencies are never fetched. The package's
-    # `prebuild` script does that install; it is repeated here because
-    # buildNpmPackage runs `npm run build` directly.
+    nativeBuildInputs = [ nodejs npmHooks.npmConfigHook ];
+
+    # Offline, from the cache above, standing in for the `prebuild` script.
     preBuild = ''
-      npm install --prefix ../../packages/webui
+      # Writable first: the source arrives from the store, and buildNpmPackage
+      # only makes `sourceRoot` writable — a sibling directory is still
+      # r-xr-xr-x, so `npm ci` fails on `mkdir node_modules` with EACCES.
+      chmod -R u+w ../../packages/webui
+      pushd ../../packages/webui
+      npm ci --offline --no-audit --no-fund --cache=${webuiDeps} --nodedir=${nodejs}
+      popd
     '';
 
     installPhase = ''
@@ -82,9 +124,14 @@ rustPlatform.buildRustPackage {
   # says it does not.
   doCheck = false;
 
+  # `frontend/dist`, not `frontend` — `server.rs` reads `frontend/dist`
+  # relative to its working directory, and the module links `frontend` from the
+  # state directory to what is created here. Linking the panel's output *as*
+  # `frontend` puts the files one level too high, and every request 404s with
+  # the panel sitting right there.
   postInstall = ''
-    mkdir -p $out/share/server-box-monitor
-    ln -s ${panel}/dist $out/share/server-box-monitor/frontend
+    mkdir -p $out/share/server-box-monitor/frontend
+    ln -s ${panel}/dist $out/share/server-box-monitor/frontend/dist
   '';
 
   passthru.updateScript = nix-update-script { };


### PR DESCRIPTION
Two unrelated commits that happened to land together; the second is docs only.

## `fix(monitor)` — the agent collected nothing on NixOS

Found by installing it, not by reading paths. Built an aarch64 static musl
binary and installed it on NixOS 25.11: the service came up, the API answered
healthy, the database migrated — and **every collection cycle failed**.

```
ERROR ...monitoring::service: Failed to collect metrics:
  Status script error: No such file or directory (os error 2)
```

A systemd unit that sets no PATH gets systemd's compiled-in one, and that is a
per-distribution value. On most distributions it is the FHS list and this
change would be a no-op. NixOS builds systemd with its own store path, so the
service saw exactly one directory:

```
PATH=/nix/store/…-systemd-258.7/bin/
```

`sh` was not on PATH at all. It surfaces as a running agent with an empty
panel, which is the worst shape a failure can take.

Worth noting that `/bin/sh` *does* exist on NixOS — spelling the interpreter
absolutely would have started the script and then failed inside it on the
first `cat`. PATH is the level this belongs at, because the agent shells out
to whatever the command manifest names.

Measured after the fix: a clean install goes from a failure every cycle to
none, `status.sh` is written, and an alert rule fires on real data
(`cpu 78.08% (threshold: >=77%)`). Debian (systemd) and Alpine (OpenRC) were
reinstalled from the same package to check nothing moved — both still install
and collect.

### `--system`, and `monitor/nix/`

`--system` cannot work on NixOS at all: `/etc/systemd/system` is a read-only
symlink into the store, for root as much as anyone. It now says so *before*
trying, rather than surfacing a bare `Read-only file system` from the unit
write, and points at the module added here — a system service on this
distribution is `configuration.nix`'s job and there is no imperative
equivalent to offer.

The module carries a state directory and links the panel into it, because the
agent resolves `config.toml`, the SQLite file and `frontend/dist` relative to
its working directory and *writes* the first two. So that directory can be
neither the store nor a bare empty one. Migrations need nothing —
`sqlx::migrate!` embeds them at compile time.

Both `.nix` files are parse-checked and `npmDepsHash` is computed rather than
guessed. Neither has been through a real `nix build`; that is stated in the
commit message rather than implied away.

### Also

SSH discovery ran `/usr/bin/avahi-browse` by absolute path while calling `ip`
by name two lines above. An absolute `/usr/bin` is a guess about the
filesystem rather than about the tool, and it is wrong on NixOS, where only
`/bin/sh` and `/usr/bin/env` sit at an FHS path.

## `docs` — the onboarding skill

`.claude/skills/serverbox-onboarding/`: orientation for installing and using
the app, deploying the monitor agent, bootstrapping the Flutter + Rust + Node
environment, and the handful of facts that explain most "why can't I do X"
questions — chiefly that a server is reached over SSH **or** a monitor agent,
never both.

## Checks

- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- `monitor/frontend`: `eslint --max-warnings 0` clean, `svelte-check` 0 errors 0 warnings
- `flutter analyze lib test integration_test` — clean
- `website` build, `docs` locale parity — pass

Draft: the monitor half is verified on three distributions, but no
`monitor-v*` release exists yet, so the path users actually take
(`install.sh install`) is still untested end to end. See TODOS.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NixOS support for installing and running the ServerBox Monitor as a managed system service.
  * Added configurable service options, firewall handling, packaging, and frontend asset integration.
  * Added environment diagnostics to identify missing tools, dependencies, and setup issues.

* **Bug Fixes**
  * Improved Linux SSH discovery across systems where `avahi-browse` is installed outside standard paths.
  * Improved command discovery in generated Monitor services.
  * Added clearer handling for unsupported system-mode installation on NixOS.

* **Documentation**
  * Added comprehensive onboarding, installation, development, deployment, troubleshooting, and architecture guidance.
  * Documented current NixOS installation validation findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->