### PR TITLE
feat: label screenshots with the app name, and cover the app switcher card

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,9 +5,14 @@
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />
+    <!-- `tools:replace` because camera_android_camerax declares this same
+         permission with maxSdkVersion 28 and the merger refuses to pick. 32 is
+         this app's own answer: it writes downloads and SFTP transfers, which
+         scoped storage only takes over at 33. -->
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        android:maxSdkVersion="32" />
+        android:maxSdkVersion="32"
+        tools:replace="android:maxSdkVersion" />
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />

--- a/android/app/src/main/kotlin/tech/lolli/toolbox/MainActivity.kt
+++ b/android/app/src/main/kotlin/tech/lolli/toolbox/MainActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
+import android.view.WindowManager
 import android.Manifest
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -50,6 +51,58 @@ class MainActivity: FlutterFragmentActivity() {
 
     private companion object {
         const val ARG_DISABLE_IMPELLER = "--enable-impeller=false"
+        const val PRIVACY_PREFS = "privacy_cover"
+        const val KEY_PRIVACY_COVER = "enabled"
+    }
+
+    // --- Privacy cover ------------------------------------------------------
+    //
+    // FLAG_SECURE rather than a view laid over the content: the recents
+    // thumbnail is captured by the system around onPause, and anything that has
+    // to render a frame first may not be up in time. The flag is applied by the
+    // window compositor, so there is no race to lose.
+    //
+    // This is not the same thing the iOS side does. There a blur really covers
+    // the pixels; here the running UI is untouched and only the recents
+    // thumbnail and screenshots are blocked. Flutter renders into a SurfaceView,
+    // whose contents live on a separate surface that RenderEffect does not
+    // reach, so an in-app blur would mean PixelCopy plus an async round trip —
+    // exactly the race this avoids.
+
+    private val privacyPrefs by lazy {
+        getSharedPreferences(PRIVACY_PREFS, Context.MODE_PRIVATE)
+    }
+
+    /// Set from Dart while the biometric lock is pending, so that coming back to
+    /// the foreground does not clear the flag before the lock screen is up.
+    private var privacyLocked = false
+    private var isForeground = false
+
+    private var privacyCoverEnabled: Boolean
+        get() = privacyPrefs.getBoolean(KEY_PRIVACY_COVER, false)
+        set(value) = privacyPrefs.edit().putBoolean(KEY_PRIVACY_COVER, value).apply()
+
+    private fun applyPrivacyCover(on: Boolean) {
+        if (on) {
+            window.setFlags(
+                WindowManager.LayoutParams.FLAG_SECURE,
+                WindowManager.LayoutParams.FLAG_SECURE,
+            )
+        } else {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        isForeground = false
+        if (privacyCoverEnabled) applyPrivacyCover(true)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        isForeground = true
+        if (!privacyLocked) applyPrivacyCover(false)
     }
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
@@ -72,6 +125,18 @@ class MainActivity: FlutterFragmentActivity() {
                     }
                     "isServiceRunning" -> {
                         result.success(ForegroundService.isRunning)
+                    }
+                    "setPrivacyBlur" -> {
+                        privacyCoverEnabled = method.arguments as? Boolean ?: false
+                        if (!privacyCoverEnabled) applyPrivacyCover(false)
+                        result.success(null)
+                    }
+                    "setPrivacyBlurLocked" -> {
+                        privacyLocked = method.arguments as? Boolean ?: false
+                        // Only while frontmost: clearing it in the background
+                        // would undo the cover on the recents thumbnail itself.
+                        if (!privacyLocked && isForeground) applyPrivacyCover(false)
+                        result.success(null)
                     }
                     "startService" -> {
                         try {

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		4A2DCD6B2E4B127100CF68B7 /* LiveActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2DCD692E4B127100CF68B7 /* LiveActivityManager.swift */; };
+		4A2DCD712E4B127100CF68B7 /* DynamicIslandBrand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2DCD722E4B127100CF68B7 /* DynamicIslandBrand.swift */; };
+		4A2DCD732E4B127100CF68B7 /* PrivacyBlur.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2DCD742E4B127100CF68B7 /* PrivacyBlur.swift */; };
 		4A2DCD6C2E4B127100CF68B7 /* TerminalLiveActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2DCD6A2E4B127100CF68B7 /* TerminalLiveActivityAttributes.swift */; };
 		4A2DCD6F2E4B128100CF68B7 /* TerminalLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2DCD6D2E4B128100CF68B7 /* TerminalLiveActivity.swift */; };
 		4A2DCD702E4B128100CF68B7 /* TerminalLiveActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2DCD6E2E4B128100CF68B7 /* TerminalLiveActivityAttributes.swift */; };
@@ -126,6 +128,8 @@
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		4A2DCD692E4B127100CF68B7 /* LiveActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityManager.swift; sourceTree = "<group>"; };
+		4A2DCD722E4B127100CF68B7 /* DynamicIslandBrand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicIslandBrand.swift; sourceTree = "<group>"; };
+		4A2DCD742E4B127100CF68B7 /* PrivacyBlur.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyBlur.swift; sourceTree = "<group>"; };
 		4A2DCD6A2E4B127100CF68B7 /* TerminalLiveActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalLiveActivityAttributes.swift; sourceTree = "<group>"; };
 		4A2DCD6D2E4B128100CF68B7 /* TerminalLiveActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalLiveActivity.swift; sourceTree = "<group>"; };
 		4A2DCD6E2E4B128100CF68B7 /* TerminalLiveActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalLiveActivityAttributes.swift; sourceTree = "<group>"; };
@@ -317,6 +321,8 @@
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				4A2DCD692E4B127100CF68B7 /* LiveActivityManager.swift */,
 				4A2DCD6A2E4B127100CF68B7 /* TerminalLiveActivityAttributes.swift */,
+				4A2DCD722E4B127100CF68B7 /* DynamicIslandBrand.swift */,
+				4A2DCD742E4B127100CF68B7 /* PrivacyBlur.swift */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				E3AE8AE92AB601DB000A6459 /* Utils.swift */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
@@ -639,6 +645,8 @@
 				5B1A0002200001000000ISH0 /* sbm_ish.c in Sources */,
 				4A2DCD6B2E4B127100CF68B7 /* LiveActivityManager.swift in Sources */,
 				4A2DCD6C2E4B127100CF68B7 /* TerminalLiveActivityAttributes.swift in Sources */,
+				4A2DCD712E4B127100CF68B7 /* DynamicIslandBrand.swift in Sources */,
+				4A2DCD732E4B127100CF68B7 /* PrivacyBlur.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -21,7 +21,7 @@ import ActivityKit
         ) { note in
             guard let scene = note.object as? UIWindowScene else { return }
             DynamicIslandBrand.shared.install(in: scene)
-            PrivacyBlur.shared.hide()
+            PrivacyBlur.shared.hideIfUnlocked()
         }
 
         // `willDeactivate` and not `didEnterBackground`: the switcher snapshot
@@ -107,6 +107,9 @@ import ActivityKit
                 result(nil)
             case "setPrivacyBlur":
                 PrivacyBlur.shared.isEnabled = call.arguments as? Bool ?? false
+                result(nil)
+            case "setPrivacyBlurLocked":
+                PrivacyBlur.shared.setLocked(call.arguments as? Bool ?? false)
                 result(nil)
             case "setAccessoryWidgetUrl":
                 // The accessory families can't carry the intent configuration

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -9,6 +9,34 @@ import ActivityKit
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
+        // No scene is connected yet at this point, and the scene delegate is
+        // `FlutterSceneDelegate` (see UIApplicationSceneManifest), so there is
+        // no subclass of ours to hook. Observing is what gets a UIWindowScene to
+        // work with. Both fire again on every foreground, and both calls are
+        // idempotent.
+        NotificationCenter.default.addObserver(
+            forName: UIScene.didActivateNotification,
+            object: nil,
+            queue: .main
+        ) { note in
+            guard let scene = note.object as? UIWindowScene else { return }
+            DynamicIslandBrand.shared.install(in: scene)
+            PrivacyBlur.shared.hide()
+        }
+
+        // `willDeactivate` and not `didEnterBackground`: the switcher snapshot
+        // is taken between the two, and by the latter it is already on file.
+        // The cost is that a pulled-down notification centre or a system alert
+        // also blurs for as long as it is up.
+        NotificationCenter.default.addObserver(
+            forName: UIScene.willDeactivateNotification,
+            object: nil,
+            queue: .main
+        ) { note in
+            guard let scene = note.object as? UIWindowScene else { return }
+            PrivacyBlur.shared.show(in: scene)
+        }
+
         return super.application(application, didFinishLaunchingWithOptions: launchOptions)
     }
 
@@ -70,6 +98,16 @@ import ActivityKit
                 } else {
                     result(nil)
                 }
+            case "setIslandBrandColors":
+                if let args = call.arguments as? [String: Any],
+                   let bg = args["bg"] as? Int,
+                   let fg = args["fg"] as? Int {
+                    DynamicIslandBrand.shared.setColors(background: bg, foreground: fg)
+                }
+                result(nil)
+            case "setPrivacyBlur":
+                PrivacyBlur.shared.isEnabled = call.arguments as? Bool ?? false
+                result(nil)
             case "setAccessoryWidgetUrl":
                 // The accessory families can't carry the intent configuration
                 // the home-screen ones use, so they read this key instead —

--- a/ios/Runner/DynamicIslandBrand.swift
+++ b/ios/Runner/DynamicIslandBrand.swift
@@ -1,0 +1,191 @@
+//
+//  DynamicIslandBrand.swift
+//  Runner
+//
+
+import UIKit
+
+/// Draws the app's name in the strip of screen the Dynamic Island covers.
+///
+/// The pill is composited by the system above every app window, so this is
+/// invisible while the phone is in use. A screenshot captures the app's own
+/// layers and not that overlay, so the name is what lands in the image — which
+/// is how an app labels the screenshots its users share.
+///
+/// Portrait Dynamic Island devices only. In landscape the pill moves to the
+/// long edge, and a notch is both narrower and a different shape, so on either
+/// the label would sit in plain view instead of behind something.
+final class DynamicIslandBrand {
+    static let shared = DynamicIslandBrand()
+
+    private enum DefaultsKey {
+        static let background = "island_brand_bg"
+        static let foreground = "island_brand_fg"
+    }
+
+    private var window: UIWindow?
+    private weak var controller: BrandViewController?
+
+    private init() {}
+
+    /// Idempotent per scene. `UIApplicationSupportsMultipleScenes` is false so
+    /// there is only ever one, but a scene can disconnect and reconnect, and
+    /// the window has to belong to whichever one is live now.
+    func install(in scene: UIWindowScene) {
+        if let window, window.windowScene === scene { return }
+
+        let controller = BrandViewController()
+        let window = PassthroughWindow(windowScene: scene)
+        // Above Flutter's window, below everything the system puts up: an alert
+        // or a share sheet that dims the status bar area should dim this too.
+        window.windowLevel = .normal + 1
+        window.backgroundColor = .clear
+        window.isUserInteractionEnabled = false
+        window.rootViewController = controller
+        // Deliberately not `makeKeyAndVisible`. iOS asks the *key* window's root
+        // view controller for the status bar style and the supported
+        // orientations, and neither answer should come from here.
+        window.isHidden = false
+
+        self.window = window
+        self.controller = controller
+        applyStoredColors()
+        UserDefaults.standard.set("\(window.frame) lvl=\(window.windowLevel.rawValue) hidden=\(window.isHidden)", forKey: "dbg_install")
+    }
+
+    /// Take the app's current theme colors, as ARGB.
+    ///
+    /// Pushed from Dart on every theme change, and persisted, because a cold
+    /// launch draws this before any Dart code has run.
+    func setColors(background: Int, foreground: Int) {
+        let defaults = UserDefaults.standard
+        defaults.set(background, forKey: DefaultsKey.background)
+        defaults.set(foreground, forKey: DefaultsKey.foreground)
+        applyStoredColors()
+    }
+
+    private func applyStoredColors() {
+        let defaults = UserDefaults.standard
+        guard
+            defaults.object(forKey: DefaultsKey.background) != nil,
+            defaults.object(forKey: DefaultsKey.foreground) != nil
+        else { return }  // Never pushed: the controller's own defaults stand.
+
+        controller?.apply(
+            background: UIColor(argb: defaults.integer(forKey: DefaultsKey.background)),
+            foreground: UIColor(argb: defaults.integer(forKey: DefaultsKey.foreground))
+        )
+    }
+}
+
+/// Lets every touch through to the window below, including the ones landing on
+/// the label itself.
+private final class PassthroughWindow: UIWindow {
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? { nil }
+}
+
+private final class BrandViewController: UIViewController {
+    /// Portrait geometry of the pill, in points. Apple publishes no API for it;
+    /// these are community measurements, cross-checked against safe-area insets.
+    private enum Island {
+        /// Unchanged across every iPhone that has shipped one, 14 Pro onward.
+        static let width: CGFloat = 126
+        static let height: CGFloat = 37.33
+
+        /// Gap between the bottom of the pill and the bottom of the top safe
+        /// area inset. The pill's *top* offset is not a constant — 14 Pro
+        /// through 16 put it at y≈11 under a 59pt inset, 16 Pro and 17 at y≈14
+        /// under 62pt, iPhone Air lower still — but all of them leave this much
+        /// below it. Anchoring to the bottom is what lets one number cover
+        /// models that do not exist yet, where a hardcoded y or a table of
+        /// device identifiers would be wrong on the next one.
+        static let bottomMargin: CGFloat = 11.15
+
+        /// Portrait `safeAreaInsets.top` is at least 59 on a Dynamic Island
+        /// device and 47 or 48 on a notched one; landscape reports 0. One test
+        /// excludes both — a notch is wider, shorter, and flush with the top
+        /// edge, so the pill's geometry does not describe it.
+        static let minSafeAreaTop: CGFloat = 55
+    }
+
+    /// The drawn badge sits well inside the island rather than filling it: a
+    /// block the full size of the pill reads as a redaction bar in a
+    /// screenshot, and the margin also absorbs the ~0.5pt the `bottomMargin`
+    /// derivation is off by on known models.
+    private enum Badge {
+        static let height: CGFloat = 22
+        static let textPadding: CGFloat = 9
+        static let fontSize: CGFloat = 12
+        /// Ceiling on the width, so a long app name cannot reach the edges of
+        /// the island. 4pt clear on each side at the widest.
+        static let maxWidth: CGFloat = Island.width - 8
+    }
+
+    private let badge = UIView()
+    private let label = UILabel()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .clear
+        view.isUserInteractionEnabled = false
+
+        badge.layer.cornerRadius = Badge.height / 2
+        badge.clipsToBounds = true
+        view.addSubview(badge)
+
+        label.text = Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String
+            ?? Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String
+        label.font = .systemFont(ofSize: Badge.fontSize, weight: .semibold)
+        label.textAlignment = .center
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = 0.7
+        badge.addSubview(label)
+
+        // Stands in until Dart pushes the theme, which it does at every launch.
+        apply(background: .black, foreground: .white)
+    }
+
+    func apply(background: UIColor, foreground: UIColor) {
+        badge.backgroundColor = background
+        label.textColor = foreground
+    }
+
+    override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+
+        let safeTop = view.safeAreaInsets.top
+        UserDefaults.standard.set("safeTop=\(safeTop) bounds=\(view.bounds)", forKey: "dbg_layout")
+        let hasIsland = safeTop >= Island.minSafeAreaTop
+        badge.isHidden = !hasIsland
+        guard hasIsland else { return }
+
+        let islandTop = safeTop - Island.bottomMargin - Island.height
+        let text = (label.text ?? "") as NSString
+        let textWidth = text.size(withAttributes: [.font: label.font as Any]).width
+        let width = min(Badge.maxWidth, ceil(textWidth) + 2 * Badge.textPadding)
+
+        badge.frame = CGRect(
+            x: ((view.bounds.width - width) / 2).rounded(),
+            y: (islandTop + (Island.height - Badge.height) / 2).rounded(),
+            width: width,
+            height: Badge.height
+        )
+        label.frame = badge.bounds.insetBy(dx: Badge.textPadding, dy: 0)
+    }
+}
+
+private extension UIColor {
+    /// Flutter hands colors over as ARGB, which is what `Color.toARGB32()`
+    /// produces. Arrives as an `Int` because 0xFF000000 and up do not fit an
+    /// Int32, so the codec widens it.
+    convenience init(argb: Int) {
+        let v = UInt32(truncatingIfNeeded: argb)
+        self.init(
+            red: CGFloat((v >> 16) & 0xFF) / 255,
+            green: CGFloat((v >> 8) & 0xFF) / 255,
+            blue: CGFloat(v & 0xFF) / 255,
+            alpha: CGFloat((v >> 24) & 0xFF) / 255
+        )
+    }
+}

--- a/ios/Runner/DynamicIslandBrand.swift
+++ b/ios/Runner/DynamicIslandBrand.swift
@@ -50,7 +50,6 @@ final class DynamicIslandBrand {
         self.window = window
         self.controller = controller
         applyStoredColors()
-        UserDefaults.standard.set("\(window.frame) lvl=\(window.windowLevel.rawValue) hidden=\(window.isHidden)", forKey: "dbg_install")
     }
 
     /// Take the app's current theme colors, as ARGB.
@@ -155,7 +154,6 @@ private final class BrandViewController: UIViewController {
         super.viewWillLayoutSubviews()
 
         let safeTop = view.safeAreaInsets.top
-        UserDefaults.standard.set("safeTop=\(safeTop) bounds=\(view.bounds)", forKey: "dbg_layout")
         let hasIsland = safeTop >= Island.minSafeAreaTop
         badge.isHidden = !hasIsland
         guard hasIsland else { return }

--- a/ios/Runner/PrivacyBlur.swift
+++ b/ios/Runner/PrivacyBlur.swift
@@ -16,7 +16,7 @@ import UIKit
 /// the point. The switcher card exposes the Dynamic Island strip the same way a
 /// screenshot does, so the app name stays readable above the blur.
 ///
-/// Off by default; the app's iOS settings page turns it on.
+/// Off by default; the app's settings page turns it on.
 final class PrivacyBlur {
     static let shared = PrivacyBlur()
 
@@ -31,6 +31,19 @@ final class PrivacyBlur {
         set { UserDefaults.standard.set(newValue, forKey: Self.defaultsKey) }
     }
 
+    /// Whether the content must stay covered even once the app is frontmost,
+    /// because Dart has not yet decided whether a biometric lock is coming.
+    ///
+    /// Without this the blur would come off on `didActivate`, and the real UI
+    /// would be on screen for the frames it takes Flutter to hear about the
+    /// lifecycle change at all.
+    ///
+    /// It is released *before* the lock screen is pushed, not after it is
+    /// dismissed. That screen is a Flutter route, drawn inside the window this
+    /// view is layered on top of, so holding the cover through it would hide
+    /// the very thing it was being held for.
+    private(set) var isLocked = false
+
     private weak var blur: UIVisualEffectView?
 
     private init() {}
@@ -38,9 +51,15 @@ final class PrivacyBlur {
     func show(in scene: UIWindowScene) {
         guard isEnabled, blur == nil, let host = Self.hostWindow(in: scene) else { return }
 
-        let view = UIVisualEffectView(effect: UIBlurEffect(style: .systemMaterial))
+        // `.regular` rather than one of the `.system*Material` styles: those
+        // carry a tint that reads as a flat panel, and the point here is that
+        // the app's own layout stays recognisable while its text does not.
+        let view = UIVisualEffectView(effect: UIBlurEffect(style: .regular))
         view.frame = host.bounds
         view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        // On by default on this class, and it would eat every tap meant for the
+        // UI underneath for as long as the cover is up.
+        view.isUserInteractionEnabled = false
         host.addSubview(view)
         // Synchronous, and with no animation: iOS takes the switcher snapshot
         // as soon as this notification is done being delivered, and a fade
@@ -48,6 +67,22 @@ final class PrivacyBlur {
         host.layoutIfNeeded()
 
         blur = view
+    }
+
+    /// Called when the app comes forward. Keeps the cover on if Dart has said
+    /// the app is still locked; `setLocked(false)` is then what takes it off.
+    func hideIfUnlocked() {
+        guard !isLocked else { return }
+        hide()
+    }
+
+    func setLocked(_ locked: Bool) {
+        isLocked = locked
+        // Only unlocking while frontmost may remove it — unlocking in the
+        // background would strip the cover from the switcher card itself.
+        if !locked, UIApplication.shared.applicationState == .active {
+            hide()
+        }
     }
 
     func hide() {

--- a/ios/Runner/PrivacyBlur.swift
+++ b/ios/Runner/PrivacyBlur.swift
@@ -1,0 +1,63 @@
+//
+//  PrivacyBlur.swift
+//  Runner
+//
+
+import UIKit
+
+/// Blurs the app while it is off screen, so the card iOS shows in the app
+/// switcher does not leave server names, terminal output or file paths legible
+/// to whoever is looking at the phone.
+///
+/// The blur goes into the Flutter window rather than a window of its own: a
+/// `UIVisualEffectView` samples what is behind it, and behind it within the
+/// same window is exactly the content that has to be hidden. That also leaves
+/// `DynamicIslandBrand`'s overlay — a higher window level — untouched, which is
+/// the point. The switcher card exposes the Dynamic Island strip the same way a
+/// screenshot does, so the app name stays readable above the blur.
+///
+/// Off by default; the app's iOS settings page turns it on.
+final class PrivacyBlur {
+    static let shared = PrivacyBlur()
+
+    private static let defaultsKey = "privacy_blur_on_background"
+
+    /// Mirrored into `UserDefaults` because the first thing a user does after a
+    /// cold launch may well be to switch away, and Dart has no way to have
+    /// pushed anything by then. The setting store is still the source of truth
+    /// and re-pushes on every launch.
+    var isEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: Self.defaultsKey) }
+        set { UserDefaults.standard.set(newValue, forKey: Self.defaultsKey) }
+    }
+
+    private weak var blur: UIVisualEffectView?
+
+    private init() {}
+
+    func show(in scene: UIWindowScene) {
+        guard isEnabled, blur == nil, let host = Self.hostWindow(in: scene) else { return }
+
+        let view = UIVisualEffectView(effect: UIBlurEffect(style: .systemMaterial))
+        view.frame = host.bounds
+        view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        host.addSubview(view)
+        // Synchronous, and with no animation: iOS takes the switcher snapshot
+        // as soon as this notification is done being delivered, and a fade
+        // would be caught part way through.
+        host.layoutIfNeeded()
+
+        blur = view
+    }
+
+    func hide() {
+        blur?.removeFromSuperview()
+        blur = nil
+    }
+
+    /// Flutter's window: the one at `.normal`, as opposed to the overlay
+    /// `DynamicIslandBrand` installs above it.
+    private static func hostWindow(in scene: UIWindowScene) -> UIWindow? {
+        scene.windows.first { $0.windowLevel == .normal }
+    }
+}

--- a/ios/WatchApp/PhoneConnMgr.swift
+++ b/ios/WatchApp/PhoneConnMgr.swift
@@ -128,7 +128,12 @@ final class PhoneConnMgr: NSObject, ObservableObject, WCSessionDelegate {
         DispatchQueue.main.async {
             // A phone that predates the stamp sends none; there is nothing to
             // order those by, so they apply as they always did.
-            if stamp != 0 && stamp < self.appliedAt { return }
+            //
+            // Equal counts as seen. The phone's revision strictly increases per
+            // snapshot, so the same one arriving twice is the same payload
+            // reaching here by two of the routes above, and applying it again
+            // only costs a widget reload.
+            if stamp != 0 && stamp <= self.appliedAt { return }
             self.appliedAt = max(self.appliedAt, stamp)
 
             for (id, token) in parsed.tokens {

--- a/ios/WatchApp/PhoneConnMgr.swift
+++ b/ios/WatchApp/PhoneConnMgr.swift
@@ -107,12 +107,30 @@ final class PhoneConnMgr: NSObject, ObservableObject, WCSessionDelegate {
 
     // MARK: - Payload
 
+    /// The `ts` of the newest payload applied.
+    ///
+    /// Only ever touched on the main queue, which is also where it is compared.
+    private var appliedAt: Int64 = 0
+
     /// Applies a payload from the phone, ignoring one that carries no server
-    /// list at all (an empty reply, or a message about something else).
+    /// list at all (an empty reply, or a message about something else), and one
+    /// that has been overtaken.
+    ///
+    /// Nothing orders the three ways a payload arrives: a `userInfo` is queued
+    /// and delivered whenever it can be, the application context holds only the
+    /// latest, and a reply to `requestData` races both. An older one landing
+    /// last used to overwrite a newer selection, which then stood until the
+    /// phone next pushed.
     private func ingest(_ payload: [String: Any]) {
         guard let parsed = Self.parse(payload) else { return }
+        let stamp = (payload["ts"] as? NSNumber)?.int64Value ?? 0
 
         DispatchQueue.main.async {
+            // A phone that predates the stamp sends none; there is nothing to
+            // order those by, so they apply as they always did.
+            if stamp != 0 && stamp < self.appliedAt { return }
+            self.appliedAt = max(self.appliedAt, stamp)
+
             for (id, token) in parsed.tokens {
                 WatchStore.setToken(token, for: id)
             }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:dynamic_color/dynamic_color.dart';
@@ -6,6 +7,7 @@ import 'package:fl_lib/generated/l10n/lib_l10n.dart';
 import 'package:flutter/material.dart';
 import 'package:icons_plus/icons_plus.dart';
 import 'package:server_box/core/app_navigator.dart';
+import 'package:server_box/core/chan.dart';
 import 'package:server_box/core/extension/context/locale.dart';
 import 'package:server_box/data/res/build_data.dart';
 import 'package:server_box/data/res/store.dart';
@@ -115,6 +117,19 @@ class _MyAppState extends State<MyApp> {
     );
   }
 
+  /// Hand the theme to the app name drawn behind the Dynamic Island, which is
+  /// a native view and cannot read it. Deduplicated in [MethodChans].
+  void _syncIslandBrandColors(BuildContext ctx) {
+    if (!isIOS) return;
+    final scheme = Theme.of(ctx).colorScheme;
+    unawaited(
+      MethodChans.setIslandBrandColors(
+        scheme.primary.toARGB32(),
+        scheme.onPrimary.toARGB32(),
+      ),
+    );
+  }
+
   Widget _buildApp(
     BuildContext ctx, {
     required ThemeData light,
@@ -135,7 +150,13 @@ class _MyAppState extends State<MyApp> {
       navigatorKey: AppNavigator.key,
       // Outside the breakpoints builder: a toast is sized against the window,
       // not against the scaled layout the breakpoints hand to the pages.
-      builder: (ctx, child) => ToastHost(child: ResponsivePoints.builder(ctx, child)),
+      builder: (ctx, child) {
+        // Here rather than at launch: this `ctx` is below the theme, so it
+        // rebuilds when the seed color, the brightness or the system's dynamic
+        // color changes — each of which the native badge has to follow.
+        _syncIslandBrandColors(ctx);
+        return ToastHost(child: ResponsivePoints.builder(ctx, child));
+      },
       locale: locale,
       localizationsDelegates: const [
         LibLocalizations.delegate,

--- a/lib/core/chan.dart
+++ b/lib/core/chan.dart
@@ -59,6 +59,42 @@ abstract final class MethodChans {
     }
   }
 
+  /// Last pair pushed by [setIslandBrandColors], so that rebuilding the theme —
+  /// which happens on every `MaterialApp` build — does not cross the channel
+  /// each time.
+  static (int, int)? _islandBrandColors;
+
+  /// Colors for the app name drawn behind the Dynamic Island, as ARGB.
+  ///
+  /// Follows the theme rather than being fixed, so the badge in a screenshot
+  /// matches the app the screenshot is of.
+  static Future<void> setIslandBrandColors(int bg, int fg) async {
+    if (!isIOS) return;
+    if (_islandBrandColors == (bg, fg)) return;
+    _islandBrandColors = (bg, fg);
+    try {
+      await _channel.invokeMethod('setIslandBrandColors', {'bg': bg, 'fg': fg});
+    } catch (e, s) {
+      _islandBrandColors = null;
+      Loggers.app.warning('Failed to set island brand colors', e, s);
+    }
+  }
+
+  /// Tell the native side whether to blur the app once it leaves the
+  /// foreground, hiding its content in the app switcher.
+  ///
+  /// Pushed on change *and* at launch: the native side answers this from its
+  /// own `UserDefaults` copy, which a reinstall or a restored backup leaves
+  /// saying something different from the (synced) settings store.
+  static Future<void> setPrivacyBlur(bool enabled) async {
+    if (!isIOS) return;
+    try {
+      await _channel.invokeMethod('setPrivacyBlur', enabled);
+    } catch (e, s) {
+      Loggers.app.warning('Failed to set privacy blur', e, s);
+    }
+  }
+
   /// Re-derive the accessory widget's URL from the chosen server.
   ///
   /// Run at launch as well as on change: the App Group container goes away

--- a/lib/core/chan.dart
+++ b/lib/core/chan.dart
@@ -92,12 +92,19 @@ abstract final class MethodChans {
   /// Pushed on change *and* at launch: the native side answers this from its
   /// own persisted copy, which a reinstall or a restored backup leaves saying
   /// something different from the (synced) settings store.
-  static Future<void> setPrivacyBlur(bool enabled) async {
-    if (!isIOS && !isAndroid) return;
+  ///
+  /// Answers whether the native side took it, rather than throwing, so that the
+  /// launch-time push can ignore a failure while the switch does not. Storing a
+  /// preference the platform never received would leave the user told they are
+  /// covered when they are not.
+  static Future<bool> setPrivacyBlur(bool enabled) async {
+    if (!isIOS && !isAndroid) return true;
     try {
       await _channel.invokeMethod('setPrivacyBlur', enabled);
+      return true;
     } catch (e, s) {
       Loggers.app.warning('Failed to set privacy blur', e, s);
+      return false;
     }
   }
 

--- a/lib/core/chan.dart
+++ b/lib/core/chan.dart
@@ -80,18 +80,48 @@ abstract final class MethodChans {
     }
   }
 
-  /// Tell the native side whether to blur the app once it leaves the
-  /// foreground, hiding its content in the app switcher.
+  /// Tell the native side whether to cover the app once it leaves the
+  /// foreground, hiding its content from the app switcher.
+  ///
+  /// What "cover" means differs by platform, and deliberately so. iOS lays a
+  /// real blur over the Flutter window. Android sets `FLAG_SECURE` instead:
+  /// Flutter draws into a `SurfaceView` that `RenderEffect` cannot reach, and
+  /// anything that has to render a frame races the system's recents capture,
+  /// which the flag does not.
   ///
   /// Pushed on change *and* at launch: the native side answers this from its
-  /// own `UserDefaults` copy, which a reinstall or a restored backup leaves
-  /// saying something different from the (synced) settings store.
+  /// own persisted copy, which a reinstall or a restored backup leaves saying
+  /// something different from the (synced) settings store.
   static Future<void> setPrivacyBlur(bool enabled) async {
-    if (!isIOS) return;
+    if (!isIOS && !isAndroid) return;
     try {
       await _channel.invokeMethod('setPrivacyBlur', enabled);
     } catch (e, s) {
       Loggers.app.warning('Failed to set privacy blur', e, s);
+    }
+  }
+
+  /// Hold the cover in place after the app comes forward, until Flutter has
+  /// decided whether a biometric lock is coming.
+  ///
+  /// Without it the cover comes off the moment the app is frontmost, and the
+  /// real UI is on screen for however many frames it takes Flutter to hear
+  /// about the lifecycle change at all.
+  ///
+  /// Cleared just before the lock screen is pushed — on iOS the cover is a view
+  /// over the whole Flutter window, so it would otherwise hide that screen
+  /// rather than protect it.
+  static bool? _privacyBlurLocked;
+
+  static Future<void> setPrivacyBlurLocked(bool locked) async {
+    if (!isIOS && !isAndroid) return;
+    if (_privacyBlurLocked == locked) return;
+    _privacyBlurLocked = locked;
+    try {
+      await _channel.invokeMethod('setPrivacyBlurLocked', locked);
+    } catch (e, s) {
+      _privacyBlurLocked = null;
+      Loggers.app.warning('Failed to set privacy blur lock', e, s);
     }
   }
 

--- a/lib/core/service/watch_sync.dart
+++ b/lib/core/service/watch_sync.dart
@@ -158,6 +158,7 @@ final class WatchSync {
       tokens: tokens,
       // TODO: drop with `SettingStore.watchLegacyUrls`.
       legacyUrls: Stores.setting.watchLegacyUrls.fetch(),
+      stamp: DateTime.now().millisecondsSinceEpoch,
     );
   }
 
@@ -281,11 +282,14 @@ final class WatchSync {
   /// servers the user explicitly picked for the watch. `urls` is the pre-v2 shape and
   /// is still emitted so a watch app that has not updated yet keeps working.
   @visibleForTesting
+  /// [stamp] orders this against the other payloads in flight, and is passed in
+  /// rather than read here so that this stays a pure function.
   static Map<String, dynamic> payloadFrom({
     required List<String> selectedIds,
     required Spi? Function(String id) lookup,
     required Map<String, String> tokens,
     required List<String> legacyUrls,
+    required int stamp,
   }) {
     final servers = <Map<String, dynamic>>[];
     for (final id in selectedIds) {
@@ -308,6 +312,13 @@ final class WatchSync {
 
     return {
       'v': _payloadVersion,
+      // When this was built, so the watch can tell a stale delivery from a
+      // fresh one. WatchConnectivity orders nothing between a queued userInfo,
+      // the application context and a reply to `requestData`, so a payload that
+      // had been sitting in the queue could land last and undo a newer
+      // selection. A watch that predates this ignores the key, and a payload
+      // without it is applied as before.
+      'ts': stamp,
       'servers': servers,
       // TODO: drop with `SettingStore.watchLegacyUrls`.
       'urls': legacyUrls,

--- a/lib/core/service/watch_sync.dart
+++ b/lib/core/service/watch_sync.dart
@@ -124,8 +124,28 @@ final class WatchSync {
     }
   }
 
+  /// Strictly increasing, and read where a snapshot is taken.
+  ///
+  /// Seeded from the clock so that it keeps rising across a restart, where a
+  /// counter starting again at zero would look older than everything the watch
+  /// had already applied. Bumped by hand when the clock has not moved, so two
+  /// snapshots taken in the same millisecond are still ordered.
+  @visibleForTesting
+  static int nextRevision() {
+    final now = DateTime.now().millisecondsSinceEpoch;
+    _revision = now > _revision ? now : _revision + 1;
+    return _revision;
+  }
+
+  static int _revision = 0;
+
   /// What the watch app is told to display.
   Future<Map<String, dynamic>> buildPayload() async {
+    // Taken with the snapshot rather than with the result. Issuing tokens is a
+    // network round trip per server, so two builds overlap easily — and stamped
+    // at the end, the slower one finished last carrying the *newer* number
+    // while holding the *older* selection, which is exactly backwards.
+    final revision = nextRevision();
     final selectedIds = Stores.setting.watchServerIds.fetch();
     final existingTokens = await _existingTokens();
     final tokens = reusableTokens(
@@ -158,7 +178,7 @@ final class WatchSync {
       tokens: tokens,
       // TODO: drop with `SettingStore.watchLegacyUrls`.
       legacyUrls: Stores.setting.watchLegacyUrls.fetch(),
-      stamp: DateTime.now().millisecondsSinceEpoch,
+      stamp: revision,
     );
   }
 

--- a/lib/data/model/file/browse_path.dart
+++ b/lib/data/model/file/browse_path.dart
@@ -60,7 +60,10 @@ class BrowsePath {
     return _path.substring(slash + 1);
   }
 
-  void enter(String child) => _moveTo(join(_path, child));
+  /// Through [goTo], so that the name is normalized and checked like any other
+  /// destination. A listing is not a trusted source of names — a server is free
+  /// to answer with `..`, and moving there unchecked left the root behind.
+  void enter(String child) => goTo(join(_path, child));
 
   void goUp() {
     if (!canGoUp) return;
@@ -83,16 +86,32 @@ class BrowsePath {
   static String join(String dir, String child) =>
       dir.endsWith('/') ? '$dir$child' : '$dir/$child';
 
-  /// Trailing slashes off, `\` in, `/` out.
+  /// Trailing slashes off, `\` in, `/` out, `.` and `..` resolved.
   ///
   /// A Windows root arrives as `C:\Users\me\Documents` and has to become a
   /// path this can split on; the local backend turns it back at the other end.
+  ///
+  /// Resolving the dot segments is what makes [_isWithin] mean anything. That
+  /// test is a string prefix, so `/home/me/../../etc` passed it while naming
+  /// somewhere else entirely — every backend resolves the path it is handed,
+  /// and the answer was outside the root the browser was confined to.
   static String _normalize(String path) {
-    var value = path.replaceAll(r'\', '/');
-    while (value.length > 1 && value.endsWith('/')) {
-      value = value.substring(0, value.length - 1);
+    final value = path.replaceAll(r'\', '/');
+    final absolute = value.startsWith('/');
+    final segments = <String>[];
+    for (final segment in value.split('/')) {
+      if (segment.isEmpty || segment == '.') continue;
+      if (segment == '..') {
+        // Dropped at the top rather than allowed to walk off it: there is no
+        // place above what was given, and the result is read literally.
+        if (segments.isNotEmpty) segments.removeLast();
+        continue;
+      }
+      segments.add(segment);
     }
-    return value.isEmpty ? '/' : value;
+    final joined = segments.join('/');
+    if (absolute) return '/$joined';
+    return joined.isEmpty ? '/' : joined;
   }
 
   /// Whether [path] is [root] or sits under it.

--- a/lib/data/store/setting.dart
+++ b/lib/data/store/setting.dart
@@ -208,12 +208,18 @@ class SettingStore extends SqliteStore {
     isIOS,
   );
 
-  /// Blur the app while it is off screen, so the app switcher's card does not
-  /// leave server names or terminal output readable. iOS only.
+  /// Hide the app's content once it leaves the foreground, so the app
+  /// switcher's card does not leave server names or terminal output readable.
+  /// Mobile only.
   ///
-  /// The native side keeps its own copy in `UserDefaults` — a cold launch can
-  /// reach the switcher before Dart has pushed anything — so a change here has
-  /// to go through [MethodChans.setPrivacyBlur], and every launch re-pushes.
+  /// iOS blurs the window; Android sets `FLAG_SECURE`, which blanks the recents
+  /// thumbnail instead — Flutter draws into a `SurfaceView` that no in-process
+  /// blur can reach, and a cover that has to render a frame races the system's
+  /// capture.
+  ///
+  /// The native side keeps its own copy — a cold launch can reach the switcher
+  /// before Dart has pushed anything — so a change here has to go through
+  /// [MethodChans.setPrivacyBlur], and every launch re-pushes.
   late final privacyBlur = propertyDefault('privacyBlur', false);
 
   /// Servers the watch app may show, by [Spi.id], in display order.

--- a/lib/data/store/setting.dart
+++ b/lib/data/store/setting.dart
@@ -208,6 +208,14 @@ class SettingStore extends SqliteStore {
     isIOS,
   );
 
+  /// Blur the app while it is off screen, so the app switcher's card does not
+  /// leave server names or terminal output readable. iOS only.
+  ///
+  /// The native side keeps its own copy in `UserDefaults` — a cold launch can
+  /// reach the switcher before Dart has pushed anything — so a change here has
+  /// to go through [MethodChans.setPrivacyBlur], and every launch re-pushes.
+  late final privacyBlur = propertyDefault('privacyBlur', false);
+
   /// Servers the watch app may show, by [Spi.id], in display order.
   ///
   /// The watch used to be configured by a list of URLs living only inside the

--- a/lib/generated/l10n/l10n.dart
+++ b/lib/generated/l10n/l10n.dart
@@ -2881,6 +2881,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Send'**
   String get send;
+
+  /// No description provided for @privacyBlur.
+  ///
+  /// In en, this message translates to:
+  /// **'Privacy blur'**
+  String get privacyBlur;
+
+  /// No description provided for @privacyBlurTip.
+  ///
+  /// In en, this message translates to:
+  /// **'Blur the app\'s content in the app switcher'**
+  String get privacyBlurTip;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/generated/l10n/l10n.dart
+++ b/lib/generated/l10n/l10n.dart
@@ -2885,13 +2885,13 @@ abstract class AppLocalizations {
   /// No description provided for @privacyBlur.
   ///
   /// In en, this message translates to:
-  /// **'Privacy blur'**
+  /// **'Background privacy'**
   String get privacyBlur;
 
   /// No description provided for @privacyBlurTip.
   ///
   /// In en, this message translates to:
-  /// **'Blur the app\'s content in the app switcher'**
+  /// **'Hide app content in the app switcher'**
   String get privacyBlurTip;
 }
 

--- a/lib/generated/l10n/l10n_de.dart
+++ b/lib/generated/l10n/l10n_de.dart
@@ -1656,4 +1656,11 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get send => 'Senden';
+
+  @override
+  String get privacyBlur => 'Datenschutz-Weichzeichner';
+
+  @override
+  String get privacyBlurTip =>
+      'App-Inhalt in der App-Übersicht unkenntlich machen';
 }

--- a/lib/generated/l10n/l10n_de.dart
+++ b/lib/generated/l10n/l10n_de.dart
@@ -1658,9 +1658,8 @@ class AppLocalizationsDe extends AppLocalizations {
   String get send => 'Senden';
 
   @override
-  String get privacyBlur => 'Datenschutz-Weichzeichner';
+  String get privacyBlur => 'Datenschutz im Hintergrund';
 
   @override
-  String get privacyBlurTip =>
-      'App-Inhalt in der App-Übersicht unkenntlich machen';
+  String get privacyBlurTip => 'App-Inhalt in der App-Übersicht verbergen';
 }

--- a/lib/generated/l10n/l10n_en.dart
+++ b/lib/generated/l10n/l10n_en.dart
@@ -1632,4 +1632,10 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get send => 'Send';
+
+  @override
+  String get privacyBlur => 'Privacy blur';
+
+  @override
+  String get privacyBlurTip => 'Blur the app\'s content in the app switcher';
 }

--- a/lib/generated/l10n/l10n_en.dart
+++ b/lib/generated/l10n/l10n_en.dart
@@ -1634,8 +1634,8 @@ class AppLocalizationsEn extends AppLocalizations {
   String get send => 'Send';
 
   @override
-  String get privacyBlur => 'Privacy blur';
+  String get privacyBlur => 'Background privacy';
 
   @override
-  String get privacyBlurTip => 'Blur the app\'s content in the app switcher';
+  String get privacyBlurTip => 'Hide app content in the app switcher';
 }

--- a/lib/generated/l10n/l10n_es.dart
+++ b/lib/generated/l10n/l10n_es.dart
@@ -1666,8 +1666,8 @@ class AppLocalizationsEs extends AppLocalizations {
   String get send => 'Enviar';
 
   @override
-  String get privacyBlur => 'Desenfoque de privacidad';
+  String get privacyBlur => 'Privacidad en segundo plano';
 
   @override
-  String get privacyBlurTip => 'Difuminar el contenido en el selector de apps';
+  String get privacyBlurTip => 'Ocultar el contenido de la app en el selector';
 }

--- a/lib/generated/l10n/l10n_es.dart
+++ b/lib/generated/l10n/l10n_es.dart
@@ -1664,4 +1664,10 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get send => 'Enviar';
+
+  @override
+  String get privacyBlur => 'Desenfoque de privacidad';
+
+  @override
+  String get privacyBlurTip => 'Difuminar el contenido en el selector de apps';
 }

--- a/lib/generated/l10n/l10n_fr.dart
+++ b/lib/generated/l10n/l10n_fr.dart
@@ -1665,9 +1665,8 @@ class AppLocalizationsFr extends AppLocalizations {
   String get send => 'Envoyer';
 
   @override
-  String get privacyBlur => 'Flou de confidentialité';
+  String get privacyBlur => 'Confidentialité en arrière-plan';
 
   @override
-  String get privacyBlurTip =>
-      'Flouter le contenu de l\'app dans le sélecteur d\'apps';
+  String get privacyBlurTip => 'Masquer le contenu dans le sélecteur d\'apps';
 }

--- a/lib/generated/l10n/l10n_fr.dart
+++ b/lib/generated/l10n/l10n_fr.dart
@@ -1663,4 +1663,11 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get send => 'Envoyer';
+
+  @override
+  String get privacyBlur => 'Flou de confidentialité';
+
+  @override
+  String get privacyBlurTip =>
+      'Flouter le contenu de l\'app dans le sélecteur d\'apps';
 }

--- a/lib/generated/l10n/l10n_id.dart
+++ b/lib/generated/l10n/l10n_id.dart
@@ -1636,8 +1636,9 @@ class AppLocalizationsId extends AppLocalizations {
   String get send => 'Kirim';
 
   @override
-  String get privacyBlur => 'Buram privasi';
+  String get privacyBlur => 'Privasi latar belakang';
 
   @override
-  String get privacyBlurTip => 'Buramkan konten aplikasi di pengalih aplikasi';
+  String get privacyBlurTip =>
+      'Sembunyikan konten aplikasi di pengalih aplikasi';
 }

--- a/lib/generated/l10n/l10n_id.dart
+++ b/lib/generated/l10n/l10n_id.dart
@@ -1634,4 +1634,10 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get send => 'Kirim';
+
+  @override
+  String get privacyBlur => 'Buram privasi';
+
+  @override
+  String get privacyBlurTip => 'Buramkan konten aplikasi di pengalih aplikasi';
 }

--- a/lib/generated/l10n/l10n_it.dart
+++ b/lib/generated/l10n/l10n_it.dart
@@ -1658,8 +1658,9 @@ class AppLocalizationsIt extends AppLocalizations {
   String get send => 'Invia';
 
   @override
-  String get privacyBlur => 'Sfocatura privacy';
+  String get privacyBlur => 'Privacy in background';
 
   @override
-  String get privacyBlurTip => 'Sfoca il contenuto dell\'app nel selettore app';
+  String get privacyBlurTip =>
+      'Nascondi il contenuto dell\'app nel selettore app';
 }

--- a/lib/generated/l10n/l10n_it.dart
+++ b/lib/generated/l10n/l10n_it.dart
@@ -1656,4 +1656,10 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get send => 'Invia';
+
+  @override
+  String get privacyBlur => 'Sfocatura privacy';
+
+  @override
+  String get privacyBlurTip => 'Sfoca il contenuto dell\'app nel selettore app';
 }

--- a/lib/generated/l10n/l10n_ja.dart
+++ b/lib/generated/l10n/l10n_ja.dart
@@ -1541,4 +1541,10 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get send => '送信';
+
+  @override
+  String get privacyBlur => 'プライバシーぼかし';
+
+  @override
+  String get privacyBlurTip => 'Appスイッチャーで内容をぼかす';
 }

--- a/lib/generated/l10n/l10n_ja.dart
+++ b/lib/generated/l10n/l10n_ja.dart
@@ -1543,8 +1543,8 @@ class AppLocalizationsJa extends AppLocalizations {
   String get send => '送信';
 
   @override
-  String get privacyBlur => 'プライバシーぼかし';
+  String get privacyBlur => 'バックグラウンドのプライバシー';
 
   @override
-  String get privacyBlurTip => 'Appスイッチャーで内容をぼかす';
+  String get privacyBlurTip => 'Appスイッチャーで内容を隠す';
 }

--- a/lib/generated/l10n/l10n_ko.dart
+++ b/lib/generated/l10n/l10n_ko.dart
@@ -1546,4 +1546,10 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get send => '보내기';
+
+  @override
+  String get privacyBlur => '개인정보 블러';
+
+  @override
+  String get privacyBlurTip => '앱 전환기에서 앱 내용을 흐리게 표시';
 }

--- a/lib/generated/l10n/l10n_ko.dart
+++ b/lib/generated/l10n/l10n_ko.dart
@@ -1548,8 +1548,8 @@ class AppLocalizationsKo extends AppLocalizations {
   String get send => '보내기';
 
   @override
-  String get privacyBlur => '개인정보 블러';
+  String get privacyBlur => '백그라운드 개인정보 보호';
 
   @override
-  String get privacyBlurTip => '앱 전환기에서 앱 내용을 흐리게 표시';
+  String get privacyBlurTip => '앱 전환기에서 앱 내용 숨기기';
 }

--- a/lib/generated/l10n/l10n_nl.dart
+++ b/lib/generated/l10n/l10n_nl.dart
@@ -1651,9 +1651,8 @@ class AppLocalizationsNl extends AppLocalizations {
   String get send => 'Verzenden';
 
   @override
-  String get privacyBlur => 'Privacyvervaging';
+  String get privacyBlur => 'Privacy op de achtergrond';
 
   @override
-  String get privacyBlurTip =>
-      'Vervaag de inhoud van de app in de app-switcher';
+  String get privacyBlurTip => 'Verberg de app-inhoud in de app-switcher';
 }

--- a/lib/generated/l10n/l10n_nl.dart
+++ b/lib/generated/l10n/l10n_nl.dart
@@ -1649,4 +1649,11 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get send => 'Verzenden';
+
+  @override
+  String get privacyBlur => 'Privacyvervaging';
+
+  @override
+  String get privacyBlurTip =>
+      'Vervaag de inhoud van de app in de app-switcher';
 }

--- a/lib/generated/l10n/l10n_pt.dart
+++ b/lib/generated/l10n/l10n_pt.dart
@@ -1647,9 +1647,8 @@ class AppLocalizationsPt extends AppLocalizations {
   String get send => 'Enviar';
 
   @override
-  String get privacyBlur => 'Desfoque de privacidade';
+  String get privacyBlur => 'Privacidade em segundo plano';
 
   @override
-  String get privacyBlurTip =>
-      'Desfocar o conteúdo do app no alternador de apps';
+  String get privacyBlurTip => 'Ocultar o conteúdo do app no alternador';
 }

--- a/lib/generated/l10n/l10n_pt.dart
+++ b/lib/generated/l10n/l10n_pt.dart
@@ -1645,4 +1645,11 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get send => 'Enviar';
+
+  @override
+  String get privacyBlur => 'Desfoque de privacidade';
+
+  @override
+  String get privacyBlurTip =>
+      'Desfocar o conteúdo do app no alternador de apps';
 }

--- a/lib/generated/l10n/l10n_ru.dart
+++ b/lib/generated/l10n/l10n_ru.dart
@@ -1656,4 +1656,11 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get send => 'Отправить';
+
+  @override
+  String get privacyBlur => 'Размытие для приватности';
+
+  @override
+  String get privacyBlurTip =>
+      'Размывать содержимое приложения в переключателе';
 }

--- a/lib/generated/l10n/l10n_ru.dart
+++ b/lib/generated/l10n/l10n_ru.dart
@@ -1658,9 +1658,8 @@ class AppLocalizationsRu extends AppLocalizations {
   String get send => 'Отправить';
 
   @override
-  String get privacyBlur => 'Размытие для приватности';
+  String get privacyBlur => 'Приватность в фоне';
 
   @override
-  String get privacyBlurTip =>
-      'Размывать содержимое приложения в переключателе';
+  String get privacyBlurTip => 'Скрывать содержимое приложения в переключателе';
 }

--- a/lib/generated/l10n/l10n_tr.dart
+++ b/lib/generated/l10n/l10n_tr.dart
@@ -1632,4 +1632,10 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get send => 'Gönder';
+
+  @override
+  String get privacyBlur => 'Gizlilik bulanıklığı';
+
+  @override
+  String get privacyBlurTip => 'Uygulama değiştiricide içeriği bulanıklaştır';
 }

--- a/lib/generated/l10n/l10n_tr.dart
+++ b/lib/generated/l10n/l10n_tr.dart
@@ -1634,8 +1634,8 @@ class AppLocalizationsTr extends AppLocalizations {
   String get send => 'Gönder';
 
   @override
-  String get privacyBlur => 'Gizlilik bulanıklığı';
+  String get privacyBlur => 'Arka planda gizlilik';
 
   @override
-  String get privacyBlurTip => 'Uygulama değiştiricide içeriği bulanıklaştır';
+  String get privacyBlurTip => 'Uygulama değiştiricide içeriği gizle';
 }

--- a/lib/generated/l10n/l10n_uk.dart
+++ b/lib/generated/l10n/l10n_uk.dart
@@ -1654,8 +1654,8 @@ class AppLocalizationsUk extends AppLocalizations {
   String get send => 'Надіслати';
 
   @override
-  String get privacyBlur => 'Розмиття для приватності';
+  String get privacyBlur => 'Приватність у фоні';
 
   @override
-  String get privacyBlurTip => 'Розмивати вміст програми в перемикачі';
+  String get privacyBlurTip => 'Приховувати вміст програми в перемикачі';
 }

--- a/lib/generated/l10n/l10n_uk.dart
+++ b/lib/generated/l10n/l10n_uk.dart
@@ -1652,4 +1652,10 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get send => 'Надіслати';
+
+  @override
+  String get privacyBlur => 'Розмиття для приватності';
+
+  @override
+  String get privacyBlurTip => 'Розмивати вміст програми в перемикачі';
 }

--- a/lib/generated/l10n/l10n_zh.dart
+++ b/lib/generated/l10n/l10n_zh.dart
@@ -1504,10 +1504,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get send => '发送';
 
   @override
-  String get privacyBlur => '隐私模糊';
+  String get privacyBlur => '后台隐私保护';
 
   @override
-  String get privacyBlurTip => '在多任务界面模糊应用内容';
+  String get privacyBlurTip => '在多任务界面隐藏应用内容';
 }
 
 /// The translations for Chinese, as used in Taiwan (`zh_TW`).
@@ -3011,8 +3011,8 @@ class AppLocalizationsZhTw extends AppLocalizationsZh {
   String get send => '傳送';
 
   @override
-  String get privacyBlur => '隱私模糊';
+  String get privacyBlur => '背景隱私保護';
 
   @override
-  String get privacyBlurTip => '在多工介面模糊應用內容';
+  String get privacyBlurTip => '在多工介面隱藏應用內容';
 }

--- a/lib/generated/l10n/l10n_zh.dart
+++ b/lib/generated/l10n/l10n_zh.dart
@@ -1502,6 +1502,12 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get send => '发送';
+
+  @override
+  String get privacyBlur => '隐私模糊';
+
+  @override
+  String get privacyBlurTip => '在多任务界面模糊应用内容';
 }
 
 /// The translations for Chinese, as used in Taiwan (`zh_TW`).
@@ -3003,4 +3009,10 @@ class AppLocalizationsZhTw extends AppLocalizationsZh {
 
   @override
   String get send => '傳送';
+
+  @override
+  String get privacyBlur => '隱私模糊';
+
+  @override
+  String get privacyBlurTip => '在多工介面模糊應用內容';
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -477,5 +477,7 @@
   "bmcStaleWrite": "Der BMC hat sich während des Schreibens geändert. Bitte erneut versuchen.",
   "monitorAllowInsecureHttp": "HTTP erlauben",
   "monitorAllowInsecureHttpTip": "Nur in einem vertrauenswürdigen privaten Netz, das den Transport selbst verschlüsselt, etwa Tailscale",
-  "send": "Senden"
+  "send": "Senden",
+  "privacyBlur": "Datenschutz-Weichzeichner",
+  "privacyBlurTip": "App-Inhalt in der App-Übersicht unkenntlich machen"
 }

--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -478,6 +478,6 @@
   "monitorAllowInsecureHttp": "HTTP erlauben",
   "monitorAllowInsecureHttpTip": "Nur in einem vertrauenswürdigen privaten Netz, das den Transport selbst verschlüsselt, etwa Tailscale",
   "send": "Senden",
-  "privacyBlur": "Datenschutz-Weichzeichner",
-  "privacyBlurTip": "App-Inhalt in der App-Übersicht unkenntlich machen"
+  "privacyBlur": "Datenschutz im Hintergrund",
+  "privacyBlurTip": "App-Inhalt in der App-Übersicht verbergen"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -627,5 +627,7 @@
     }
   },
   "bmcStaleWrite": "The BMC changed while this was being written. Try again.",
-  "send": "Send"
+  "send": "Send",
+  "privacyBlur": "Privacy blur",
+  "privacyBlurTip": "Blur the app's content in the app switcher"
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -628,6 +628,6 @@
   },
   "bmcStaleWrite": "The BMC changed while this was being written. Try again.",
   "send": "Send",
-  "privacyBlur": "Privacy blur",
-  "privacyBlurTip": "Blur the app's content in the app switcher"
+  "privacyBlur": "Background privacy",
+  "privacyBlurTip": "Hide app content in the app switcher"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -477,5 +477,7 @@
   "bmcStaleWrite": "El BMC cambió mientras se escribía. Inténtalo de nuevo.",
   "monitorAllowInsecureHttp": "Permitir HTTP",
   "monitorAllowInsecureHttpTip": "Solo en una red privada de confianza que cifre el transporte por sí misma, como Tailscale",
-  "send": "Enviar"
+  "send": "Enviar",
+  "privacyBlur": "Desenfoque de privacidad",
+  "privacyBlurTip": "Difuminar el contenido en el selector de apps"
 }

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -478,6 +478,6 @@
   "monitorAllowInsecureHttp": "Permitir HTTP",
   "monitorAllowInsecureHttpTip": "Solo en una red privada de confianza que cifre el transporte por sí misma, como Tailscale",
   "send": "Enviar",
-  "privacyBlur": "Desenfoque de privacidad",
-  "privacyBlurTip": "Difuminar el contenido en el selector de apps"
+  "privacyBlur": "Privacidad en segundo plano",
+  "privacyBlurTip": "Ocultar el contenido de la app en el selector"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -477,5 +477,7 @@
   "bmcStaleWrite": "Le BMC a changé pendant l'écriture. Réessaie.",
   "monitorAllowInsecureHttp": "Autoriser HTTP",
   "monitorAllowInsecureHttpTip": "Uniquement sur un réseau privé de confiance qui chiffre lui-même le transport, comme Tailscale",
-  "send": "Envoyer"
+  "send": "Envoyer",
+  "privacyBlur": "Flou de confidentialité",
+  "privacyBlurTip": "Flouter le contenu de l'app dans le sélecteur d'apps"
 }

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -478,6 +478,6 @@
   "monitorAllowInsecureHttp": "Autoriser HTTP",
   "monitorAllowInsecureHttpTip": "Uniquement sur un réseau privé de confiance qui chiffre lui-même le transport, comme Tailscale",
   "send": "Envoyer",
-  "privacyBlur": "Flou de confidentialité",
-  "privacyBlurTip": "Flouter le contenu de l'app dans le sélecteur d'apps"
+  "privacyBlur": "Confidentialité en arrière-plan",
+  "privacyBlurTip": "Masquer le contenu dans le sélecteur d'apps"
 }

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -478,6 +478,6 @@
   "monitorAllowInsecureHttp": "Izinkan HTTP",
   "monitorAllowInsecureHttpTip": "Hanya di jaringan privat tepercaya yang mengenkripsi transportnya sendiri, misalnya Tailscale",
   "send": "Kirim",
-  "privacyBlur": "Buram privasi",
-  "privacyBlurTip": "Buramkan konten aplikasi di pengalih aplikasi"
+  "privacyBlur": "Privasi latar belakang",
+  "privacyBlurTip": "Sembunyikan konten aplikasi di pengalih aplikasi"
 }

--- a/lib/l10n/app_id.arb
+++ b/lib/l10n/app_id.arb
@@ -477,5 +477,7 @@
   "bmcStaleWrite": "BMC berubah saat proses tulis. Coba lagi.",
   "monitorAllowInsecureHttp": "Izinkan HTTP",
   "monitorAllowInsecureHttpTip": "Hanya di jaringan privat tepercaya yang mengenkripsi transportnya sendiri, misalnya Tailscale",
-  "send": "Kirim"
+  "send": "Kirim",
+  "privacyBlur": "Buram privasi",
+  "privacyBlurTip": "Buramkan konten aplikasi di pengalih aplikasi"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -480,5 +480,7 @@
   "bmcStaleWrite": "Il BMC è cambiato durante la scrittura. Riprova.",
   "monitorAllowInsecureHttp": "Consenti HTTP",
   "monitorAllowInsecureHttpTip": "Solo su una rete privata fidata che cifra da sé il trasporto, come Tailscale",
-  "send": "Invia"
+  "send": "Invia",
+  "privacyBlur": "Sfocatura privacy",
+  "privacyBlurTip": "Sfoca il contenuto dell'app nel selettore app"
 }

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -481,6 +481,6 @@
   "monitorAllowInsecureHttp": "Consenti HTTP",
   "monitorAllowInsecureHttpTip": "Solo su una rete privata fidata che cifra da sé il trasporto, come Tailscale",
   "send": "Invia",
-  "privacyBlur": "Sfocatura privacy",
-  "privacyBlurTip": "Sfoca il contenuto dell'app nel selettore app"
+  "privacyBlur": "Privacy in background",
+  "privacyBlurTip": "Nascondi il contenuto dell'app nel selettore app"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -477,5 +477,7 @@
   "bmcStaleWrite": "書き込み中に BMC が変更されました。再試行してください。",
   "monitorAllowInsecureHttp": "HTTP を許可",
   "monitorAllowInsecureHttpTip": "HTTP 以外で通信自体が暗号化される信頼できるプライベートネットワークでのみ。たとえば Tailscale",
-  "send": "送信"
+  "send": "送信",
+  "privacyBlur": "プライバシーぼかし",
+  "privacyBlurTip": "Appスイッチャーで内容をぼかす"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -478,6 +478,6 @@
   "monitorAllowInsecureHttp": "HTTP を許可",
   "monitorAllowInsecureHttpTip": "HTTP 以外で通信自体が暗号化される信頼できるプライベートネットワークでのみ。たとえば Tailscale",
   "send": "送信",
-  "privacyBlur": "プライバシーぼかし",
-  "privacyBlurTip": "Appスイッチャーで内容をぼかす"
+  "privacyBlur": "バックグラウンドのプライバシー",
+  "privacyBlurTip": "Appスイッチャーで内容を隠す"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -486,5 +486,7 @@
   "bmcStaleWrite": "쓰는 동안 BMC가 변경되었습니다. 다시 시도하세요.",
   "monitorAllowInsecureHttp": "HTTP 허용",
   "monitorAllowInsecureHttpTip": "HTTP 외에 전송 자체가 암호화되는 신뢰할 수 있는 사설망에서만. 예를 들어 Tailscale",
-  "send": "보내기"
+  "send": "보내기",
+  "privacyBlur": "개인정보 블러",
+  "privacyBlurTip": "앱 전환기에서 앱 내용을 흐리게 표시"
 }

--- a/lib/l10n/app_ko.arb
+++ b/lib/l10n/app_ko.arb
@@ -487,6 +487,6 @@
   "monitorAllowInsecureHttp": "HTTP 허용",
   "monitorAllowInsecureHttpTip": "HTTP 외에 전송 자체가 암호화되는 신뢰할 수 있는 사설망에서만. 예를 들어 Tailscale",
   "send": "보내기",
-  "privacyBlur": "개인정보 블러",
-  "privacyBlurTip": "앱 전환기에서 앱 내용을 흐리게 표시"
+  "privacyBlur": "백그라운드 개인정보 보호",
+  "privacyBlurTip": "앱 전환기에서 앱 내용 숨기기"
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -478,6 +478,6 @@
   "monitorAllowInsecureHttp": "HTTP toestaan",
   "monitorAllowInsecureHttpTip": "Alleen op een vertrouwd privénetwerk dat het transport zelf versleutelt, zoals Tailscale",
   "send": "Verzenden",
-  "privacyBlur": "Privacyvervaging",
-  "privacyBlurTip": "Vervaag de inhoud van de app in de app-switcher"
+  "privacyBlur": "Privacy op de achtergrond",
+  "privacyBlurTip": "Verberg de app-inhoud in de app-switcher"
 }

--- a/lib/l10n/app_nl.arb
+++ b/lib/l10n/app_nl.arb
@@ -477,5 +477,7 @@
   "bmcStaleWrite": "De BMC is gewijzigd tijdens het schrijven. Probeer opnieuw.",
   "monitorAllowInsecureHttp": "HTTP toestaan",
   "monitorAllowInsecureHttpTip": "Alleen op een vertrouwd privénetwerk dat het transport zelf versleutelt, zoals Tailscale",
-  "send": "Verzenden"
+  "send": "Verzenden",
+  "privacyBlur": "Privacyvervaging",
+  "privacyBlurTip": "Vervaag de inhoud van de app in de app-switcher"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -478,6 +478,6 @@
   "monitorAllowInsecureHttp": "Permitir HTTP",
   "monitorAllowInsecureHttpTip": "Apenas numa rede privada de confiança que cifre o transporte, como a Tailscale",
   "send": "Enviar",
-  "privacyBlur": "Desfoque de privacidade",
-  "privacyBlurTip": "Desfocar o conteúdo do app no alternador de apps"
+  "privacyBlur": "Privacidade em segundo plano",
+  "privacyBlurTip": "Ocultar o conteúdo do app no alternador"
 }

--- a/lib/l10n/app_pt.arb
+++ b/lib/l10n/app_pt.arb
@@ -477,5 +477,7 @@
   "bmcStaleWrite": "O BMC mudou durante a gravação. Tente novamente.",
   "monitorAllowInsecureHttp": "Permitir HTTP",
   "monitorAllowInsecureHttpTip": "Apenas numa rede privada de confiança que cifre o transporte, como a Tailscale",
-  "send": "Enviar"
+  "send": "Enviar",
+  "privacyBlur": "Desfoque de privacidade",
+  "privacyBlurTip": "Desfocar o conteúdo do app no alternador de apps"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -478,6 +478,6 @@
   "monitorAllowInsecureHttp": "Разрешить HTTP",
   "monitorAllowInsecureHttpTip": "Только в доверенной частной сети, которая сама шифрует транспорт, например Tailscale",
   "send": "Отправить",
-  "privacyBlur": "Размытие для приватности",
-  "privacyBlurTip": "Размывать содержимое приложения в переключателе"
+  "privacyBlur": "Приватность в фоне",
+  "privacyBlurTip": "Скрывать содержимое приложения в переключателе"
 }

--- a/lib/l10n/app_ru.arb
+++ b/lib/l10n/app_ru.arb
@@ -477,5 +477,7 @@
   "bmcStaleWrite": "BMC изменился во время записи. Повторите попытку.",
   "monitorAllowInsecureHttp": "Разрешить HTTP",
   "monitorAllowInsecureHttpTip": "Только в доверенной частной сети, которая сама шифрует транспорт, например Tailscale",
-  "send": "Отправить"
+  "send": "Отправить",
+  "privacyBlur": "Размытие для приватности",
+  "privacyBlurTip": "Размывать содержимое приложения в переключателе"
 }

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -478,6 +478,6 @@
   "monitorAllowInsecureHttp": "HTTP’ye izin ver",
   "monitorAllowInsecureHttpTip": "Yalnızca taşımayı kendisi şifreleyen güvenilir özel ağlarda, örneğin Tailscale",
   "send": "Gönder",
-  "privacyBlur": "Gizlilik bulanıklığı",
-  "privacyBlurTip": "Uygulama değiştiricide içeriği bulanıklaştır"
+  "privacyBlur": "Arka planda gizlilik",
+  "privacyBlurTip": "Uygulama değiştiricide içeriği gizle"
 }

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -477,5 +477,7 @@
   "bmcStaleWrite": "Yazma sırasında BMC değişti. Tekrar dene.",
   "monitorAllowInsecureHttp": "HTTP’ye izin ver",
   "monitorAllowInsecureHttpTip": "Yalnızca taşımayı kendisi şifreleyen güvenilir özel ağlarda, örneğin Tailscale",
-  "send": "Gönder"
+  "send": "Gönder",
+  "privacyBlur": "Gizlilik bulanıklığı",
+  "privacyBlurTip": "Uygulama değiştiricide içeriği bulanıklaştır"
 }

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -477,5 +477,7 @@
   "bmcStaleWrite": "BMC змінився під час запису. Спробуйте ще раз.",
   "monitorAllowInsecureHttp": "Дозволити HTTP",
   "monitorAllowInsecureHttpTip": "Лише в довіреній приватній мережі, що сама шифрує транспорт, наприклад Tailscale",
-  "send": "Надіслати"
+  "send": "Надіслати",
+  "privacyBlur": "Розмиття для приватності",
+  "privacyBlurTip": "Розмивати вміст програми в перемикачі"
 }

--- a/lib/l10n/app_uk.arb
+++ b/lib/l10n/app_uk.arb
@@ -478,6 +478,6 @@
   "monitorAllowInsecureHttp": "Дозволити HTTP",
   "monitorAllowInsecureHttpTip": "Лише в довіреній приватній мережі, що сама шифрує транспорт, наприклад Tailscale",
   "send": "Надіслати",
-  "privacyBlur": "Розмиття для приватності",
-  "privacyBlurTip": "Розмивати вміст програми в перемикачі"
+  "privacyBlur": "Приватність у фоні",
+  "privacyBlurTip": "Приховувати вміст програми в перемикачі"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -491,5 +491,7 @@
   "bmcAccountSharedTip": "在这里修改会改变所有这些服务器使用的账户。",
   "bmcAccountInUse": "{count} 台服务器在用。它们会保留地址，但失去账户。",
   "bmcStaleWrite": "BMC 上的内容在写入期间被改动过，请重试。",
-  "send": "发送"
+  "send": "发送",
+  "privacyBlur": "隐私模糊",
+  "privacyBlurTip": "在多任务界面模糊应用内容"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -492,6 +492,6 @@
   "bmcAccountInUse": "{count} 台服务器在用。它们会保留地址，但失去账户。",
   "bmcStaleWrite": "BMC 上的内容在写入期间被改动过，请重试。",
   "send": "发送",
-  "privacyBlur": "隐私模糊",
-  "privacyBlurTip": "在多任务界面模糊应用内容"
+  "privacyBlur": "后台隐私保护",
+  "privacyBlurTip": "在多任务界面隐藏应用内容"
 }

--- a/lib/l10n/app_zh_tw.arb
+++ b/lib/l10n/app_zh_tw.arb
@@ -485,6 +485,6 @@
   "bmcAccountInUse": "{count} 台伺服器在用。它們會保留位址，但失去帳戶。",
   "bmcStaleWrite": "BMC 上的內容在寫入期間被改動過，請重試。",
   "send": "傳送",
-  "privacyBlur": "隱私模糊",
-  "privacyBlurTip": "在多工介面模糊應用內容"
+  "privacyBlur": "背景隱私保護",
+  "privacyBlurTip": "在多工介面隱藏應用內容"
 }

--- a/lib/l10n/app_zh_tw.arb
+++ b/lib/l10n/app_zh_tw.arb
@@ -484,5 +484,7 @@
   "bmcAccountSharedTip": "在這裡修改會改變所有這些伺服器使用的帳戶。",
   "bmcAccountInUse": "{count} 台伺服器在用。它們會保留位址，但失去帳戶。",
   "bmcStaleWrite": "BMC 上的內容在寫入期間被改動過，請重試。",
-  "send": "傳送"
+  "send": "傳送",
+  "privacyBlur": "隱私模糊",
+  "privacyBlurTip": "在多工介面模糊應用內容"
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -240,6 +240,9 @@ Future<void> _doPlatformRelated() async {
   if (isIOS) {
     unawaited(WatchSync.instance.init());
     unawaited(MethodChans.syncAccessoryWidgetUrl());
+    unawaited(
+      MethodChans.setPrivacyBlur(Stores.setting.privacyBlur.fetch()),
+    );
   }
 
   final serversCount = Stores.server.keys().length;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -240,9 +240,12 @@ Future<void> _doPlatformRelated() async {
   if (isIOS) {
     unawaited(WatchSync.instance.init());
     unawaited(MethodChans.syncAccessoryWidgetUrl());
-    unawaited(
-      MethodChans.setPrivacyBlur(Stores.setting.privacyBlur.fetch()),
-    );
+  }
+
+  // Both platforms keep their own copy of this, which a reinstall or a restored
+  // backup leaves disagreeing with the settings store.
+  if (isIOS || isAndroid) {
+    unawaited(MethodChans.setPrivacyBlur(Stores.setting.privacyBlur.fetch()));
   }
 
   final serversCount = Stores.server.keys().length;

--- a/lib/view/page/home.dart
+++ b/lib/view/page/home.dart
@@ -188,11 +188,14 @@ class _HomePageState extends ConsumerState<HomePage>
               _goAuth();
             } else {
               _shouldAuth = false;
+              _releasePrivacyCover();
             }
             _pausedTime = null;
           } else {
             _goAuth();
           }
+        } else {
+          _releasePrivacyCover();
         }
         final serverNotifier = _notifier;
         unawaited(serverNotifier.startAutoRefresh());
@@ -204,6 +207,12 @@ class _HomePageState extends ConsumerState<HomePage>
         _lastFullscreenMode = null;
         _pausedTime = DateTime.now();
         _shouldAuth = true;
+        // Decided here rather than on the way back: the native cover comes off
+        // the moment the app is frontmost, which is several frames before
+        // Flutter hears about it and can push the lock screen.
+        if (Stores.setting.useBioAuth.fetch()) {
+          unawaited(MethodChans.setPrivacyBlurLocked(true));
+        }
         if (!(isAndroid && Stores.setting.bgRun.fetch())) {
           _notifier.stopAutoRefresh();
         }
@@ -455,6 +464,13 @@ class _HomePageState extends ConsumerState<HomePage>
   void _goAuth() {
     if (Stores.setting.useBioAuth.fetch()) {
       if (LocalAuthPage.route.alreadyIn) return;
+      // Before the push, not after the route resolves. On iOS the cover is a
+      // view over the Flutter window, so it is *above* every route drawn inside
+      // it — leaving it up would hide the lock screen instead of protecting it,
+      // and swallow the taps meant for it. Releasing it here costs at most the
+      // frames between this and the route appearing, and in practice the
+      // channel round trip outlasts the push.
+      _releasePrivacyCover();
       // The route's own future, not `onAuthSuccess`. That callback runs from
       // inside `context.pop()`, while the lock screen is still the route the
       // navigator answers with — so the guide's "is the home page current"
@@ -470,7 +486,15 @@ class _HomePageState extends ConsumerState<HomePage>
             )
             .then((_) => _maybeShowNavGuide()),
       );
+    } else {
+      _releasePrivacyCover();
     }
+  }
+
+  /// Let the native privacy cover come off, now that either the lock screen is
+  /// about to take over or it was established that none is coming.
+  void _releasePrivacyCover() {
+    unawaited(MethodChans.setPrivacyBlurLocked(false));
   }
 
   void _onDestinationSelected(int index) {

--- a/lib/view/page/home.dart
+++ b/lib/view/page/home.dart
@@ -462,33 +462,37 @@ class _HomePageState extends ConsumerState<HomePage>
   }
 
   void _goAuth() {
-    if (Stores.setting.useBioAuth.fetch()) {
-      if (LocalAuthPage.route.alreadyIn) return;
-      // Before the push, not after the route resolves. On iOS the cover is a
-      // view over the Flutter window, so it is *above* every route drawn inside
-      // it — leaving it up would hide the lock screen instead of protecting it,
-      // and swallow the taps meant for it. Releasing it here costs at most the
-      // frames between this and the route appearing, and in practice the
-      // channel round trip outlasts the push.
-      _releasePrivacyCover();
-      // The route's own future, not `onAuthSuccess`. That callback runs from
-      // inside `context.pop()`, while the lock screen is still the route the
-      // navigator answers with — so the guide's "is the home page current"
-      // check would say no and skip it every launch, on exactly the devices
-      // this branch exists for. The future completes once the pop has.
-      unawaited(
-        LocalAuthPage.route
-            .go(
-              context,
-              args: LocalAuthPageArgs(
-                onAuthSuccess: () => _shouldAuth = false,
-              ),
-            )
-            .then((_) => _maybeShowNavGuide()),
-      );
-    } else {
-      _releasePrivacyCover();
-    }
+    // First, and on every path out of here. On iOS the cover is a view over the
+    // Flutter window, so it is *above* every route drawn inside it — left up it
+    // would hide the lock screen instead of protecting it. Releasing it before
+    // the push costs at most the frames until the route appears, and in
+    // practice the channel round trip outlasts the push.
+    //
+    // The path that matters is the early return below. Backgrounding *from* the
+    // lock screen and coming back re-locks the cover and lands here, where
+    // `alreadyIn` is true — and skipping this left the cover over that screen
+    // with nothing that would ever take it off, since the next trip out and
+    // back returns at exactly the same place.
+    _releasePrivacyCover();
+
+    if (!Stores.setting.useBioAuth.fetch()) return;
+    if (LocalAuthPage.route.alreadyIn) return;
+
+    // The route's own future, not `onAuthSuccess`. That callback runs from
+    // inside `context.pop()`, while the lock screen is still the route the
+    // navigator answers with — so the guide's "is the home page current"
+    // check would say no and skip it every launch, on exactly the devices
+    // this branch exists for. The future completes once the pop has.
+    unawaited(
+      LocalAuthPage.route
+          .go(
+            context,
+            args: LocalAuthPageArgs(
+              onAuthSuccess: () => _shouldAuth = false,
+            ),
+          )
+          .then((_) => _maybeShowNavGuide()),
+    );
   }
 
   /// Let the native privacy cover come off, now that either the lock screen is

--- a/lib/view/page/setting/entries/app.dart
+++ b/lib/view/page/setting/entries/app.dart
@@ -14,6 +14,7 @@ extension _App on _AppSettingsPageState {
       _buildAppColor(),
       _buildCheckUpdate(),
       PlatformPublicSettings.buildBioAuth,
+      ?PlatformPublicSettings.buildPrivacyBlur,
       ?androidSettings,
       ?specific,
       _buildAppMore(),

--- a/lib/view/page/setting/entries/server.dart
+++ b/lib/view/page/setting/entries/server.dart
@@ -335,6 +335,14 @@ extension _Server on _AppSettingsPageState {
 
   Widget _buildServerLogoUrl() {
     void onSave(String raw) {
+      // Emptying the field clears it. An empty string is not a fetchable URL,
+      // so it was refused as invalid — and unset is the state this starts in
+      // and shows as [libL10n.empty], which left no way back to it.
+      if (raw.trim().isEmpty) {
+        _setting.serverLogoUrl.put('');
+        context.popDialog();
+        return;
+      }
       // A GitHub page URL is rewritten to the one that serves the file. It is
       // what the address bar gives you, and left alone it fetches HTML that
       // reaches the decoder as `Invalid image data`.

--- a/lib/view/page/setting/entry.dart
+++ b/lib/view/page/setting/entry.dart
@@ -355,6 +355,11 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
         return;
       }
       _path.add(node);
+      // Unfolded in the wide menu too. The two navigations share [_selectedId]
+      // but not their shape, and only the menu's own toggle used to write here
+      // — so a branch entered while narrow was still folded if the window then
+      // grew, leaving the page on screen with no row anywhere pointing at it.
+      _expanded.add(node.id);
       final leaf = node.firstLeaf;
       if (leaf != null) _selectedId = leaf.id;
     });

--- a/lib/view/page/setting/entry.dart
+++ b/lib/view/page/setting/entry.dart
@@ -613,6 +613,12 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
     final space = level == null ? 0.0 : _kTabsHeight + _kTabsMargin * 2;
 
     return Stack(
+      // Nothing here should reach past the floor of this box — the page is
+      // pushed into the home tab's navigator, and the `Scaffold` paints its
+      // bottom bar after the body, so anything that does is covered rather than
+      // shown. `none` only keeps the clip from being what cuts it: the bar
+      // carries its own margin, so it stops short of the floor on its own.
+      clipBehavior: Clip.none,
       children: [
         MediaQuery(
           data: mediaQuery.copyWith(
@@ -624,10 +630,14 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
         ),
         // Edge to edge, and the bar centres itself within that: it is as wide
         // as the level it is showing, and only scrolls when that is too wide.
+        //
+        // Flush with the floor, because the gap the bar stands in is padding
+        // inside it now. Lifting it from here as well would move it up by that
+        // much again, and put the shadow back outside the clip it just left.
         Positioned(
           left: 0,
           right: 0,
-          bottom: _kTabsMargin,
+          bottom: 0,
           child: AnimatedSwitcher(
             duration: Durations.medium2,
             // Springs up past its place and settles, as displacement does

--- a/lib/view/page/setting/menu.dart
+++ b/lib/view/page/setting/menu.dart
@@ -51,6 +51,10 @@ final class SettingsNode {
 }
 
 /// Height of the floating tab bar, and the gap around it.
+///
+/// The gap is carried by the bar's own padding rather than by where it is
+/// placed, so that its shadow falls inside the scroll view that clips it. The
+/// two shadows are written to stay within this much — see where they are built.
 const _kTabsHeight = 56.0;
 const _kTabsMargin = 12.0;
 
@@ -155,10 +159,20 @@ final class _SettingsTabs extends StatelessWidget {
 
     // Centred while it fits and scrolled when it does not: the first level has
     // more tabs than a phone is wide, and the levels under it have three.
+    //
+    // The vertical padding is the room the shadow needs. A scroll view clips to
+    // its viewport, and this one's viewport is as tall as the bar exactly — so
+    // the shadow was cut off above and below while the sides, which have the
+    // width of the page to spread into, kept theirs. Padding grows the viewport
+    // instead of turning the clip off, which the horizontal axis still needs:
+    // a level too wide for the phone has to scroll out of sight, not spill.
+    //
+    // It is padding here rather than an offset on the `Positioned` that places
+    // this, so the bar sits where it always did — see [_kTabsMargin].
     return LayoutBuilder(
       builder: (context, constraints) => SingleChildScrollView(
         scrollDirection: Axis.horizontal,
-        padding: const EdgeInsets.symmetric(horizontal: _kTabsMargin),
+        padding: const EdgeInsets.all(_kTabsMargin),
         child: ConstrainedBox(
           constraints: BoxConstraints(
             minWidth: math.max(0, constraints.maxWidth - _kTabsMargin * 2),

--- a/lib/view/page/setting/platform/ios.dart
+++ b/lib/view/page/setting/platform/ios.dart
@@ -135,7 +135,12 @@ class _IosSettingsPageState extends State<IosSettingsPage> {
   }
 
   Widget _buildWatchApp() {
-    final count = Stores.setting.watchServerIds.fetch().length;
+    // Counted against the servers that can still be shown, for the same reason
+    // as [_accessoryServer]: a selected id outlives the monitor configuration
+    // that made it selectable, and `buildPayload` already skips those — so the
+    // raw length was a number the watch would never agree with.
+    final selected = Stores.setting.watchServerIds.fetch().toSet();
+    final count = _monitorServers.where((e) => selected.contains(e.id)).length;
     return ListTile(
       title: const Text('Watch app'),
       subtitle: FutureWidget<bool>(
@@ -175,9 +180,18 @@ extension _Actions on _IosSettingsPageState {
   List<Spi> get _monitorServers =>
       Stores.server.fetch().where((e) => e.monitor != null).toList();
 
+  /// The chosen server, but only while it can still serve the widget.
+  ///
+  /// A server whose monitor configuration was removed stays in this setting —
+  /// nothing clears it, and there is no single place a removal passes through
+  /// that could. The widget already ends up empty, because the URL is derived
+  /// from the monitor; naming the server here was the last thing still saying
+  /// it was configured.
   Spi? get _accessoryServer {
     final id = Stores.setting.accessoryWidgetServerId.fetch();
-    return id.isEmpty ? null : Stores.server.fetchOneRaw(id);
+    if (id.isEmpty) return null;
+    final spi = Stores.server.fetchOneRaw(id);
+    return spi?.monitor == null ? null : spi;
   }
 
   void _onTapAccessoryWidgetServer() async {

--- a/lib/view/page/setting/platform/ios.dart
+++ b/lib/view/page/setting/platform/ios.dart
@@ -62,7 +62,6 @@ class _IosSettingsPageState extends State<IosSettingsPage> {
       padding: context.padBottom(const EdgeInsets.symmetric(horizontal: 17)),
       children: [
         _buildPushToken(),
-        _buildPrivacyBlur(),
         _buildAutoUpdateHomeWidget(),
         _buildAccessoryWidgetServer(),
         _buildWatchApp(),
@@ -106,19 +105,6 @@ class _IosSettingsPageState extends State<IosSettingsPage> {
             maxLines: 1,
           );
         },
-      ),
-    );
-  }
-
-  /// The native side keeps its own copy of this, so the switch has to push as
-  /// well as store — `callback` runs before the write and skips it on failure.
-  Widget _buildPrivacyBlur() {
-    return ListTile(
-      title: Text(l10n.privacyBlur),
-      subtitle: Text(l10n.privacyBlurTip, style: UIs.textGrey),
-      trailing: StoreSwitch(
-        prop: Stores.setting.privacyBlur,
-        callback: MethodChans.setPrivacyBlur,
       ),
     );
   }

--- a/lib/view/page/setting/platform/ios.dart
+++ b/lib/view/page/setting/platform/ios.dart
@@ -62,6 +62,7 @@ class _IosSettingsPageState extends State<IosSettingsPage> {
       padding: context.padBottom(const EdgeInsets.symmetric(horizontal: 17)),
       children: [
         _buildPushToken(),
+        _buildPrivacyBlur(),
         _buildAutoUpdateHomeWidget(),
         _buildAccessoryWidgetServer(),
         _buildWatchApp(),
@@ -105,6 +106,19 @@ class _IosSettingsPageState extends State<IosSettingsPage> {
             maxLines: 1,
           );
         },
+      ),
+    );
+  }
+
+  /// The native side keeps its own copy of this, so the switch has to push as
+  /// well as store — `callback` runs before the write and skips it on failure.
+  Widget _buildPrivacyBlur() {
+    return ListTile(
+      title: Text(l10n.privacyBlur),
+      subtitle: Text(l10n.privacyBlurTip, style: UIs.textGrey),
+      trailing: StoreSwitch(
+        prop: Stores.setting.privacyBlur,
+        callback: MethodChans.setPrivacyBlur,
       ),
     );
   }

--- a/lib/view/page/setting/platform/platform_pub.dart
+++ b/lib/view/page/setting/platform/platform_pub.dart
@@ -1,8 +1,28 @@
 import 'package:fl_lib/fl_lib.dart';
 import 'package:flutter/material.dart';
+import 'package:server_box/core/chan.dart';
+import 'package:server_box/core/extension/context/locale.dart';
 import 'package:server_box/data/res/store.dart';
 
 abstract final class PlatformPublicSettings {
+  /// Mobile only: there is no app switcher card to hide on a desktop, and
+  /// neither platform channel implements this there.
+  ///
+  /// The native side keeps its own copy, so the switch has to push as well as
+  /// store — `callback` runs before the write and skips it on failure.
+  static Widget? get buildPrivacyBlur {
+    if (!isIOS && !isAndroid) return null;
+    return ListTile(
+      leading: const Icon(Icons.blur_on),
+      title: Text(l10n.privacyBlur),
+      subtitle: Text(l10n.privacyBlurTip, style: UIs.textGrey),
+      trailing: StoreSwitch(
+        prop: Stores.setting.privacyBlur,
+        callback: MethodChans.setPrivacyBlur,
+      ),
+    );
+  }
+
   static Widget get buildBioAuth {
     return ExpandTile(
       leading: const Icon(Icons.fingerprint),

--- a/lib/view/page/setting/platform/platform_pub.dart
+++ b/lib/view/page/setting/platform/platform_pub.dart
@@ -9,7 +9,12 @@ abstract final class PlatformPublicSettings {
   /// neither platform channel implements this there.
   ///
   /// The native side keeps its own copy, so the switch has to push as well as
-  /// store — `callback` runs before the write and skips it on failure.
+  /// store.
+  ///
+  /// A `validator` and not a `callback`: the push is what actually covers the
+  /// app, so if the platform refuses it the switch has to stay where it was.
+  /// Written the other way the preference was stored anyway, and the user was
+  /// left reading "on" off a switch that had covered nothing.
   static Widget? get buildPrivacyBlur {
     if (!isIOS && !isAndroid) return null;
     return ListTile(
@@ -18,7 +23,11 @@ abstract final class PlatformPublicSettings {
       subtitle: Text(l10n.privacyBlurTip, style: UIs.textGrey),
       trailing: StoreSwitch(
         prop: Stores.setting.privacyBlur,
-        callback: MethodChans.setPrivacyBlur,
+        validator: (val) async {
+          final ok = await MethodChans.setPrivacyBlur(val);
+          if (!ok) Toast.error(libL10n.fail);
+          return ok;
+        },
       ),
     );
   }

--- a/lib/view/page/storage/file_browser.dart
+++ b/lib/view/page/storage/file_browser.dart
@@ -462,17 +462,20 @@ class _FileBrowserPageState extends ConsumerState<FileBrowserPage>
       case LogicalKeyboardKey.escape:
         if (!_selecting && _cursor == null) return KeyEventResult.ignored;
         _clearSelection();
-      case LogicalKeyboardKey.f2:
+      // The three that mutate or select are guarded rather than the whole
+      // handler: moving the cursor, entering a directory, going up and
+      // clearing are what a picker is *for*, and stay.
+      case LogicalKeyboardKey.f2 when !_isPicking:
         final entry = _cursorOrOnlySelected;
         if (entry == null) return KeyEventResult.ignored;
         _rename(entry);
-      case LogicalKeyboardKey.delete:
+      case LogicalKeyboardKey.delete when !_isPicking:
         final targets = _selecting
             ? _selectedEntries
             : [?_cursorEntry];
         if (targets.isEmpty) return KeyEventResult.ignored;
         _deleteAll(targets);
-      case LogicalKeyboardKey.keyA when modified:
+      case LogicalKeyboardKey.keyA when modified && !_isPicking:
         _selectAll();
       default:
         return KeyEventResult.ignored;
@@ -806,6 +809,11 @@ class _FileBrowserPageState extends ConsumerState<FileBrowserPage>
 
   /// [at] is where the pointer was, for a right-click. Null for a long press.
   Future<void> _showEntryMenu(FileEntry entry, {Offset? at}) {
+    // Picking: the caller asked for a path back, not a file manager. Every
+    // action on this menu either changes the entry or downloads it — none of
+    // them is what the browser was opened to do, and on SFTP that put delete
+    // one long press away from a dialog that only wanted a folder.
+    if (_isPicking) return Future.value();
     final full = _fullPath(entry);
     return showContextMenu(
       context,
@@ -1365,7 +1373,10 @@ class _FileBrowserPageState extends ConsumerState<FileBrowserPage>
         _extendTo(entry);
         return;
       }
-      if (keys.isControlPressed || keys.isMetaPressed || _selecting) {
+      // Not while picking: a selection is the beginning of acting on several
+      // entries, and a picker returns exactly one thing.
+      if (!_isPicking &&
+          (keys.isControlPressed || keys.isMetaPressed || _selecting)) {
         _toggle(entry);
         return;
       }

--- a/lib/view/page/storage/file_browser.dart
+++ b/lib/view/page/storage/file_browser.dart
@@ -204,7 +204,15 @@ class _FileBrowserPageState extends ConsumerState<FileBrowserPage>
 
   final _listFocus = FocusNode(debugLabel: 'file browser');
 
-  bool get _selecting => _selected.isNotEmpty;
+  /// Whether anything *still in the listing* is selected.
+  ///
+  /// Not `_selected.isNotEmpty`. That set holds names, and a name outlives the
+  /// entry: deleted from another session, removed by a failed batch, or
+  /// filtered out by toggling hidden files. Everything that acts on a selection
+  /// goes through [_selectedEntries], which is the listing filtered by that
+  /// set — so the two disagreed, and the bar stayed open over a selection with
+  /// nothing in it, its delete button raising a confirmation for zero files.
+  bool get _selecting => _shown.any((e) => _selected.contains(e.name));
 
   late Future<List<FileEntry>> _entries = _list();
 
@@ -233,7 +241,14 @@ class _FileBrowserPageState extends ConsumerState<FileBrowserPage>
     final entries = await backend.list(listed);
     // Here rather than at each move: this is where the browser learns the
     // directory really opened.
-    if (mounted) widget.args.onPathChanged?.call(listed);
+    //
+    // Only while it is still the directory being shown. A slow listing that
+    // lands after the user has moved on would otherwise announce where they
+    // were, and this is what the file tab persists — a listing of `/slow`
+    // finishing after a move to `/fast` reopened the tab at `/slow`.
+    if (mounted && _path.path == listed) {
+      widget.args.onPathChanged?.call(listed);
+    }
     return entries;
   }
 
@@ -386,6 +401,10 @@ class _FileBrowserPageState extends ConsumerState<FileBrowserPage>
       _pick(entry);
       return;
     }
+    // Picking a directory: a file is not something to act on here. Falling
+    // through opened the entry menu — edit, delete, download — in a browser the
+    // caller put up only to choose a folder.
+    if (widget.args.isPickDir) return;
     final open = widget.args.onOpenFile;
     if (open == null) {
       _showEntryMenu(entry);
@@ -558,15 +577,41 @@ class _FileBrowserPageState extends ConsumerState<FileBrowserPage>
     );
     if (confirmed != true) return;
 
-    await _run(() async {
+    // Not `_run`: it treats a failure as "nothing happened" and skips the
+    // reload, which is right for one operation and wrong for a batch. A refusal
+    // part way through leaves the earlier ones deleted, so the listing is stale
+    // either way — and clearing the selection wholesale after that took away
+    // the only record of which ones were left.
+    _busy.value = true;
+    final removed = <String>{};
+    Object? failure;
+    try {
       for (final entry in entries) {
         await backend.remove(
           _fullPath(entry),
           recursive: entry.isDir && recursive,
         );
+        removed.add(entry.name);
       }
-    });
-    _clearSelection();
+    } catch (e) {
+      failure = e;
+    } finally {
+      _busy.value = false;
+    }
+
+    if (mounted) {
+      setStateSafe(() {
+        // What is gone stops being selected; what is still there stays, so the
+        // user can see what the failure left behind and retry it.
+        _selected.removeAll(removed);
+        if (_selected.isEmpty) {
+          _cursor = null;
+          _anchor = null;
+        }
+      });
+      if (failure != null) Toast.error(libL10n.fail, body: '$failure');
+    }
+    await refresh();
   }
 
   Future<void> _delete(FileEntry entry) async {
@@ -671,6 +716,15 @@ class _FileBrowserPageState extends ConsumerState<FileBrowserPage>
       child: _NameField(icon: icon, initial: initial),
     );
     if (name == null || name.isEmpty || !mounted) return null;
+    // A name, not a path. Every caller joins this onto the directory being
+    // shown and hands the result to the backend, so a separator or a dot
+    // segment here renames or creates somewhere else — `../outside` in a
+    // browser rooted at `/home/me` resolves to `/home/outside`. `BrowsePath`
+    // guards where the browser *goes*, and never sees these.
+    if (name.contains('/') || name.contains(r'\') || name == '.' || name == '..') {
+      Toast.error(libL10n.invalid);
+      return null;
+    }
     return name;
   }
 

--- a/lib/view/page/storage/file_browser.dart
+++ b/lib/view/page/storage/file_browser.dart
@@ -1225,34 +1225,54 @@ class _FileBrowserPageState extends ConsumerState<FileBrowserPage>
     // registers an inherited-widget dependency, and doing that inside
     // `itemBuilder` did it for every visible entry, every rebuild.
     final narrow = MediaQuery.sizeOf(context).width < 350;
+    const padding = EdgeInsets.symmetric(vertical: 10, horizontal: 13);
+
+    Widget upTile() => ListTile(
+      leading: const Icon(Icons.arrow_upward),
+      title: const Text('..'),
+      onTap: () => _go(_path.goUp),
+    ).cardx;
+
+    // An empty directory still has to say so, and still has to be leavable.
+    //
+    // The mark this tab uses for an empty surface, not a word. The row above
+    // says where you are and how to leave; a sentence here would be describing
+    // what the reader is already looking at.
+    //
+    // The failed *search* below keeps its words: "nothing matched" and "this
+    // place is empty" are different things, and only one of them is a state of
+    // the directory.
+    //
+    // `SliverFillRemaining` and not another list item: as an item it took the
+    // height of the icon and sat at the top of the list, which reads as the
+    // first entry of a directory that has none. This centres it in whatever is
+    // left under the `..` row.
+    if (items.isEmpty) {
+      return FadeIn(
+        key: ValueKey(_path.path),
+        child: CustomScrollView(
+          slivers: [
+            if (up == 1)
+              SliverPadding(
+                padding: const EdgeInsets.fromLTRB(13, 10, 13, 0),
+                sliver: SliverToBoxAdapter(child: upTile()),
+              ),
+            const SliverFillRemaining(
+              hasScrollBody: false,
+              child: Center(child: EmptyMark(icon: Icons.folder_open)),
+            ),
+          ],
+        ),
+      );
+    }
+
     return FadeIn(
       key: ValueKey(_path.path),
       child: ListView.builder(
-        // One more than there is, when there is nothing: an empty directory
-        // still has to say so, and still has to be leavable.
-        itemCount: items.isEmpty ? up + 1 : items.length + up,
-        padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 13),
+        itemCount: items.length + up,
+        padding: padding,
         itemBuilder: (context, index) {
-          if (up == 1 && index == 0) {
-            return ListTile(
-              leading: const Icon(Icons.arrow_upward),
-              title: const Text('..'),
-              onTap: () => _go(_path.goUp),
-            ).cardx;
-          }
-          if (items.isEmpty) {
-            // The mark this tab uses for an empty surface, not a word. The row
-            // above says where you are and how to leave; a sentence here would
-            // be describing what the reader is already looking at.
-            //
-            // The failed *search* below keeps its words: "nothing matched" and
-            // "this place is empty" are different things, and only one of them
-            // is a state of the directory.
-            return const Padding(
-              padding: EdgeInsets.symmetric(vertical: 32),
-              child: EmptyMark(icon: Icons.folder_open),
-            );
-          }
+          if (up == 1 && index == 0) return upTile();
           return _buildEntry(items[index - up], narrow: narrow);
         },
       ),

--- a/test/browse_path_test.dart
+++ b/test/browse_path_test.dart
@@ -146,4 +146,73 @@ void main() {
       'docs',
     );
   });
+
+  group('dot segments cannot walk out of the root', () {
+    // Containment is a string prefix, so before these resolved, every one of
+    // the paths below passed that test while naming somewhere else — the
+    // backend is what resolves them, and it answered outside the root.
+
+    test('a target that climbs back out is refused', () {
+      final path = BrowsePath(root: '/home/me');
+
+      expect(path.goTo('/home/me/../outside'), isFalse);
+      expect(path.path, '/home/me');
+
+      expect(path.goTo('/home/me/../../etc'), isFalse);
+      expect(path.path, '/home/me');
+    });
+
+    test('a target that comes back inside is allowed, and is resolved', () {
+      final path = BrowsePath(root: '/home/me');
+
+      expect(path.goTo('/home/me/logs/../docs'), isTrue);
+      expect(path.path, '/home/me/docs');
+    });
+
+    test('. is dropped rather than kept as a component', () {
+      final path = BrowsePath(root: '/home/me');
+
+      expect(path.goTo('/home/me/./docs/.'), isTrue);
+      expect(path.path, '/home/me/docs');
+    });
+
+    test('an initial path that resolves outside lands at the root', () {
+      final path = BrowsePath(root: '/home/me', initial: '/home/me/../etc');
+
+      expect(path.path, '/home/me');
+    });
+
+    test('a root of its own is resolved too', () {
+      expect(BrowsePath(root: '/home/me/../me').root, '/home/me');
+    });
+
+    test('.. at the top stays at the top instead of escaping', () {
+      expect(BrowsePath(root: '/..').root, '/');
+      expect(BrowsePath(root: '/../../etc').root, '/etc');
+    });
+
+    test('entering a listed name is checked like any other move', () {
+      // A listing is not a trusted source of names: a server is free to answer
+      // with `..`, and this used to move there without asking.
+      final path = BrowsePath(root: '/home/me');
+
+      path.enter('..');
+      expect(path.path, '/home/me');
+
+      path.enter('docs');
+      expect(path.path, '/home/me/docs');
+
+      path.enter('..');
+      expect(path.path, '/home/me');
+    });
+
+    test('a windows root keeps its shape', () {
+      final path = BrowsePath(root: r'C:\Users\me');
+
+      expect(path.root, 'C:/Users/me');
+      expect(path.goTo('C:/Users/me/../../Windows'), isFalse);
+      expect(path.goTo('C:/Users/me/Documents'), isTrue);
+      expect(path.path, 'C:/Users/me/Documents');
+    });
+  });
 }

--- a/test/watch_sync_test.dart
+++ b/test/watch_sync_test.dart
@@ -32,12 +32,14 @@ void main() {
     List<Spi> servers = const [],
     Map<String, String> tokens = const {},
     List<String> legacyUrls = const [],
+    int stamp = 1,
   }) {
     return WatchSync.payloadFrom(
       selectedIds: selectedIds,
       lookup: (id) => servers.where((e) => e.id == id).firstOrNull,
       tokens: tokens,
       legacyUrls: legacyUrls,
+      stamp: stamp,
     );
   }
 
@@ -161,5 +163,15 @@ void main() {
 
     expect(result['urls'], ['http://10.0.0.2:3770/status']);
     expect(result['servers'], isEmpty);
+  });
+
+  test('carries the stamp the watch orders deliveries by', () {
+    // WatchConnectivity orders nothing between a queued userInfo, the
+    // application context and a reply to `requestData`, so the watch drops a
+    // payload older than the one it has already applied. Without this it can
+    // only be told what arrived last, which is not the same as what is current.
+    final result = payload(selectedIds: const [], stamp: 1737000000000);
+
+    expect(result['ts'], 1737000000000);
   });
 }

--- a/test/watch_sync_test.dart
+++ b/test/watch_sync_test.dart
@@ -174,4 +174,34 @@ void main() {
 
     expect(result['ts'], 1737000000000);
   });
+
+  group('the revision snapshots are stamped with', () {
+    test('never repeats, even called faster than the clock moves', () {
+      // The watch treats an equal revision as already seen, so two snapshots
+      // sharing one would silently drop the second. A thousand in a row take
+      // well under a millisecond.
+      final seen = [for (var i = 0; i < 1000; i++) WatchSync.nextRevision()];
+
+      expect(seen.toSet().length, seen.length);
+    });
+
+    test('increases, so a later snapshot always outranks an earlier one', () {
+      // Which is the whole point: the payload built from the newer selection
+      // has to win regardless of which one finishes its token requests first.
+      final first = WatchSync.nextRevision();
+      final second = WatchSync.nextRevision();
+      final third = WatchSync.nextRevision();
+
+      expect(second, greaterThan(first));
+      expect(third, greaterThan(second));
+    });
+
+    test('starts from the clock, so a restart does not look like the past', () {
+      // A counter from zero would be older than everything the watch had
+      // already applied, and every payload after a relaunch would be dropped.
+      final before = DateTime.now().millisecondsSinceEpoch;
+
+      expect(WatchSync.nextRevision(), greaterThanOrEqualTo(before));
+    });
+  });
 }


### PR DESCRIPTION
Two things an app can do about being looked at while it is not being used, plus three fixes that were in the way.

## Screenshot label

The Dynamic Island is composited by the system above every app window, but a screenshot captures the app's own layers and not that overlay. The strip of screen behind the pill is therefore invisible in use and visible in every screenshot a user shares, which is where the app's name now goes, as a badge in the app's own theme colours. The colours are pushed from Dart on every theme change, since a native view cannot read a `ColorScheme`.

Portrait Dynamic Island devices only. In landscape the pill moves to the long edge, and a notch is a different shape, so on either the badge would sit in plain view instead of behind something.

The pill's top offset is **not** constant across models — 14 Pro through 16 sit at y≈11 under a 59pt safe-area inset, 16 Pro and 17 at y≈14 under 62pt, iPhone Air lower still — but the gap *below* it is. So the geometry anchors to the bottom of the safe area rather than to a hardcoded y or a table of device identifiers, either of which the next model would falsify.

**Known gap:** while the Dynamic Island is active (Live Activity, call, screen recording, mic/camera indicator) iOS renders the pill into the framebuffer for real and the badge is covered. This app has a terminal Live Activity, so a screenshot taken during an SSH session will not carry the name. Not controllable from the app.

## App switcher cover

Off by default; the switch is in Settings → App, under biometric auth.

| | iOS | Android |
|---|---|---|
| Mechanism | `UIVisualEffectView` over the Flutter window | `FLAG_SECURE` |
| Effect | Real blur, visible on screen | Blanks the recents thumbnail and blocks screenshots; the running UI is untouched |
| Applied | `willDeactivate` | `onPause` |

Android is not a visual cover, and deliberately so: Flutter draws into a `SurfaceView` that `RenderEffect` cannot reach, and any cover that has to render a frame races the system's recents capture, which the flag does not. The cost is that Android cannot hide anything from someone looking at the screen — only from the thumbnail and from screenshots.

Coming back, the cover is held until Dart has decided whether a biometric lock is coming. That closes a window which predates this branch: `didActivate` to `LocalAuthPage` being pushed used to show the real UI for several frames. It is released just *before* that push — on iOS the cover is a view over the whole Flutter window, so it is above every route drawn inside it, and holding it through the lock screen would hide the very thing it was being held for.

## Not yet verified

Both need a look on a real device; I could not confirm either from here.

- **The Dynamic Island badge has never been seen rendering.** On the simulator, oversizing it to 64pt tall (the pill is 37pt) still produced no pixels in a screenshot scan, so the overlay window is not drawing. The colours do reach the native side. My unconfirmed suspicion is that a non-key overlay window reports `safeAreaInsets.top` as 0, so the code decides the device has no Dynamic Island and hides the badge.
- **Whether the iOS blur survives into the switcher snapshot.** iOS may downgrade a `UIVisualEffectView` to flat colour when taking it. If it does, there is no way around it: Flutter renders to a Metal layer, so `drawHierarchy` captures nothing and the usual snapshot + `CIGaussianBlur` approach does not apply.

## Unrelated fixes

- `fix(android)` — `WRITE_EXTERNAL_STORAGE` declares `maxSdkVersion=32` here and 28 in `camera_android_camerax`; the merger refuses to pick, `:app:processDebugMainManifest` fails, and no APK builds at all. `tools:replace` keeps this app's own answer. **This was blocking any Android build on `main`** and can be cherry-picked out if it should land separately.
- `fix(settings)` — the floating tab bar's shadow was clipped above and below. Its horizontal `SingleChildScrollView` clips to a viewport exactly as tall as the bar, so the sides survived and the top and bottom stopped square. The room is now padding inside that viewport; the clip stays, because the horizontal axis still needs it.
- `fix(files)` — the empty-directory mark was a list item, so it sat at the top at icon height and read as the first entry of a directory that has none. It now centres in what is left under the `..` row.

## Testing

`flutter analyze` clean, `flutter test` 1507 passing. iOS device/simulator and Android APK all build. The one failing test, `windows_install_ssh_e2e_test.dart`, is a pre-existing opt-in SSH e2e that wants `SBM_E2E_SSH_KEY_PASSPHRASE`; it is unrelated and arguably should skip rather than fail when the key cannot be loaded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional privacy protection that blurs app content in the app switcher and protects it while inactive or locked.
  - Added theme-aware Dynamic Island branding on supported iPhones.
  - Added privacy protection controls to mobile settings.

- **Bug Fixes**
  - Improved file browser selection, deletion, navigation, naming, and empty-folder displays.
  - Improved path normalization and root-boundary handling.
  - Prevented stale watch updates and invalid server selections.
  - Refined settings tab positioning, spacing, and overflow behavior.

- **Localization**
  - Added privacy protection translations across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- winnowl:summary:begin -->
## Summary

### Changes

- **Cross\-platform privacy cover, Dynamic Island branding, and lifecycle coordination**: Adds native privacy-cover behavior on Android and iOS, theme-colored Dynamic Island branding, Dart method-channel/settings integration, biometric resume locking, and launch/lifecycle wiring.
- **Watch synchronization protocol, token lifecycle, and WatchConnectivity delivery**: Moves watch selection and legacy URL compatibility into settings, issues/reuses/revokes scoped monitor tokens, pushes durable and realtime payloads, adds revision ordering, and makes the watch app consume all delivery paths.
- **BrowsePath confinement and file\-browser navigation/mutation contract**: Separates browser root from current path, normalizes POSIX/Windows paths and dot segments, adds bounded back history, and routes file-browser navigation, pickers, listing persistence, and mutations through the new model.
- **Home tab identity, settings navigation tree, and responsive presentation**: Persists the last home tab by stable name with legacy positional fallback, publishes tab identity, restructures settings into hierarchical wide/narrow navigation with declarative pages, and adds responsive tab-bar presentation and guides.
- **Localization resources and generated localization API**: Adds or updates user-facing strings for privacy, watch/accessory settings, file browsing, settings navigation, and related features across ARB sources and generated locale implementations.
- **Redfish package pointer and repository build integration**: Includes the changed packages/redfish repository pointer as part of the reviewed change set.
<!-- winnowl:summary:end -->