### PR TITLE
fix(settings): pop nested pages on system back

### DIFF
--- a/lib/view/page/setting/entry.dart
+++ b/lib/view/page/setting/entry.dart
@@ -562,7 +562,7 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
       );
     }
 
-    return Navigator(
+    final navigator = Navigator(
       key: _contentNav,
       pages: [
         if (wide)
@@ -593,6 +593,14 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
           setState(_path.removeLast);
         }
       },
+    );
+
+    // Platform back belongs to this stack while it has somewhere to go. Without
+    // a pop handler the enclosing navigator removes the whole settings route,
+    // skipping whichever level or manually pushed page is currently on top.
+    return NavigatorPopHandler(
+      onPopWithResult: (_) => _contentNav.currentState?.pop(),
+      child: navigator,
     );
   }
 

--- a/test/settings_menu_test.dart
+++ b/test/settings_menu_test.dart
@@ -331,4 +331,36 @@ void main() {
     await settle(tester, 20);
     expect(contentNav().pages.length, 1);
   });
+
+  testWidgets('system back pops one settings page at a time', (tester) async {
+    await pump(tester, width: 500);
+    await tester.tap(menuRow(libL10n.server));
+    await settle(tester, 20);
+
+    final contentNavFinder = find.byWidgetPredicate(
+      (widget) => widget is Navigator && widget.pages.isNotEmpty,
+    );
+    final contentNav = tester.state<NavigatorState>(contentNavFinder);
+    final pushed = contentNav.push<void>(
+      MaterialPageRoute<void>(
+        builder: (_) => const Scaffold(body: Text('deeper settings page')),
+      ),
+    );
+    await settle(tester);
+
+    await tester.binding.handlePopRoute();
+    await pushed;
+    await settle(tester, 40);
+    expect(find.text('deeper settings page'), findsNothing);
+    expect(barTitle(tester), libL10n.general);
+
+    await tester.binding.handlePopRoute();
+    await settle(tester, 20);
+    expect(barTitle(tester), libL10n.setting);
+    expect(menuRow(libL10n.server), findsOneWidget);
+
+    await tester.binding.handlePopRoute();
+    await settle(tester, 20);
+    expect(find.text('open'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary

- route platform back events through the settings content navigator while it can still pop
- preserve the normal behavior of leaving Settings only after the nested stack reaches its root
- add a regression test covering a pushed child page, a settings group, the settings root, and the app page

## Testing

- `flutter test test/settings_menu_test.dart`
- `flutter analyze lib/view/page/setting/entry.dart test/settings_menu_test.dart`

Fixes #1361


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved back navigation in Settings so platform back actions return through nested Settings pages one at a time instead of exiting Settings immediately.
  * Ensured the Settings route closes only after all nested pages have been dismissed.

* **Tests**
  * Added coverage verifying the expected back-navigation sequence from nested Settings pages to the launch screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->