### PR TITLE
fix: overlapping server refreshes at startup

### DIFF
--- a/lib/data/provider/server/all.dart
+++ b/lib/data/provider/server/all.dart
@@ -16,6 +16,7 @@ import 'package:server_box/data/model/server/server.dart';
 import 'package:server_box/data/model/server/server_private_info.dart';
 import 'package:server_box/data/model/server/try_limiter.dart';
 import 'package:server_box/data/provider/port_forward_provider.dart';
+import 'package:server_box/data/provider/server/refresh_scheduler.dart';
 import 'package:server_box/data/provider/server/selection.dart';
 import 'package:server_box/data/provider/server/single.dart';
 import 'package:server_box/data/res/store.dart';
@@ -41,6 +42,14 @@ class ServersNotifier extends _$ServersNotifier {
   static const _maxConcurrentRefreshes = 4;
   int _autoRefreshGeneration = 0;
   Future<void> _mutationTail = Future.value();
+  ServerRefreshScheduler? _refreshScheduler;
+
+  ServerRefreshScheduler get _refreshes =>
+      _refreshScheduler ??= ServerRefreshScheduler(
+        maxConcurrent: _maxConcurrentRefreshes,
+        refresh: (serverId) =>
+            ref.read(serverProvider(serverId).notifier).refresh(),
+      );
 
   Future<T> _mutate<T>(Future<T> Function() action) async {
     final previous = _mutationTail;
@@ -229,27 +238,12 @@ class ServersNotifier extends _$ServersNotifier {
     await _refreshEach(ids);
   }
 
-  /// Refreshes [ids], a few at a time.
+  /// Refreshes [ids] through the app-wide queue.
   ///
-  /// The cap is what keeps a list of thirty machines from opening thirty
-  /// connections at once; the workers share one cursor rather than a slice
-  /// each, so a slow server holds up nothing but itself.
-  Future<void> _refreshEach(List<String> ids) async {
-    var next = 0;
-    Future<void> worker() async {
-      while (next < ids.length) {
-        final serverNotifier = ref.read(serverProvider(ids[next++]).notifier);
-        await serverNotifier.refresh();
-      }
-    }
-
-    await Future.wait(
-      List.generate(
-        ids.length.clamp(0, _maxConcurrentRefreshes).toInt(),
-        (_) => worker(),
-      ),
-    );
-  }
+  /// The scheduler is shared by startup, lifecycle, timer and explicit bulk
+  /// requests, so overlapping calls cannot each create their own set of four
+  /// workers. It also coalesces a server already queued or in flight.
+  Future<void> _refreshEach(List<String> ids) => _refreshes.refresh(ids);
 
   Future<void> startAutoRefresh() async {
     stopAutoRefresh();

--- a/lib/data/provider/server/refresh_scheduler.dart
+++ b/lib/data/provider/server/refresh_scheduler.dart
@@ -1,0 +1,88 @@
+import 'dart:async';
+import 'dart:collection';
+
+typedef ServerRefreshTask = Future<void> Function(String serverId);
+
+/// Coordinates server refresh work across every caller.
+///
+/// A per-call worker pool is not enough: startup, lifecycle handling and the
+/// timer may all ask for a refresh while an earlier request is still running.
+/// Each pool can then skip the servers already refreshing and start a different
+/// set, making their combined concurrency much larger than any one pool's cap.
+///
+/// This scheduler owns the single queue instead. Requests for a server that is
+/// already queued or active share its future, while requests for other servers
+/// wait for one of the global slots.
+class ServerRefreshScheduler {
+  ServerRefreshScheduler({
+    required this.maxConcurrent,
+    required ServerRefreshTask refresh,
+  }) : assert(maxConcurrent > 0),
+       _refresh = refresh;
+
+  final int maxConcurrent;
+  final ServerRefreshTask _refresh;
+
+  final Queue<_ServerRefreshJob> _pending = Queue<_ServerRefreshJob>();
+  final Map<String, _ServerRefreshJob> _jobs = <String, _ServerRefreshJob>{};
+  int _active = 0;
+
+  /// Refreshes [serverIds], sharing work already queued by another request.
+  Future<void> refresh(Iterable<String> serverIds) {
+    final futures = <Future<void>>[];
+    final requested = <String>{};
+
+    for (final serverId in serverIds) {
+      if (!requested.add(serverId)) continue;
+
+      var job = _jobs[serverId];
+      if (job == null) {
+        job = _ServerRefreshJob(serverId);
+        _jobs[serverId] = job;
+        _pending.add(job);
+      }
+      futures.add(job.future);
+    }
+
+    _drain();
+    if (futures.isEmpty) return Future<void>.value();
+    return Future.wait(futures);
+  }
+
+  void _drain() {
+    while (_active < maxConcurrent && _pending.isNotEmpty) {
+      final job = _pending.removeFirst();
+      _active++;
+      unawaited(_run(job));
+    }
+  }
+
+  Future<void> _run(_ServerRefreshJob job) async {
+    try {
+      await _refresh(job.serverId);
+      job.complete();
+    } catch (error, stackTrace) {
+      job.completeError(error, stackTrace);
+    } finally {
+      _active--;
+      if (identical(_jobs[job.serverId], job)) {
+        _jobs.remove(job.serverId);
+      }
+      _drain();
+    }
+  }
+}
+
+class _ServerRefreshJob {
+  _ServerRefreshJob(this.serverId);
+
+  final String serverId;
+  final Completer<void> _completer = Completer<void>();
+
+  Future<void> get future => _completer.future;
+
+  void complete() => _completer.complete();
+
+  void completeError(Object error, StackTrace stackTrace) =>
+      _completer.completeError(error, stackTrace);
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -257,10 +257,13 @@ Future<void> _doPlatformRelated() async {
     unawaited(MethodChans.setPrivacyBlur(Stores.setting.privacyBlur.fetch()));
   }
 
-  final serversCount = Stores.server.keys().length;
-  await Computer.shared.turnOn(
-    workersCount: (serversCount / 3).round() + 1,
-  ); // Plus 1 to avoid 0.
+  // Status parsing used to run on this pool, which is why its size followed
+  // the server count. It now runs on the Rust thread pool, while the remaining
+  // Computer tasks (backup parsing, editor work and PVE responses) are
+  // occasional and already queue safely. Starting several otherwise idle
+  // isolates before the first frame only makes a larger server list slower and
+  // more memory-hungry to open.
+  await Computer.shared.turnOn(workersCount: 1);
 }
 
 // It may contains some async heavy funcs.

--- a/lib/view/page/home.dart
+++ b/lib/view/page/home.dart
@@ -59,6 +59,7 @@ class _HomePageState extends ConsumerState<HomePage>
   bool _shouldAuth = false;
   bool? _lastFullscreenMode;
   DateTime? _pausedTime;
+  int _serverRefreshCycle = 0;
 
   late final _notifier = ref.read(serversProvider.notifier);
   late List<AppTab> _tabs = Stores.setting.homeTabs.fetch();
@@ -76,6 +77,7 @@ class _HomePageState extends ConsumerState<HomePage>
 
   @override
   void dispose() {
+    _stopServerRefreshCycle();
     if (isMobile) {
       SystemUIs.switchStatusBar(hide: false);
     }
@@ -202,9 +204,7 @@ class _HomePageState extends ConsumerState<HomePage>
         } else {
           _releasePrivacyCover();
         }
-        final serverNotifier = _notifier;
-        unawaited(serverNotifier.startAutoRefresh());
-        unawaited(serverNotifier.refresh());
+        unawaited(_restartServerRefreshCycle());
         unawaited(MethodChans.updateHomeWidget());
         _syncFullscreenSystemUi();
         break;
@@ -219,7 +219,7 @@ class _HomePageState extends ConsumerState<HomePage>
           unawaited(MethodChans.setPrivacyBlurLocked(true));
         }
         if (!(isAndroid && Stores.setting.bgRun.fetch())) {
-          _notifier.stopAutoRefresh();
+          _stopServerRefreshCycle();
         }
         break;
       case AppLifecycleState.inactive:
@@ -489,7 +489,7 @@ class _HomePageState extends ConsumerState<HomePage>
       await _maybeShowNavGuide();
     }());
 
-    await _notifier.refresh();
+    unawaited(_restartServerRefreshCycle());
 
     bakSync.sync(milliDelay: 1000);
   }
@@ -613,13 +613,43 @@ extension _HomePageStateActions on _HomePageState {
   }
 
   void _handleRefreshIntervalChanged() {
-    final lifecycle = WidgetsBinding.instance.lifecycleState;
-    if (isDesktop ||
-        lifecycle == null ||
-        lifecycle == AppLifecycleState.resumed) {
-      unawaited(_notifier.startAutoRefresh());
-      unawaited(_notifier.refresh());
+    if (_canRefreshServers) {
+      unawaited(_restartServerRefreshCycle());
+    } else {
+      _stopServerRefreshCycle();
     }
+  }
+
+  bool get _canRefreshServers {
+    if (isDesktop) return true;
+    final lifecycle = WidgetsBinding.instance.lifecycleState;
+    if (lifecycle == null || lifecycle == AppLifecycleState.resumed) {
+      return true;
+    }
+    return isAndroid && Stores.setting.bgRun.fetch();
+  }
+
+  /// Starts a new polling cycle without letting its timer race the first run.
+  ///
+  /// The generation prevents a refresh that finishes after pause, dispose or a
+  /// newer restart from turning the timer back on. Repeated restart requests
+  /// share the notifier's global refresh queue; only the latest one schedules
+  /// the next poll.
+  Future<void> _restartServerRefreshCycle() async {
+    final cycle = ++_serverRefreshCycle;
+    _notifier.stopAutoRefresh();
+    try {
+      await _notifier.refresh();
+    } catch (error, stackTrace) {
+      Loggers.app.warning('Initial server refresh failed', error, stackTrace);
+    }
+    if (!mounted || cycle != _serverRefreshCycle || !_canRefreshServers) return;
+    await _notifier.startAutoRefresh();
+  }
+
+  void _stopServerRefreshCycle() {
+    _serverRefreshCycle++;
+    _notifier.stopAutoRefresh();
   }
 }
 

--- a/lib/view/page/home.dart
+++ b/lib/view/page/home.dart
@@ -573,6 +573,18 @@ class _HomePageState extends ConsumerState<HomePage>
 }
 
 
+extension _HomePageStateUtils on _HomePageState {
+  bool get _canRefreshServers {
+    if (isDesktop) return true;
+    final lifecycle = WidgetsBinding.instance.lifecycleState;
+    if (lifecycle == null || lifecycle == AppLifecycleState.resumed) {
+      return true;
+    }
+    return isAndroid && Stores.setting.bgRun.fetch();
+  }
+}
+
+
 extension _HomePageStateActions on _HomePageState {
   void _handleHomeTabsChanged() {
     final newTabs = Stores.setting.homeTabs.fetch();
@@ -618,15 +630,6 @@ extension _HomePageStateActions on _HomePageState {
     } else {
       _stopServerRefreshCycle();
     }
-  }
-
-  bool get _canRefreshServers {
-    if (isDesktop) return true;
-    final lifecycle = WidgetsBinding.instance.lifecycleState;
-    if (lifecycle == null || lifecycle == AppLifecycleState.resumed) {
-      return true;
-    }
-    return isAndroid && Stores.setting.bgRun.fetch();
   }
 
   /// Starts a new polling cycle without letting its timer race the first run.

--- a/lib/view/page/server/tab/tab.dart
+++ b/lib/view/page/server/tab/tab.dart
@@ -63,10 +63,7 @@ const _kTagBarSideRoom = 80.0;
 const _kFlightDuration = Durations.medium3;
 
 class _ServerPageState extends ConsumerState<ServerPage>
-    with
-        AutomaticKeepAliveClientMixin,
-        AfterLayoutMixin,
-        TickerProviderStateMixin {
+    with AutomaticKeepAliveClientMixin, TickerProviderStateMixin {
   double _textFactorDouble = 1.0;
   final ValueNotifier<double> _offsetNotifier = ValueNotifier(1);
   TextScaler _textFactor = TextScaler.linear(1.0);
@@ -545,12 +542,6 @@ class _ServerPageState extends ConsumerState<ServerPage>
 
   @override
   bool get wantKeepAlive => true;
-
-  @override
-  Future<void> afterFirstLayout(BuildContext context) async {
-    ref.read(serversProvider.notifier).refresh();
-    ref.read(serversProvider.notifier).startAutoRefresh();
-  }
 
   static const _kCardHeightMin = 23.0;
   static const _kCardHeightFlip = 99.0;

--- a/test/server_refresh_scheduler_test.dart
+++ b/test/server_refresh_scheduler_test.dart
@@ -1,0 +1,71 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:server_box/data/provider/server/refresh_scheduler.dart';
+
+void main() {
+  test('applies one concurrency cap across overlapping requests', () async {
+    final release = Completer<void>();
+    final calls = <String, int>{};
+    var active = 0;
+    var maxActive = 0;
+
+    final scheduler = ServerRefreshScheduler(
+      maxConcurrent: 2,
+      refresh: (serverId) async {
+        calls.update(serverId, (count) => count + 1, ifAbsent: () => 1);
+        active++;
+        if (active > maxActive) maxActive = active;
+        await release.future;
+        active--;
+      },
+    );
+
+    final first = scheduler.refresh(['a', 'b', 'c', 'd']);
+    final second = scheduler.refresh(['a', 'b', 'c', 'd', 'e']);
+
+    await Future<void>.delayed(Duration.zero);
+    expect(calls.keys, unorderedEquals(['a', 'b']));
+    expect(maxActive, 2);
+
+    release.complete();
+    await Future.wait([first, second]);
+
+    expect(calls, {'a': 1, 'b': 1, 'c': 1, 'd': 1, 'e': 1});
+    expect(maxActive, 2);
+  });
+
+  test('deduplicates repeated ids within one request', () async {
+    final calls = <String, int>{};
+    final scheduler = ServerRefreshScheduler(
+      maxConcurrent: 2,
+      refresh: (serverId) async {
+        calls.update(serverId, (count) => count + 1, ifAbsent: () => 1);
+      },
+    );
+
+    await scheduler.refresh(['a', 'a', 'b', 'a', 'b']);
+
+    expect(calls, {'a': 1, 'b': 1});
+  });
+
+  test('continues draining after a task fails', () async {
+    final calls = <String>[];
+    final scheduler = ServerRefreshScheduler(
+      maxConcurrent: 1,
+      refresh: (serverId) async {
+        calls.add(serverId);
+        if (serverId == 'bad') throw StateError('failed');
+      },
+    );
+
+    await expectLater(
+      scheduler.refresh(['bad', 'good']),
+      throwsA(isA<StateError>()),
+    );
+    expect(calls, ['bad', 'good']);
+
+    await expectLater(scheduler.refresh(['bad']), throwsA(isA<StateError>()));
+    expect(calls, ['bad', 'good', 'bad']);
+  });
+}


### PR DESCRIPTION
## What this changes

Fixes #1358.

- Route startup, lifecycle, timer, and explicit bulk refreshes through one shared queue with a global concurrency limit.
- Coalesce duplicate work when the same server is already queued or refreshing.
- Start periodic polling only after the initial refresh completes, and prevent stale lifecycle work from restarting the timer.
- Remove the redundant refresh trigger from the server tab.
- Start a single legacy Computer worker because server-status parsing now runs on the Rust thread pool.

## How it was tested

- Windows 11
- `flutter analyze lib test integration_test`
- `cargo build -p sbm_ffi`
- `flutter test` (1737 passed, 30 skipped)

## Checklist

- [x] `make analyze` and `make test` pass
- [x] `make gen` was run, if any model / ARB file changed (not applicable)
- [x] `cargo test --workspace` passes, if anything under `crates/` or `monitor/` changed (not applicable)
- [x] No formatter was run over untouched code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server refresh reliability by preventing duplicate refreshes and managing concurrent requests more efficiently.
  * Refresh polling now pauses and resumes correctly when the app is backgrounded, resumed, or disposed.
  * Refresh interval changes no longer allow outdated operations to restart polling unexpectedly.
  * Refresh failures no longer block other queued server updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->