### PR TITLE
fix(container): accept missing SSH exit status

### DIFF
--- a/lib/data/provider/container.dart
+++ b/lib/data/provider/container.dart
@@ -468,7 +468,7 @@ class ContainerNotifier extends _$ContainerNotifier {
       type: type,
       containerHost: containerHost,
     );
-    int? code;
+    late final ExecResult result;
     String raw = '';
     // Kept apart from [raw]: parsing wants stdout only, but everything that
     // explains a failure — `sh: docker: not found`, a permission denial — is
@@ -486,7 +486,7 @@ class ContainerNotifier extends _$ContainerNotifier {
         await _restartAfterServerChange(target, isAuto);
         return;
       }
-      final result = await exec.runWithSudo(
+      result = await exec.runWithSudo(
         cmd,
         password: password,
         onStderr: (data) {
@@ -500,7 +500,7 @@ class ContainerNotifier extends _$ContainerNotifier {
         await _restartAfterServerChange(target, isAuto);
         return;
       }
-      (code, raw, errOut) = (result.exitCode, result.stdout, result.stderr);
+      (raw, errOut) = (result.stdout, result.stderr);
       if (result.outputIncomplete) {
         if (_isStaleRefresh(refreshGeneration)) return;
         _setRefreshError(
@@ -540,7 +540,7 @@ class ContainerNotifier extends _$ContainerNotifier {
     }
 
     /// Code 127 means command not found
-    if (code == 127 ||
+    if (result.exitCode == 127 ||
         errOut.contains(_dockerNotFound) ||
         raw.contains(_dockerNotFound)) {
       _setRefreshError(
@@ -559,7 +559,7 @@ class ContainerNotifier extends _$ContainerNotifier {
     }
 
     /// Sudo password error
-    if (needSudo && code == kSudoPasswordRejected) {
+    if (needSudo && result.exitCode == kSudoPasswordRejected) {
       _cachedPassword = null;
       _setRefreshError(
         target,
@@ -571,7 +571,7 @@ class ContainerNotifier extends _$ContainerNotifier {
       await _finishRefresh(refreshGeneration);
       return;
     }
-    if (code != 0) {
+    if (!result.succeeded) {
       _setRefreshError(
         target,
         ContainerErr(
@@ -953,7 +953,7 @@ class ContainerNotifier extends _$ContainerNotifier {
       await _finishRun();
       return ContainerErr(type: ContainerErrType.unknown, message: detail);
     }
-    if (result.exitCode != 0) {
+    if (!result.succeeded) {
       if (result.exitCode == 127 || detail.contains(_dockerNotFound)) {
         await _finishRun();
         return ContainerErr(

--- a/test/server_exec_test.dart
+++ b/test/server_exec_test.dart
@@ -31,6 +31,28 @@ class _RecordingExec implements ServerExec {
 }
 
 void main() {
+  group('ExecResult', () {
+    test('accepts output when the SSH server omits a clean exit status', () {
+      const result = ExecResult(
+        exitCode: null,
+        stdout: 'container output',
+        stderr: '',
+      );
+
+      expect(result.succeeded, isTrue);
+    });
+
+    test('rejects a missing exit status when stderr reports a failure', () {
+      const result = ExecResult(
+        exitCode: null,
+        stdout: '',
+        stderr: 'permission denied',
+      );
+
+      expect(result.succeeded, isFalse);
+    });
+  });
+
   group('runWithSudo', () {
     test('the password goes to stdin, never into the command', () async {
       final exec = _RecordingExec();


### PR DESCRIPTION
## Summary

- use `ExecResult.succeeded` for container refreshes and container actions
- accept valid command output when an SSH server omits the exit status and stderr is empty
- keep rejecting non-zero exits, stderr-only failures, and incomplete output
- add regression coverage for missing SSH exit statuses

## Testing

- `flutter test test/server_exec_test.dart test/container_test.dart`
- `flutter analyze lib/data/provider/container.dart test/server_exec_test.dart`

Closes #1357.
Addresses the Docker portion of #1363.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command execution and container refresh handling for more reliable success and failure detection.
  - Preserved command results accurately when exit status information is unavailable.

- **Tests**
  - Added coverage for successful commands with output but no exit status.
  - Added coverage for failed commands that report errors without an exit status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->