### PR TITLE
fix: Android terminal back navigation and service crash

### DIFF
--- a/android/app/src/main/kotlin/tech/lolli/toolbox/ForegroundService.kt
+++ b/android/app/src/main/kotlin/tech/lolli/toolbox/ForegroundService.kt
@@ -16,6 +16,8 @@ class ForegroundService : Service() {
     companion object {
         @Volatile
         var isRunning: Boolean = false
+
+        const val ACTION_STOP_SERVICE = "tech.lolli.toolbox.ACTION_STOP_SERVICE"
     }
     private val chanId = "ForegroundServiceChannel"
     private val NOTIFICATION_ID = 1000
@@ -50,6 +52,12 @@ class ForegroundService : Service() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         try {
+            if (intent?.action == ACTION_STOP_SERVICE) {
+                Log.d("ForegroundService", "Stopping after queued starts")
+                stopForegroundService()
+                return START_NOT_STICKY
+            }
+
             // Before the permission check below, because stopping needs no
             // notification. A user who revokes the permission while this is
             // running still has the action on a notification the system has not

--- a/android/app/src/main/kotlin/tech/lolli/toolbox/MainActivity.kt
+++ b/android/app/src/main/kotlin/tech/lolli/toolbox/MainActivity.kt
@@ -164,31 +164,21 @@ class MainActivity: FlutterFragmentActivity() {
                         if (!privacyLocked && isForeground) applyPrivacyCover(false)
                         result.success(null)
                     }
-                    "startService" -> {
+                    "stopService" -> {
                         try {
-                            reqPerm()
-                            if (!notificationsAllowed()) {
-                                // Don't start foreground service without notification permission on API 33+
-                                result.error("NOTIFICATION_PERMISSION_DENIED", "Notification permission not granted", null)
-                                return@setMethodCallHandler
+                            // Queue the stop behind any pending foreground start.
+                            // Context.stopService can destroy the instance before
+                            // that start reaches onStartCommand, leaving Android's
+                            // foreground-service obligation outstanding.
+                            val serviceIntent = Intent(this@MainActivity, ForegroundService::class.java).apply {
+                                action = ForegroundService.ACTION_STOP_SERVICE
                             }
-                            val serviceIntent = Intent(this@MainActivity, ForegroundService::class.java)
-                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                                startForegroundService(serviceIntent)
-                            } else {
-                                startService(serviceIntent)
-                            }
+                            startService(serviceIntent)
                             result.success(null)
                         } catch (e: Exception) {
-                            // Log error but don't crash
-                            android.util.Log.e("MainActivity", "Failed to start service: ${e.message}")
+                            android.util.Log.e("MainActivity", "Failed to stop service: ${e.message}")
                             result.error("SERVICE_ERROR", e.message, null)
                         }
-                    }
-                    "stopService" -> {
-                        val serviceIntent = Intent(this@MainActivity, ForegroundService::class.java)
-                        stopService(serviceIntent)
-                        result.success(null)
                     }
                     "updateHomeWidget" -> {
                         HomeWidget.broadcastUpdate(applicationContext)
@@ -213,6 +203,7 @@ class MainActivity: FlutterFragmentActivity() {
                     }
                     "updateSessions" -> {
                         try {
+                            reqPerm()
                             if (!notificationsAllowed()) {
                                 // Avoid starting/continuing service updates when notifications are blocked
                                 result.error("NOTIFICATION_PERMISSION_DENIED", "Notification permission not granted", null)
@@ -221,7 +212,7 @@ class MainActivity: FlutterFragmentActivity() {
                             val serviceIntent = Intent(this@MainActivity, ForegroundService::class.java)
                             serviceIntent.action = ACTION_UPDATE_SESSIONS
                             serviceIntent.putExtra("payload", method.arguments as String)
-                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !ForegroundService.isRunning) {
                                 startForegroundService(serviceIntent)
                             } else {
                                 startService(serviceIntent)
@@ -332,7 +323,7 @@ class MainActivity: FlutterFragmentActivity() {
         if (requestCode == 123) {
             if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                 android.util.Log.i("MainActivity", "Notification permission granted")
-                // `reqPerm` is asynchronous and `startService`/`updateSessions`
+                // `reqPerm` is asynchronous and `updateSessions`
                 // test the permission the moment after asking for it, so the
                 // first attempt is always refused and nothing retries it. With
                 // a session already open and no further lifecycle change

--- a/lib/core/chan.dart
+++ b/lib/core/chan.dart
@@ -21,23 +21,15 @@ abstract final class MethodChans {
     }
   }
 
-  /// Puts the Android process in the foreground, so the system stops treating
-  /// it as cached and freezing it (#662, #1287).
-  ///
-  /// Ungated. It used to return here unless `fgService` was true — a setting
-  /// whose switch was commented out of the Android settings page and then
-  /// deleted with it, so it was false for every install and both of these did
-  /// nothing at all. What kept the service alive instead was [updateSessions],
-  /// which starts it as a side effect; the moment the session list went empty
-  /// that side effect went the other way and the process lost its foreground
-  /// status with nothing able to give it back. Whether the service is wanted
-  /// is `TermSessionManager`'s decision, and it is the only caller.
-  static void startService() {
-    _channel.invokeMethod('startService');
-  }
-
-  static void stopService() {
-    _channel.invokeMethod('stopService');
+  /// Stops Android's terminal foreground service after its queued starts have
+  /// been handled.
+  static Future<void> stopService() async {
+    if (!isAndroid) return;
+    try {
+      await _channel.invokeMethod('stopService');
+    } catch (e, s) {
+      Loggers.app.warning('Failed to stop Android terminal service', e, s);
+    }
   }
 
   static Future<void> updateHomeWidget() async {
@@ -153,8 +145,10 @@ abstract final class MethodChans {
     }
   }
 
-  /// Update Android foreground service notifications for SSH sessions
-  /// The [payload] is a JSON string describing sessions list.
+  /// Starts or updates Android's terminal foreground service with [payload].
+  ///
+  /// The native side also owns the notification permission request, so one
+  /// call describes the desired state instead of racing a separate start.
   static Future<void> updateSessions(String payload) async {
     if (!isAndroid) return;
     try {
@@ -259,7 +253,7 @@ abstract final class MethodChans {
         // triggered the prompt has already been refused by the time the user
         // answers it. This is the only edge that says the answer was yes, and
         // without acting on it the foreground service stays stopped until
-        // something else happens to sync — see [startService].
+        // something else happens to sync — see [updateSessions].
         case 'notificationPermissionGranted':
           onNotificationPermissionGranted?.call();
           return;

--- a/lib/data/ssh/android_service_policy.dart
+++ b/lib/data/ssh/android_service_policy.dart
@@ -1,0 +1,18 @@
+/// What one serialized Android terminal-service sync should do.
+enum AndroidSessionServiceAction { update, stop, none }
+
+/// Chooses a single service transition for the latest terminal state.
+///
+/// An empty update is deliberately not an action: `updateSessions` starts a
+/// foreground service when needed, so using it to say "nothing is running"
+/// briefly starts and immediately stops that service. Android 16 can treat
+/// that race as an unmet `startForegroundService` contract and kill the app.
+AndroidSessionServiceAction decideAndroidSessionServiceAction({
+  required bool wanted,
+  required bool running,
+  required bool backgrounded,
+}) {
+  if (wanted) return AndroidSessionServiceAction.update;
+  if (running && !backgrounded) return AndroidSessionServiceAction.stop;
+  return AndroidSessionServiceAction.none;
+}

--- a/lib/data/ssh/session_manager.dart
+++ b/lib/data/ssh/session_manager.dart
@@ -5,6 +5,7 @@ import 'package:fl_lib/fl_lib.dart';
 import 'package:flutter/foundation.dart';
 import 'package:server_box/core/chan.dart';
 import 'package:server_box/data/res/store.dart';
+import 'package:server_box/data/ssh/android_service_policy.dart';
 
 enum TermSessionStatus {
   connecting,
@@ -212,25 +213,34 @@ abstract final class TermSessionManager {
   static Future<void> _syncLatest() async {
     // Android: update foreground service notifications
     if (isAndroid) {
-      final isRunning = await MethodChans.isServiceRunning();
       final wanted = _serviceWanted;
-      if (wanted && !isRunning) {
-        MethodChans.startService();
-      } else if (!wanted && isRunning && !_backgrounded) {
-        // Never while backgrounded, even when nothing is left to keep alive:
-        // stopping is the one direction that cannot be undone from there.
-        MethodChans.stopService();
+      // No query is needed for an update, and no stop is allowed while the app
+      // is backgrounded. Apart from saving a platform round trip, that keeps an
+      // empty state from starting a foreground service just to stop it again.
+      final running = !wanted && !_backgrounded
+          ? await MethodChans.isServiceRunning()
+          : false;
+      switch (decideAndroidSessionServiceAction(
+        wanted: wanted,
+        running: running,
+        backgrounded: _backgrounded,
+      )) {
+        case AndroidSessionServiceAction.update:
+          await MethodChans.updateSessions(
+            jsonEncode({
+              'sessions': _entries.values.map((e) => e.info.toJson()).toList(),
+              // Tells the service that an empty list is not the same as
+              // "nothing to do" while background execution is wanted.
+              'keepAlive': wanted,
+            }),
+          );
+        case AndroidSessionServiceAction.stop:
+          // Serialized through the service itself, so a pending foreground
+          // start is promoted before the stop command is handled.
+          await MethodChans.stopService();
+        case AndroidSessionServiceAction.none:
+          break;
       }
-      await MethodChans.updateSessions(
-        jsonEncode({
-          'sessions': _entries.values.map((e) => e.info.toJson()).toList(),
-          // Tells the service that an empty list is not the same as "nothing
-          // to do". Without it the native side cancels its notification, which
-          // drops the process out of the foreground exactly when it is
-          // background and cannot get back in.
-          'keepAlive': wanted,
-        }),
-      );
     }
 
     // iOS: manage Live Activity timer

--- a/lib/data/store/setting.dart
+++ b/lib/data/store/setting.dart
@@ -622,8 +622,8 @@ class SettingStore extends SqliteStore {
   // `fgService` was here: a second switch for the Android foreground service,
   // whose tile was commented out of the settings page long before that page
   // was deleted. It defaulted to false, nothing could turn it on, and it gated
-  // `MethodChans.startService` — so the app never asked for the service it
-  // needs to survive being backgrounded. [bgRun] is the one switch now.
+  // Android service updates — so the app never asked for the service it needs
+  // to survive being backgrounded. [bgRun] is the one switch now.
   //
   // TODO: the stale `fgService` row in `kv` is harmless and is left to be swept
   // with the next settings migration.

--- a/lib/view/page/ssh/page/page.dart
+++ b/lib/view/page/ssh/page/page.dart
@@ -10,7 +10,6 @@ import 'package:flutter/foundation.dart' show ValueListenable;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:server_box/core/chan.dart';
 import 'package:server_box/core/extension/context/locale.dart';
 import 'package:server_box/core/utils/sudo_password.dart';
 import 'package:server_box/data/model/ai/agent_conversation.dart';
@@ -284,7 +283,7 @@ class SSHPageState extends ConsumerState<SSHPage>
   /// Current tmux window index (for state restoration)
   int? get tmuxCurrentWindow => _tmuxCurrentWindow;
 
-  /// Used for (de)activate the wake lock and forground service
+  /// Used to activate the wake lock while at least one terminal page exists.
   static var _sshConnCount = 0;
   late final String _sessionId = ShortId.generate();
   late final int _sessionStartMs = DateTime.now().millisecondsSinceEpoch;
@@ -346,9 +345,6 @@ class SSHPageState extends ConsumerState<SSHPage>
 
     if (--_sshConnCount <= 0) {
       WakelockPlus.disable();
-      if (isAndroid) {
-        MethodChans.stopService();
-      }
     }
 
     // Remove session entry
@@ -391,9 +387,6 @@ class SSHPageState extends ConsumerState<SSHPage>
 
     if (++_sshConnCount == 1) {
       WakelockPlus.enable();
-      if (isAndroid) {
-        MethodChans.startService();
-      }
     }
 
     // Add session entry (for Android notifications & iOS Live Activities)

--- a/test/android_service_policy_test.dart
+++ b/test/android_service_policy_test.dart
@@ -1,0 +1,71 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:server_box/data/ssh/android_service_policy.dart';
+
+void main() {
+  test('wanted terminal state updates the service', () {
+    expect(
+      decideAndroidSessionServiceAction(
+        wanted: true,
+        running: false,
+        backgrounded: false,
+      ),
+      AndroidSessionServiceAction.update,
+    );
+  });
+
+  test('idle foreground state stops only a running service', () {
+    expect(
+      decideAndroidSessionServiceAction(
+        wanted: false,
+        running: true,
+        backgrounded: false,
+      ),
+      AndroidSessionServiceAction.stop,
+    );
+    expect(
+      decideAndroidSessionServiceAction(
+        wanted: false,
+        running: false,
+        backgrounded: false,
+      ),
+      AndroidSessionServiceAction.none,
+    );
+  });
+
+  test('idle background state leaves the service unchanged', () {
+    expect(
+      decideAndroidSessionServiceAction(
+        wanted: false,
+        running: true,
+        backgrounded: true,
+      ),
+      AndroidSessionServiceAction.none,
+    );
+  });
+
+  test('terminal pages do not control the Android service directly', () {
+    final source = File('lib/view/page/ssh/page/page.dart').readAsStringSync();
+
+    expect(source, isNot(contains('MethodChans.startService')));
+    expect(source, isNot(contains('MethodChans.stopService')));
+  });
+
+  test('Android queues service stops behind foreground starts', () {
+    final activity = File(
+      'android/app/src/main/kotlin/tech/lolli/toolbox/MainActivity.kt',
+    ).readAsStringSync();
+    final service = File(
+      'android/app/src/main/kotlin/tech/lolli/toolbox/ForegroundService.kt',
+    ).readAsStringSync();
+
+    expect(activity, isNot(contains('"startService" ->')));
+    expect(activity, isNot(contains('stopService(serviceIntent)')));
+    expect(
+      activity,
+      contains('action = ForegroundService.ACTION_STOP_SERVICE'),
+    );
+    expect(service, contains('intent?.action == ACTION_STOP_SERVICE'));
+  });
+}

--- a/test/android_service_policy_test.dart
+++ b/test/android_service_policy_test.dart
@@ -1,3 +1,6 @@
+@TestOn('vm') // Reads the Android and Dart source trees through dart:io.
+library;
+
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -15,7 +18,7 @@ void main() {
     );
   });
 
-  test('idle foreground state stops only a running service', () {
+  test('idle foreground state stops a running service', () {
     expect(
       decideAndroidSessionServiceAction(
         wanted: false,
@@ -24,6 +27,9 @@ void main() {
       ),
       AndroidSessionServiceAction.stop,
     );
+  });
+
+  test('idle state leaves a pending foreground start alone', () {
     expect(
       decideAndroidSessionServiceAction(
         wanted: false,
@@ -32,6 +38,26 @@ void main() {
       ),
       AndroidSessionServiceAction.none,
     );
+  });
+
+  test('a wanted state followed by idle updates before stopping', () {
+    final actions = [
+      decideAndroidSessionServiceAction(
+        wanted: true,
+        running: false,
+        backgrounded: false,
+      ),
+      decideAndroidSessionServiceAction(
+        wanted: false,
+        running: true,
+        backgrounded: false,
+      ),
+    ];
+
+    expect(actions, [
+      AndroidSessionServiceAction.update,
+      AndroidSessionServiceAction.stop,
+    ]);
   });
 
   test('idle background state leaves the service unchanged', () {
@@ -45,14 +71,14 @@ void main() {
     );
   });
 
-  test('terminal pages do not control the Android service directly', () {
+  test('terminal-page source wiring does not own the Android service', () {
     final source = File('lib/view/page/ssh/page/page.dart').readAsStringSync();
 
     expect(source, isNot(contains('MethodChans.startService')));
     expect(source, isNot(contains('MethodChans.stopService')));
   });
 
-  test('Android queues service stops behind foreground starts', () {
+  test('Android source wiring dispatches stop through a service action', () {
     final activity = File(
       'android/app/src/main/kotlin/tech/lolli/toolbox/MainActivity.kt',
     ).readAsStringSync();


### PR DESCRIPTION
## Summary
- preserve the terminal root route when Android system back is rejected by its `PopScope`
- make `TermSessionManager` the sole owner of the Android terminal foreground service
- skip idle empty-session updates that would start and immediately stop a foreground service
- serialize stop requests through the service command queue so pending foreground starts are promoted first

## Root cause
Issue #1364 contains two independent failure modes:

1. `NestedNavigator` forced `Navigator.pop`, bypassing the terminal root's `PopScope` and removing the nested navigator's only route. This left the terminal pane blank.
2. `SSHPage` and `TermSessionManager` both started and stopped the Android foreground service. An empty session update could race a pending start with `Context.stopService`, leaving Android's foreground-service contract unmet. The Android 16 logcat reports `ForegroundServiceDidNotStartInTimeException`.

## Dependency
- lollipopkit/fl_lib#45, merged into `fl_lib/main` as `e79633a`

## Testing
- `flutter test test/android_service_policy_test.dart test/terminal_session_test.dart test/ssh_tab_restore_test.dart test/terminal_platform_test.dart`
- `flutter analyze lib/core/chan.dart lib/data/ssh/android_service_policy.dart lib/data/ssh/session_manager.dart lib/data/store/setting.dart lib/view/page/ssh/page/page.dart test/android_service_policy_test.dart`
- `flutter test --no-pub test/nested_navigator_test.dart` in `packages/fl_lib`
- verified `android_service_policy_test.dart` is excluded from the Chrome target by its VM-only test selector

An Android APK build could not be run in this worktree because no Android SDK is configured.

Closes #1364.