### PR TITLE
fix: repeated Android notification permission requests

### DIFF
--- a/android/app/src/main/kotlin/tech/lolli/toolbox/MainActivity.kt
+++ b/android/app/src/main/kotlin/tech/lolli/toolbox/MainActivity.kt
@@ -27,6 +27,7 @@ class MainActivity: FlutterFragmentActivity() {
     private var stopAllReceiver: BroadcastReceiver? = null
     private var disableImpeller = false
     private var ownsFlutterEngine = false
+    private var notificationPermissionRequestInFlight = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         val graphicsCompatibility = ImpellerCompatibility.check(this)
@@ -55,6 +56,9 @@ class MainActivity: FlutterFragmentActivity() {
         const val ARG_DISABLE_IMPELLER = "--enable-impeller=false"
         const val PRIVACY_PREFS = "privacy_cover"
         const val KEY_PRIVACY_COVER = "enabled"
+        const val NOTIFICATION_PERMISSION_REQUEST_CODE = 123
+        const val NOTIFICATION_PERMISSION_PREFS = "notification_permission"
+        const val KEY_NOTIFICATION_PERMISSION_REQUESTED = "requested"
     }
 
     // --- Privacy cover ------------------------------------------------------
@@ -203,7 +207,7 @@ class MainActivity: FlutterFragmentActivity() {
                     }
                     "updateSessions" -> {
                         try {
-                            reqPerm()
+                            requestNotificationPermissionOnce()
                             if (!notificationsAllowed()) {
                                 // Avoid starting/continuing service updates when notifications are blocked
                                 result.error("NOTIFICATION_PERMISSION_DENIED", "Notification permission not granted", null)
@@ -236,26 +240,36 @@ class MainActivity: FlutterFragmentActivity() {
         setupStopAllReceiver()
     }
 
-    private fun reqPerm() {
+    private fun requestNotificationPermissionOnce() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
-        
+
+        if (notificationsAllowed()) return
+        if (notificationPermissionRequestInFlight) return
+
+        val permissionPrefs = getSharedPreferences(
+            NOTIFICATION_PERMISSION_PREFS,
+            Context.MODE_PRIVATE,
+        )
+        if (permissionPrefs.getBoolean(KEY_NOTIFICATION_PERMISSION_REQUESTED, false)) return
+
+        // Record this before launching Android's permission activity. That
+        // activity changes the Flutter lifecycle, which immediately causes
+        // another session sync; without both guards every sync launches a new
+        // permission activity until Android removes the task.
+        notificationPermissionRequestInFlight = true
+        permissionPrefs.edit().putBoolean(KEY_NOTIFICATION_PERMISSION_REQUESTED, true).apply()
+
         try {
-            // Check if we already have the permission to avoid unnecessary prompts
-            if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS)
-                != PackageManager.PERMISSION_GRANTED) {
-                // Check if we should show rationale
-                if (ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.POST_NOTIFICATIONS)) {
-                    android.util.Log.i("MainActivity", "User previously denied notification permission")
-                }
-                
-                ActivityCompat.requestPermissions(
-                    this,
-                    arrayOf(Manifest.permission.POST_NOTIFICATIONS),
-                    123,
-                )
-            }
+            ActivityCompat.requestPermissions(
+                this,
+                arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                NOTIFICATION_PERMISSION_REQUEST_CODE,
+            )
         } catch (e: Exception) {
-            // Log error but don't crash
+            notificationPermissionRequestInFlight = false
+            // A failed launch did not ask the user anything, so allow a later
+            // sync to make one genuine retry.
+            permissionPrefs.edit().remove(KEY_NOTIFICATION_PERMISSION_REQUESTED).apply()
             android.util.Log.e("MainActivity", "Failed to request permissions: ${e.message}")
         }
     }
@@ -320,10 +334,11 @@ class MainActivity: FlutterFragmentActivity() {
         grantResults: IntArray
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        if (requestCode == 123) {
+        if (requestCode == NOTIFICATION_PERMISSION_REQUEST_CODE) {
+            notificationPermissionRequestInFlight = false
             if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                 android.util.Log.i("MainActivity", "Notification permission granted")
-                // `reqPerm` is asynchronous and `updateSessions`
+                // The permission request is asynchronous and `updateSessions`
                 // test the permission the moment after asking for it, so the
                 // first attempt is always refused and nothing retries it. With
                 // a session already open and no further lifecycle change

--- a/lib/core/chan.dart
+++ b/lib/core/chan.dart
@@ -154,6 +154,12 @@ abstract final class MethodChans {
     try {
       Loggers.app.info('Updating Android sessions: $payload');
       await _channel.invokeMethod('updateSessions', payload);
+    } on PlatformException catch (e, s) {
+      // A denied notification permission is a supported state: Android cannot
+      // run the foreground service, and the settings page explains how to
+      // enable it. Do not turn every ordinary session sync into a warning.
+      if (e.code == 'NOTIFICATION_PERMISSION_DENIED') return;
+      Loggers.app.warning('Failed to update Android sessions', e, s);
     } catch (e, s) {
       Loggers.app.warning('Failed to update Android sessions', e, s);
     }

--- a/lib/data/ssh/session_manager.dart
+++ b/lib/data/ssh/session_manager.dart
@@ -135,6 +135,7 @@ abstract final class TermSessionManager {
   static void updateStatus(String id, TermSessionStatus status) {
     final old = _entries[id];
     if (old == null) return;
+    if (old.info.status == status) return;
     _entries[id] = _Entry(
       TermSessionInfo(
         id: old.info.id,

--- a/test/android_service_policy_test.dart
+++ b/test/android_service_policy_test.dart
@@ -94,4 +94,56 @@ void main() {
     );
     expect(service, contains('intent?.action == ACTION_STOP_SERVICE'));
   });
+
+  test('Android notification permission is requested at most once', () {
+    final activity = File(
+      'android/app/src/main/kotlin/tech/lolli/toolbox/MainActivity.kt',
+    ).readAsStringSync();
+
+    expect(activity, contains('notificationPermissionRequestInFlight'));
+    expect(activity, contains('KEY_NOTIFICATION_PERMISSION_REQUESTED'));
+    expect(
+      activity,
+      contains(
+        'permissionPrefs.getBoolean(KEY_NOTIFICATION_PERMISSION_REQUESTED, false)',
+      ),
+    );
+
+    final persistedAt = activity.indexOf(
+      'putBoolean(KEY_NOTIFICATION_PERMISSION_REQUESTED, true)',
+    );
+    final inFlightGuardAt = activity.indexOf(
+      'if (notificationPermissionRequestInFlight) return',
+    );
+    final persistedGuardAt = activity.indexOf(
+      'permissionPrefs.getBoolean(KEY_NOTIFICATION_PERMISSION_REQUESTED, false)',
+    );
+    final requestedAt = activity.indexOf('ActivityCompat.requestPermissions(');
+    expect(inFlightGuardAt, greaterThanOrEqualTo(0));
+    expect(persistedGuardAt, greaterThan(inFlightGuardAt));
+    expect(persistedAt, greaterThanOrEqualTo(0));
+    expect(requestedAt, greaterThan(persistedGuardAt));
+    expect(requestedAt, greaterThan(persistedAt));
+
+    final resultHandlerAt = activity.indexOf(
+      'if (requestCode == NOTIFICATION_PERMISSION_REQUEST_CODE)',
+    );
+    final clearedAt = activity.indexOf(
+      'notificationPermissionRequestInFlight = false',
+      resultHandlerAt,
+    );
+    expect(resultHandlerAt, greaterThanOrEqualTo(0));
+    expect(clearedAt, greaterThan(resultHandlerAt));
+    expect(activity, isNot(contains('reqPerm()')));
+  });
+
+  test('notification permission denial is not logged as a sync failure', () {
+    final channel = File('lib/core/chan.dart').readAsStringSync();
+
+    expect(channel, contains('on PlatformException catch'));
+    expect(
+      channel,
+      contains("if (e.code == 'NOTIFICATION_PERMISSION_DENIED') return;"),
+    );
+  });
 }


### PR DESCRIPTION
## What this changes

- Prevents Android 13+ notification permission requests from being relaunched by repeated session syncs.
- Tracks both an in-flight request and whether the automatic prompt has already been shown, so denial remains a stable state across lifecycle changes and app launches.
- Keeps the existing grant callback so approving the prompt still starts the foreground service without waiting for another lifecycle event.
- Treats notification denial as an expected Dart-side state and skips redundant session status syncs.

ColorOS was removing the app task after the permission activity was launched repeatedly in a short period. This stops that activity loop while preserving the first automatic prompt and the notification-settings recovery path.

## How it was tested

- `flutter test test/android_service_policy_test.dart`
- `flutter analyze lib test`
- `.\\gradlew.bat :app:compileDebugKotlin -x :app:compileFlutterBuildDebug`
- `flutter test` was also run; the new regression tests passed, while the full existing suite reported 11 unrelated workspace/environment failures, including stale Flutter Rust Bridge artifacts and rootfs manifest fixture/signature failures.

A full Android asset build was attempted, but the external `sqlite3` binary download from GitHub timed out. The Kotlin-only Android compile completed successfully.

## Checklist

- [ ] `make analyze` and `make test` pass (see the unrelated full-suite failures above)
- [x] `make gen` was not required; no model or ARB file changed
- [x] `cargo test --workspace` was not required; no file under `crates/` or `monitor/` changed
- [x] No formatter was run over untouched code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated Android notification permission prompts during session updates.
  * Handled notification permission denial without displaying it as a synchronization failure.
  * Avoided unnecessary session rebuilds and synchronization when a status is unchanged.
  * Improved permission request recovery after completion or failure.

* **Tests**
  * Added coverage for permission request deduplication, callback handling, and denial behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->