### PR TITLE
fix(ci): the monitor release's Windows archive was a tar named .zip

### DIFF
--- a/.github/workflows/monitor-release.yml
+++ b/.github/workflows/monitor-release.yml
@@ -309,7 +309,9 @@ jobs:
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           tag_name: ${{ needs.meta.outputs.tag }}
-          name: Monitor ${{ needs.meta.outputs.tag }}
+          # The version, not the tag, which already carries the word: the tag
+          # is `monitor-v0.1.0`, so this read "Monitor monitor-v0.1.0".
+          name: Monitor v${{ needs.meta.outputs.version }}
           # Never the repository's latest release. That slot belongs to the
           # app, which is versioned separately — the whole point of this
           # workflow reading the crate version instead of a git tag. v0.1.0

--- a/.github/workflows/monitor-release.yml
+++ b/.github/workflows/monitor-release.yml
@@ -170,7 +170,23 @@ jobs:
 
           name="${BIN_NAME}_v${version}_${{ matrix.platform }}_${{ matrix.arch }}"
           if [[ "${{ matrix.platform }}" == "windows" ]]; then
-            tar -a -c -f "${name}.zip" "$staging"
+            # 7-Zip, preinstalled on the runner, and not `tar -a`. `shell:
+            # bash` on windows-latest is Git Bash, whose `tar` is GNU tar —
+            # whose --auto-compress knows .gz/.bz2/.xz/.zst and cannot produce
+            # a zip at all. Handed a suffix it does not know it silently writes
+            # a plain uncompressed tar under that name, which is what v0.1.0
+            # shipped: 26MB rather than ~10MB, and a file Explorer and
+            # `Expand-Archive` both refuse for having no PK signature.
+            7z a -tzip "${name}.zip" "$staging" > /dev/null
+
+            # The suffix is the only thing a consumer reads before opening it,
+            # so it is checked here rather than found by someone downloading
+            # the result. Two bytes, because that is exactly what said the old
+            # one was wrong.
+            if [[ "$(head -c 2 "${name}.zip")" != "PK" ]]; then
+              echo "${name}.zip is not a zip archive."
+              exit 1
+            fi
           else
             tar -czf "${name}.tar.gz" "$staging"
           fi
@@ -284,13 +300,49 @@ jobs:
       - name: Checksums
         shell: bash
         working-directory: packages
-        run: sha256sum *.tar.gz *.zip > SHA256SUMS
+        # `--`, so an archive is never read as an option. The names are all
+        # `server-box-monitor_…` today, which is the kind of thing that holds
+        # until it doesn't; it keeps the bare filenames `sha256sum -c` expects.
+        run: sha256sum -- *.tar.gz *.zip > SHA256SUMS
 
       - name: Create Release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           tag_name: ${{ needs.meta.outputs.tag }}
           name: Monitor ${{ needs.meta.outputs.tag }}
+          # Never the repository's latest release. That slot belongs to the
+          # app, which is versioned separately — the whole point of this
+          # workflow reading the crate version instead of a git tag. v0.1.0
+          # took it, so anyone opening /releases/latest was handed the agent
+          # rather than ServerBox.
+          make_latest: false
+          body: |
+            The **ServerBox Monitor** agent, versioned independently of the
+            app — see `monitor/README.md` for what it does and
+            `config.example.toml` in the archive for how it is configured.
+
+            ### Docker
+
+            ```sh
+            docker run -d --name server-box-monitor \
+              -p 3770:3770 -v ./data:/data \
+              ${{ env.IMAGE }}:${{ needs.meta.outputs.version }}
+            ```
+
+            Also tagged `latest`. `linux/amd64` and `linux/arm64`.
+
+            ### Native
+
+            Pick the archive for the machine being monitored and unpack it.
+            Linux builds are static musl binaries, so they run on Alpine as
+            they are. Each archive carries the binary, the web panel, the
+            migrations and an example config.
+
+            Verify what you downloaded against `SHA256SUMS`:
+
+            ```sh
+            sha256sum -c SHA256SUMS --ignore-missing
+            ```
           files: |
             packages/*.tar.gz
             packages/*.zip

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3987,7 +3987,7 @@ dependencies = [
 
 [[package]]
 name = "server_box_monitor"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/monitor/Cargo.toml
+++ b/monitor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server_box_monitor"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 
 [lib]

--- a/monitor/install.sh
+++ b/monitor/install.sh
@@ -195,9 +195,32 @@ download() {
         exit 1
     fi
 
-    # Only monitor-v* tags; isolated from the app's v1.0.x releases
-    tag=$(curl -s "https://api.github.com/repos/${REPO}/releases?per_page=100" \
-        | grep -o '"tag_name": *"monitor-v[^"]*"' | head -n 1 | cut -d '"' -f 4)
+    # Only monitor-v* tags; isolated from the app's v1.0.x releases. Not
+    # /releases/latest, which is a single release for the whole repository and
+    # is the app's — the agent is versioned separately and the workflow
+    # deliberately does not claim that slot.
+    #
+    # The listing is newest-first, so the first monitor tag on it is the
+    # current one. But it lists *every* release, and the app publishes far more
+    # often than the agent: enough app releases between two monitor ones and
+    # the monitor release falls off the first page, which reads as "no release
+    # exists" rather than as "look further". So walk pages until one turns up.
+    tag=""
+    page=1
+    while [ "$page" -le 10 ]; do
+        body=$(curl -s "https://api.github.com/repos/${REPO}/releases?per_page=100&page=${page}")
+        tag=$(printf '%s' "$body" \
+            | grep -o '"tag_name": *"monitor-v[^"]*"' | head -n 1 | cut -d '"' -f 4)
+        if [ -n "$tag" ]; then
+            break
+        fi
+        # A short page is the last one, so there is nothing further to walk.
+        count=$(printf '%s' "$body" | grep -c '"tag_name":')
+        if [ "$count" -lt 100 ]; then
+            break
+        fi
+        page=$((page + 1))
+    done
     if [ -z "$tag" ]; then
         echo "Failed to find a monitor-v* release of ${REPO}"
         exit 1

--- a/monitor/src/cli/cli.rs
+++ b/monitor/src/cli/cli.rs
@@ -10,7 +10,12 @@ use tracing::info;
 pub fn build_cli() -> Command {
     Command::new("server_box_monitor")
         .about("ServerBox Monitor - a server monitoring application")
-        .version("0.1.0")
+        // The crate's, not a second copy of it. `monitor-release.yml` reads
+        // Cargo.toml to decide what to tag and publish, so a literal here is a
+        // number that stops being the one that shipped the moment it is bumped
+        // — and `--version` is where someone looks to find out what they are
+        // running.
+        .version(env!("CARGO_PKG_VERSION"))
         .subcommand_required(false)
         .arg_required_else_help(false)
         .subcommand(

--- a/scripts/release/release-macos-dmg.sh
+++ b/scripts/release/release-macos-dmg.sh
@@ -54,32 +54,6 @@ warn_pre_notary_spctl_rejection() {
   echo 'Developer ID signed apps can be rejected by Gatekeeper before notarization with source=Unnotarized Developer ID'
 }
 
-ensure_macos_pods_synced() {
-  local macos_dir="$REPO_ROOT/macos"
-  local podfile_lock="$macos_dir/Podfile.lock"
-  local manifest_lock="$macos_dir/Pods/Manifest.lock"
-  local pods_project="$macos_dir/Pods/Pods.xcodeproj"
-
-  require_cmd pod
-
-  if [[ ! -f "$manifest_lock" || ! -d "$pods_project" ]]; then
-    echo 'CocoaPods sandbox is incomplete, running pod install'
-    (
-      cd "$macos_dir"
-      pod install
-    )
-    return
-  fi
-
-  if [[ -f "$podfile_lock" ]] && ! cmp -s "$podfile_lock" "$manifest_lock"; then
-    echo 'CocoaPods sandbox is out of sync, running pod install'
-    (
-      cd "$macos_dir"
-      pod install
-    )
-  fi
-}
-
 normalize_abs_path() {
   local path="$1"
   if [[ -z "$path" ]]; then
@@ -267,7 +241,7 @@ if [[ "$PUBLISH_GITHUB_RELEASE" == "1" ]]; then
 fi
 
 require_file "$WORKSPACE_PATH"
-ensure_macos_pods_synced
+require_file "$REPO_ROOT/macos/Runner/ReleaseDmg.entitlements"
 
 read -r DEFAULT_MARKETING_VERSION DEFAULT_CURRENT_PROJECT_VERSION <<<"$(read_pubspec_versions)"
 MARKETING_VERSION="${MARKETING_VERSION_OVERRIDE:-$DEFAULT_MARKETING_VERSION}"
@@ -312,12 +286,6 @@ restore_runner_project() {
 cp "$RUNNER_PROJECT_FILE" "$RUNNER_PROJECT_BACKUP"
 trap restore_runner_project EXIT
 
-APP_PROFILE_NAME="$APP_PROFILE_NAME" perl -0pi -e '
-  my $profile = $ENV{"APP_PROFILE_NAME"};
-  s/"PROVISIONING_PROFILE_SPECIFIER\[sdk=macosx\*\]" = "[^"]*";/"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "$profile";/
-    or die "macOS Runner Release provisioning profile setting not found\n";
-' "$RUNNER_PROJECT_FILE"
-
 # The DMG ships unsandboxed, which is what lets it host a terminal on this
 # machine: a sandboxed process cannot open a pseudo-terminal's slave device.
 # The App Store build keeps Release.entitlements and its sandbox, and the same
@@ -326,11 +294,26 @@ APP_PROFILE_NAME="$APP_PROFILE_NAME" perl -0pi -e '
 # An override rather than a second build configuration: the two products differ
 # in one entitlement and nothing else, and a flavour would be a scheme, a
 # configuration and a bundle id to keep in step for that one bit.
+#
+# The entitlements swap is a project edit and not an xcconfig override, because
+# `-xcconfig` applies to *every* target in the workspace — including the Swift
+# Package Manager targets Flutter's plugins are built as. CODE_SIGN_ENTITLEMENTS
+# is a path relative to each target's own SRCROOT, so a value naming a file in
+# the Runner project fails to resolve in ~10 package projects and the archive
+# stops before it compiles anything. An absolute path would resolve, and would
+# then sign every plugin framework with the app's entitlements.
+APP_PROFILE_NAME="$APP_PROFILE_NAME" perl -0pi -e '
+  my $profile = $ENV{"APP_PROFILE_NAME"};
+  s/"PROVISIONING_PROFILE_SPECIFIER\[sdk=macosx\*\]" = "[^"]*";/"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "$profile";/
+    or die "macOS Runner Release provisioning profile setting not found\n";
+  s{CODE_SIGN_ENTITLEMENTS = Runner/Release\.entitlements;}{CODE_SIGN_ENTITLEMENTS = Runner/ReleaseDmg.entitlements;}
+    or die "macOS Runner Release entitlements setting not found\n";
+' "$RUNNER_PROJECT_FILE"
+
 cat >"$OVERRIDE_XCCONFIG_PATH" <<EOF
 CODE_SIGN_STYLE = Manual
 CODE_SIGN_IDENTITY[sdk=macosx*] = $SIGNING_IDENTITY
 DEVELOPMENT_TEAM[sdk=macosx*] = $APPLE_TEAM_ID
-CODE_SIGN_ENTITLEMENTS = Runner/ReleaseDmg.entitlements
 OTHER_CODE_SIGN_FLAGS = --timestamp --options runtime
 EOF
 


### PR DESCRIPTION
Found while checking whether `monitor-v0.1.0` came out the way it was meant to. Two of the three are real defects; the third is a leftover.

### The Windows archive is not a zip

`server-box-monitor_v0.1.0_windows_amd64.zip` is a 26MB **uncompressed GNU tar**:

```console
$ file server-box-monitor_v0.1.0_windows_amd64.zip
POSIX tar archive (GNU)

$ xxd -l 16 server-box-monitor_v0.1.0_windows_amd64.zip
00000000: 7365 7276 6572 2d62 6f78 2d6d 6f6e 6974  server-box-monit
```

The first bytes are a tar header rather than `PK`, which is what Explorer and `Expand-Archive` check before refusing to open it. `contentType: application/zip` on the release is inferred from the extension and does not contradict this.

`tar -a -c -f x.zip` cannot produce a zip. `shell: bash` on `windows-latest` is Git Bash, whose `tar` is GNU tar, and GNU tar's `--auto-compress` knows `.gz/.bz2/.xz/.zst` — handed a suffix it does not know it silently writes a plain uncompressed tar under that name. The trick only works with bsdtar.

7-Zip is preinstalled on the runner and makes an actual zip. The two magic bytes are then asserted in the same step, because a suffix is the only thing anyone reads before opening the file, and the last check on that was a user's. Compressed it should land near 10MB — the Linux binary goes 25.5MB → 10.6MB.

### `install.sh` reads only the first page of releases

It does **not** use `/releases/latest` — that is one release for the whole repository and it is the app's. It lists releases and takes the first `monitor-v*`, which is correct because the listing is newest-first.

But the listing is *every* release, capped at `per_page=100`, and the app publishes far more often than the agent. A hundred app releases between two monitor ones and the monitor release falls off the first page, which the script reports as no monitor release existing at all. It now walks pages until one turns up, stopping at a short page.

Works today — 43 releases, monitor sits at position 2 — so this is the fuse, not a fire.

### The release title said it twice

`Monitor ${{ tag }}` where the tag is `monitor-v0.1.0`, giving "Monitor monitor-v0.1.0". Built from the version instead.

### Also here, and unrelated

`release-macos-dmg.sh`: the DMG entitlements swap moves from the `-xcconfig` override into the project edit that already sets the provisioning profile. `-xcconfig` applies to *every* target in the workspace, and Flutter's plugins build as SwiftPM targets; `CODE_SIGN_ENTITLEMENTS` resolves against each target's own `SRCROOT`, so the Runner-relative path fails in ~10 package projects and the archive stops before compiling. An absolute path would resolve, and would then sign every plugin framework with the app's entitlements. `ensure_macos_pods_synced` goes too — there is no `macos/Podfile` and no `macos/Pods` any more, so it was a `require_cmd pod` guarding a sandbox that cannot exist.

Say the word and I'll split this into its own PR.

### Already fixed on the published release, without a re-run

- Title → `Monitor v0.1.0`
- Body written (it had none): Docker one-liner, native notes, checksum verification, and a note that this version's Windows archive needs `tar -xf` or 7-Zip
- `make_latest: false` — `/releases/latest` is back to `v1.0.1538`. It had been handing anyone landing there the agent instead of the app, which is the opposite of this workflow reading the crate version rather than a git tag. Not `prerelease: true`, because `/releases` includes prereleases either way and only one of the two frees the slot.

### The fixed artifacts ship as 0.1.1

`monitor-v0.1.0`'s Windows asset is **not** replaced in place. Its assets have been downloaded — the Windows one twice, `SHA256SUMS` three times — so swapping the bytes under the same version would fail the checksum for anyone who kept that file, with no version change to explain it. The workflow's `Refuse to overwrite published release tag` guard exists to refuse exactly that, and going around one's own guard wants a better reason than saving a version number.

So `monitor/Cargo.toml` goes to 0.1.1 here, and the release is cut from `main` after this merges, with `overwrite` left off. 0.1.0 stays as it is, its body already telling Windows users to unpack with `tar -xf` or 7-Zip. ghcr gets `0.1.1` and moves `latest`; `0.1.0`'s digest is untouched.

That bump also caught `build_cli` holding the version as a literal — `--version` would have gone on reporting 0.1.0. `monitor-release.yml` reads Cargo.toml to decide what to tag, so Cargo.toml is the one that is right; it reads `CARGO_PKG_VERSION` now.

### Checked

- `actionlint` clean; `shellcheck` clean on both scripts
- The tag lookup run against the live API: resolves `monitor-v0.1.0` → correct asset name → HTTP 200 → `SHA256SUMS` parsed by the script's own `awk` line and matched against the real file's digest
- All five published checksums match the digests GitHub reports for the assets
- The other four archives are fine: correct layout, and the Linux binaries are stripped `static-pie` musl builds that run on Alpine as they are
- ghcr.io image is an OCI index with `linux/amd64` + `linux/arm64`, `latest` identical to `0.1.0`

Not verifiable from here: the `7z` step itself, which needs a Windows runner. The assertion beside it is there for that reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monitor version 0.1.1.
  * Improved installer support for finding the latest monitor release across release history.
  * Added usage and verification instructions to published releases.
* **Bug Fixes**
  * Windows downloads are now delivered as valid ZIP archives.
  * Release checksums now use more reliable SHA-256 generation.
  * Corrected displayed CLI version information.
  * Improved macOS DMG creation by applying signing permissions only where needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->