### PR TITLE
Require encryption for all remote backups

### DIFF
--- a/lib/core/sync.dart
+++ b/lib/core/sync.dart
@@ -35,16 +35,25 @@ final class BakSyncer extends SyncIface {
 
   @override
   Future<void> saveToFile() async {
+    await writeEncryptedBackup(
+      includeSettings: PrefProps.syncAppSettings.get(),
+    );
+  }
+
+  /// Writes a backup that is safe to upload to remote storage.
+  ///
+  /// Remote writes are always encrypted. Reading remains backwards-compatible
+  /// in [fromFile] so a plaintext backup created before this requirement can be
+  /// merged and replaced by an encrypted backup on the next upload.
+  Future<String> writeEncryptedBackup({
+    String? name,
+    bool includeSettings = true,
+  }) async {
     final pwd = await SecureStoreProps.bakPwd.read();
     if (pwd == null || pwd.isEmpty) {
       throw StateError(l10n.remoteBackupPasswordRequired);
     }
-    final includeSettings = PrefProps.syncAppSettings.get();
-    await BackupV2.backup(
-      null,
-      pwd,
-      includeSettings,
-    );
+    return BackupV2.backup(name, pwd, includeSettings);
   }
 
   @override
@@ -61,6 +70,9 @@ final class BakSyncer extends SyncIface {
           includeSettings: includeSettings,
         );
       }
+      // Backups uploaded before remote encryption became mandatory are
+      // plaintext. Keep accepting them; only new remote writes are required
+      // to be encrypted.
       final mergeable = MergeableUtils.fromJsonString(content).$1;
       return _normalizeSyncPayload(mergeable, includeSettings: includeSettings);
     } on SchemaTooNewException catch (e) {
@@ -144,7 +156,9 @@ final class BakSyncer extends SyncIface {
       );
       final mergeable = await fromFile(localPath);
       await mergeable.merge();
-      Loggers.app.info('Inherited sync history from ${Miscs.legacyBakFileName}');
+      Loggers.app.info(
+        'Inherited sync history from ${Miscs.legacyBakFileName}',
+      );
     } catch (e, s) {
       // Best-effort: failing to inherit leaves the user with an empty remote
       // they can populate by syncing, which is recoverable. Failing loudly

--- a/lib/view/page/backup.dart
+++ b/lib/view/page/backup.dart
@@ -9,7 +9,6 @@ import 'package:icons_plus/icons_plus.dart';
 import 'package:server_box/core/extension/context/inset.dart';
 import 'package:server_box/core/extension/context/locale.dart';
 import 'package:server_box/core/sync.dart';
-import 'package:server_box/data/model/app/bak/backup2.dart';
 import 'package:server_box/data/model/app/bak/backup_service.dart';
 import 'package:server_box/data/model/app/bak/backup_source.dart';
 import 'package:server_box/data/model/server/server_private_info.dart';
@@ -133,6 +132,10 @@ final class _BackupPageState extends ConsumerState<BackupPage>
                   UIs.width7,
                   TextButton(
                     onPressed: () async {
+                      if (_hasEnabledRemoteSync) {
+                        Toast.show(l10n.remoteBackupPasswordRequired);
+                        return;
+                      }
                       await SecureStoreProps.bakPwd.write(null);
                       Toast.show(l10n.backupPasswordRemoved);
                       setState(() {});
@@ -149,7 +152,16 @@ final class _BackupPageState extends ConsumerState<BackupPage>
     );
   }
 
-  Future<void> _onTapSetBakPwd(BuildContext context) async {
+  bool get _hasEnabledRemoteSync =>
+      (isICloudSupported && PrefProps.icloudSync.get()) ||
+      PrefProps.webdavSync.get() ||
+      PrefProps.gistSync.get();
+
+  Future<bool> _onTapSetBakPwd(
+    BuildContext context, {
+    String? hint,
+    String? emptyMessage,
+  }) async {
     final currentPwd = await SecureStoreProps.bakPwd.read();
     final controller = TextEditingController(text: currentPwd ?? '');
     final node = FocusNode();
@@ -164,7 +176,7 @@ final class _BackupPageState extends ConsumerState<BackupPage>
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text(l10n.backupPasswordTip, style: UIs.textGrey),
+            Text(hint ?? l10n.backupPasswordTip, style: UIs.textGrey),
             UIs.height13,
             Input(
               label: l10n.backupPassword,
@@ -178,16 +190,17 @@ final class _BackupPageState extends ConsumerState<BackupPage>
       ),
       actions: Btnx.oks,
     );
-    if (result != true) return;
+    if (result != true) return false;
 
     final pwd = controller.text.trim();
     if (pwd.isEmpty) {
-      Toast.show(libL10n.empty);
-      return;
+      Toast.show(emptyMessage ?? libL10n.empty);
+      return false;
     }
     await SecureStoreProps.bakPwd.write(pwd);
     Toast.show(l10n.backupPasswordSet);
     setState(() {});
+    return true;
   }
 
   Widget get _buildTip {
@@ -601,7 +614,8 @@ extension on _BackupPageState {
 
     final files = await icloud.list();
     final matches = files.where(
-      (file) => file.relativePath == Paths.bakName && file.contentChangeDate != null,
+      (file) =>
+          file.relativePath == Paths.bakName && file.contentChangeDate != null,
     );
     if (matches.isEmpty) return null;
 
@@ -649,15 +663,7 @@ extension on _BackupPageState {
     try {
       final ok = await _ensureBakPwd(context);
       if (!ok) return;
-      final savedPassword = await SecureStoreProps.bakPwd.read();
-      if (savedPassword == null || savedPassword.isEmpty) {
-        Toast.show(l10n.backupPassword);
-        return;
-      }
-      await BackupV2.backup(
-        bakName,
-        savedPassword,
-      );
+      await bakSync.writeEncryptedBackup(name: bakName);
       await Webdav.shared.upload(relativePath: bakName);
       Loggers.app.info('Upload webdav backup success');
     } catch (e, s) {
@@ -698,15 +704,7 @@ extension on _BackupPageState {
     try {
       final ok = await _ensureBakPwd(context);
       if (!ok) return;
-      final savedPassword = await SecureStoreProps.bakPwd.read();
-      if (savedPassword == null || savedPassword.isEmpty) {
-        Toast.show(l10n.backupPassword);
-        return;
-      }
-      await BackupV2.backup(
-        bakName,
-        savedPassword,
-      );
+      await bakSync.writeEncryptedBackup(name: bakName);
       await GistRs.shared.upload(relativePath: bakName);
       Loggers.app.info('Upload gist backup success');
     } catch (e, s) {
@@ -900,7 +898,7 @@ extension on _BackupPageState {
     // mandatory rather than an optional warning.
     final result = await context.showRoundDialog<bool>(
       title: l10n.backupPassword,
-      child: Text(l10n.backupPasswordTip, style: UIs.textGrey),
+      child: Text(l10n.remoteBackupPasswordRequired, style: UIs.textGrey),
       actions: [
         TextButton(
           onPressed: () => context.popDialog(false),
@@ -914,9 +912,11 @@ extension on _BackupPageState {
     );
 
     if (result == true) {
-      await _onTapSetBakPwd(context);
-      final savedAfterSetting = await SecureStoreProps.bakPwd.read();
-      return savedAfterSetting != null && savedAfterSetting.isNotEmpty;
+      return _onTapSetBakPwd(
+        context,
+        hint: l10n.remoteBackupPasswordRequired,
+        emptyMessage: l10n.remoteBackupPasswordRequired,
+      );
     }
 
     return false;

--- a/test/backup_sync_encryption_test.dart
+++ b/test/backup_sync_encryption_test.dart
@@ -1,0 +1,103 @@
+import 'dart:io';
+
+import 'package:fl_lib/fl_lib.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:server_box/core/sync.dart';
+import 'package:server_box/data/model/app/bak/backup2.dart';
+import 'package:server_box/data/res/store.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp('sbm-backup-sync-');
+    Paths.doc = tempDir.path;
+    SharedPreferences.setMockInitialValues({});
+    await PrefStore.shared.init();
+  });
+
+  tearDownAll(() async => tempDir.delete(recursive: true));
+
+  setUp(() async {
+    FlutterSecureStorage.setMockInitialValues({});
+    SqliteDb.openInMemory();
+    await Stores.init();
+  });
+
+  tearDown(() async {
+    await getIt.reset();
+    await SqliteDb.close();
+  });
+
+  test('remote backup writes require a non-empty password', () async {
+    final path = tempDir.path.joinPath('missing-password.json');
+
+    await expectLater(
+      bakSync.writeEncryptedBackup(name: 'missing-password.json'),
+      throwsA(isA<StateError>()),
+    );
+
+    expect(File(path).existsSync(), isFalse);
+  });
+
+  test('every new remote backup write is encrypted', () async {
+    FlutterSecureStorage.setMockInitialValues({
+      SecureStoreProps.bakPwd.key: 'remote-password',
+    });
+
+    final path = await bakSync.writeEncryptedBackup(name: 'encrypted.json');
+    final content = await File(path).readAsString();
+
+    expect(Cryptor.isEncrypted(content), isTrue);
+    expect(
+      BackupV2.fromJsonString(content, 'remote-password').version,
+      BackupV2.formatVer,
+    );
+  });
+
+  test('a legacy plaintext remote backup remains readable', () async {
+    FlutterSecureStorage.setMockInitialValues({
+      SecureStoreProps.bakPwd.key: 'remote-password',
+    });
+    await PrefProps.syncAppSettings.set(true);
+    addTearDown(() => PrefProps.syncAppSettings.set(false));
+    final plaintext = BackupV2(
+      version: BackupV2.formatVer,
+      date: 123,
+      spis: const {},
+      snippets: const {},
+      keys: const {},
+      container: const {},
+      history: const {},
+      settings: const {'timeOut': 17},
+    ).toJsonString();
+    final legacyFile = File(tempDir.path.joinPath('legacy-plaintext.json'));
+    await legacyFile.writeAsString(plaintext);
+
+    final restored = await bakSync.fromFile(legacyFile.path);
+
+    expect(restored, isA<BackupV2>());
+    final legacyBackup = restored as BackupV2;
+    expect(legacyBackup.date, 123);
+    expect(legacyBackup.settings['timeOut'], 17);
+    await legacyBackup.merge(force: true);
+
+    final replacementPath = await bakSync.writeEncryptedBackup(
+      name: 'replacement.json',
+    );
+    final replacement = await File(replacementPath).readAsString();
+    expect(Cryptor.isEncrypted(replacement), isTrue);
+    expect(
+      BackupV2.fromJsonString(
+        replacement,
+        'remote-password',
+      ).settings['timeOut'],
+      17,
+      reason: 'the encrypted replacement must retain the restored data',
+    );
+  });
+}


### PR DESCRIPTION
Resolve #1360

## Summary

- Enforce a non-empty backup password for remote backup writes.
- Route WebDAV, Gist, and automatic sync uploads through encrypted backup generation.
- Prevent removal of the backup password while remote sync is enabled.
- Preserve backward compatibility by continuing to read legacy plaintext remote backups.
- Add coverage for password validation, encrypted writes, and plaintext migration.

## Testing

- Added Flutter tests covering mandatory passwords, encrypted backup output, and legacy plaintext restoration followed by encrypted replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Remote backups are now encrypted when uploaded through supported sync services.
  - Added password validation and clearer prompts when configuring remote backup protection.
  - Prevented removal of the backup password while remote synchronization remains enabled.

- **Bug Fixes**
  - Legacy plaintext remote backups can still be restored and converted to encrypted backups.
  - Restored settings remain intact during backup conversion.

- **Tests**
  - Added coverage for encrypted backup creation, password validation, and legacy backup compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->