### PR TITLE
fix(ssh): avoid false incomplete command output

### DIFF
--- a/lib/core/utils/ssh_exec.dart
+++ b/lib/core/utils/ssh_exec.dart
@@ -9,6 +9,8 @@ typedef SshExecCollectedOutput = ({
   String stdout,
   String stderr,
   bool outputIncomplete,
+  Object? streamError,
+  StackTrace? streamErrorStackTrace,
 });
 
 /// Collects both SSH output streams until the command and streams have ended.
@@ -43,9 +45,22 @@ Future<SshExecCollectedOutput> collectSshExecOutput({
 
   // These must be obtained while the subscriptions are still live. Calling
   // asFuture after a done event has already been delivered creates futures
-  // that can no longer complete.
-  final outDone = outSub.asFuture<void>();
-  final errDone = errSub.asFuture<void>();
+  // that can no longer complete. `asFuture` also replaces the subscription's
+  // error callback, so catch its error here and keep the output buffered up to
+  // that point instead of letting the collector throw it away.
+  Object? streamError;
+  StackTrace? streamErrorStackTrace;
+  Future<void> captureDone(StreamSubscription<String> subscription) async {
+    try {
+      await subscription.asFuture<void>();
+    } catch (error, trace) {
+      streamError ??= error;
+      streamErrorStackTrace ??= trace;
+    }
+  }
+
+  final outDone = captureDone(outSub);
+  final errDone = captureDone(errSub);
 
   await commandDone;
 
@@ -64,6 +79,8 @@ Future<SshExecCollectedOutput> collectSshExecOutput({
     stdout: out.toString(),
     stderr: err.toString(),
     outputIncomplete: incomplete,
+    streamError: streamError,
+    streamErrorStackTrace: streamErrorStackTrace,
   );
 }
 
@@ -144,6 +161,8 @@ class SshExec implements ServerExec {
         stdout: collected.stdout,
         stderr: collected.stderr,
         outputIncomplete: collected.outputIncomplete,
+        streamError: collected.streamError,
+        streamErrorStackTrace: collected.streamErrorStackTrace,
       );
     } finally {
       session.close();

--- a/lib/core/utils/ssh_exec.dart
+++ b/lib/core/utils/ssh_exec.dart
@@ -5,6 +5,68 @@ import 'dart:typed_data';
 import 'package:dartssh2/dartssh2.dart';
 import 'package:server_box/data/model/server/server_exec.dart';
 
+typedef SshExecCollectedOutput = ({
+  String stdout,
+  String stderr,
+  bool outputIncomplete,
+});
+
+/// Collects both SSH output streams until the command and streams have ended.
+///
+/// The completion futures are registered before [commandDone] is awaited. A
+/// fast command can close stdout and stderr before its SSH exit status arrives;
+/// registering `asFuture` afterwards misses that already-delivered done event
+/// and falsely turns an ordinary command into a drain timeout.
+Future<SshExecCollectedOutput> collectSshExecOutput({
+  required Stream<List<int>> stdout,
+  required Stream<List<int>> stderr,
+  required Future<void> commandDone,
+  required Duration drainTimeout,
+  OnExecOutput? onStdout,
+  OnExecOutput? onStderr,
+}) async {
+  final out = StringBuffer();
+  final err = StringBuffer();
+  final decoder = const Utf8Decoder(allowMalformed: true);
+
+  // Subscriptions rather than `forEach`, so that giving up on the drain can
+  // actually let go of the streams instead of leaving them writing into
+  // buffers nobody will read.
+  final outSub = decoder.bind(stdout).listen((chunk) {
+    out.write(chunk);
+    onStdout?.call(chunk);
+  });
+  final errSub = decoder.bind(stderr).listen((chunk) {
+    err.write(chunk);
+    onStderr?.call(chunk);
+  });
+
+  // These must be obtained while the subscriptions are still live. Calling
+  // asFuture after a done event has already been delivered creates futures
+  // that can no longer complete.
+  final outDone = outSub.asFuture<void>();
+  final errDone = errSub.asFuture<void>();
+
+  await commandDone;
+
+  var incomplete = false;
+  await Future.wait([outDone, errDone]).timeout(
+    drainTimeout,
+    onTimeout: () async {
+      incomplete = true;
+      await outSub.cancel();
+      await errSub.cancel();
+      return const <void>[];
+    },
+  );
+
+  return (
+    stdout: out.toString(),
+    stderr: err.toString(),
+    outputIncomplete: incomplete,
+  );
+}
+
 /// [ServerExec] over an SSH connection.
 ///
 /// One command, one channel — which is what SSH multiplexing is for, and why
@@ -56,52 +118,35 @@ class SshExec implements ServerExec {
       }),
     );
 
-    final out = StringBuffer();
-    final err = StringBuffer();
-    final decoder = const Utf8Decoder(allowMalformed: true);
-
-    // Subscriptions rather than `forEach`, so that giving up on the drain can
-    // actually let go of the streams instead of leaving them writing into
-    // buffers nobody will read.
-    final outSub = decoder.bind(session.stdout).listen((chunk) {
-      out.write(chunk);
-      onStdout?.call(chunk);
-    });
-    final errSub = decoder.bind(session.stderr).listen((chunk) {
-      err.write(chunk);
-      onStderr?.call(chunk);
-    });
-
-    if (stdin != null) {
-      session.stdin.add(Uint8List.fromList(utf8.encode(stdin)));
-    }
-    if (entry != null) {
-      session.stdin.add(Uint8List.fromList(utf8.encode('$script\n')));
-    }
-    // Closed either way: a command that reads stdin would otherwise wait for
-    // input nobody is going to send.
-    await session.stdin.close();
-
-    await session.done;
-
-    var incomplete = false;
-    await Future.wait([outSub.asFuture<void>(), errSub.asFuture<void>()])
-        .timeout(
-          drainTimeout,
-          onTimeout: () async {
-            incomplete = true;
-            await outSub.cancel();
-            await errSub.cancel();
-            return const <void>[];
-          },
-        );
-    session.close();
-
-    return ExecResult(
-      exitCode: session.exitCode,
-      stdout: out.toString(),
-      stderr: err.toString(),
-      outputIncomplete: incomplete,
+    final output = collectSshExecOutput(
+      stdout: session.stdout,
+      stderr: session.stderr,
+      commandDone: session.done,
+      drainTimeout: drainTimeout,
+      onStdout: onStdout,
+      onStderr: onStderr,
     );
+
+    try {
+      if (stdin != null) {
+        session.stdin.add(Uint8List.fromList(utf8.encode(stdin)));
+      }
+      if (entry != null) {
+        session.stdin.add(Uint8List.fromList(utf8.encode('$script\n')));
+      }
+      // Closed either way: a command that reads stdin would otherwise wait for
+      // input nobody is going to send.
+      await session.stdin.close();
+
+      final collected = await output;
+      return ExecResult(
+        exitCode: session.exitCode,
+        stdout: collected.stdout,
+        stderr: collected.stderr,
+        outputIncomplete: collected.outputIncomplete,
+      );
+    } finally {
+      session.close();
+    }
   }
 }

--- a/lib/data/model/server/server_exec.dart
+++ b/lib/data/model/server/server_exec.dart
@@ -7,6 +7,8 @@ class ExecResult {
     required this.stdout,
     required this.stderr,
     this.outputIncomplete = false,
+    this.streamError,
+    this.streamErrorStackTrace,
   });
 
   /// Null where the source cannot report one — a shell that was closed rather
@@ -23,12 +25,19 @@ class ExecResult {
   /// is here; this says there may have been more.
   final bool outputIncomplete;
 
+  /// An error while reading stdout or stderr, after preserving everything that
+  /// arrived before it.
+  final Object? streamError;
+  final StackTrace? streamErrorStackTrace;
+
   /// Both streams in the order a terminal would have shown them. Most callers
   /// want this: they are parsing what a command printed, not auditing which
   /// file descriptor it used.
   String get combined => stderr.isEmpty ? stdout : '$stdout$stderr';
 
-  bool get succeeded => exitCode == 0 || (exitCode == null && stderr.isEmpty);
+  bool get succeeded =>
+      streamError == null &&
+      (exitCode == 0 || (exitCode == null && stderr.isEmpty));
 }
 
 typedef OnExecOutput = void Function(String chunk);

--- a/lib/data/provider/container.dart
+++ b/lib/data/provider/container.dart
@@ -505,8 +505,10 @@ class ContainerNotifier extends _$ContainerNotifier {
         if (_isStaleRefresh(refreshGeneration)) return;
         Loggers.app.warning(
           'Container refresh output incomplete '
-          '(exit ${result.exitCode}, stdout ${raw.length} bytes, '
-          'stderr ${errOut.length} bytes)',
+          '(exit ${result.exitCode}, stdout ${raw.length} code units, '
+          'stderr ${errOut.length} code units)',
+          result.streamError,
+          result.streamErrorStackTrace,
         );
         _setRefreshError(
           target,
@@ -577,15 +579,21 @@ class ContainerNotifier extends _$ContainerNotifier {
       return;
     }
     if (!result.succeeded) {
+      final detail = userFacingOutput(
+        errOut,
+        result.streamError == null ? raw : '',
+      );
       Loggers.app.warning(
         'Container refresh command failed (exit ${result.exitCode}): '
-        '${userFacingOutput(errOut, '') ?? 'no stderr'}',
+        '${detail ?? result.streamError ?? 'no stderr'}',
+        result.streamError,
+        result.streamErrorStackTrace,
       );
       _setRefreshError(
         target,
         ContainerErr(
           type: ContainerErrType.unknown,
-          message: userFacingOutput(errOut, raw) ?? libL10n.fail,
+          message: detail ?? '${result.streamError ?? libL10n.fail}',
         ),
       );
       await _finishRefresh(refreshGeneration);

--- a/lib/data/provider/container.dart
+++ b/lib/data/provider/container.dart
@@ -1051,12 +1051,15 @@ String? userFacingOutput(String stderr, String stdout) {
 
 /// An execution failure ready to show in the container page.
 ///
-/// A stream error means stdout may end in the middle of an otherwise valid
-/// response, so it must not be presented as the reason for the failure.
+/// Incomplete output or a stream error means stdout may end in the middle of
+/// an otherwise valid response, so it must not be presented as the reason for
+/// the failure.
 String containerExecErrorDetail(ExecResult result) =>
     userFacingOutput(
       result.stderr,
-      result.streamError == null ? result.stdout : '',
+      !result.outputIncomplete && result.streamError == null
+          ? result.stdout
+          : '',
     ) ??
     '${result.streamError ?? libL10n.fail}';
 

--- a/lib/data/provider/container.dart
+++ b/lib/data/provider/container.dart
@@ -503,6 +503,11 @@ class ContainerNotifier extends _$ContainerNotifier {
       (raw, errOut) = (result.stdout, result.stderr);
       if (result.outputIncomplete) {
         if (_isStaleRefresh(refreshGeneration)) return;
+        Loggers.app.warning(
+          'Container refresh output incomplete '
+          '(exit ${result.exitCode}, stdout ${raw.length} bytes, '
+          'stderr ${errOut.length} bytes)',
+        );
         _setRefreshError(
           target,
           ContainerErr(
@@ -572,6 +577,10 @@ class ContainerNotifier extends _$ContainerNotifier {
       return;
     }
     if (!result.succeeded) {
+      Loggers.app.warning(
+        'Container refresh command failed (exit ${result.exitCode}): '
+        '${userFacingOutput(errOut, '') ?? 'no stderr'}',
+      );
       _setRefreshError(
         target,
         ContainerErr(

--- a/lib/data/provider/container.dart
+++ b/lib/data/provider/container.dart
@@ -514,7 +514,7 @@ class ContainerNotifier extends _$ContainerNotifier {
           target,
           ContainerErr(
             type: ContainerErrType.unknown,
-            message: userFacingOutput(errOut, raw) ?? libL10n.fail,
+            message: containerExecErrorDetail(result),
           ),
         );
         await _finishRefresh(refreshGeneration);
@@ -558,7 +558,7 @@ class ContainerNotifier extends _$ContainerNotifier {
         // should be able to see what it was.
         ContainerErr(
           type: ContainerErrType.notInstalled,
-          message: userFacingOutput(errOut, raw),
+          message: containerExecErrorDetail(result),
         ),
       );
       await _finishRefresh(refreshGeneration);
@@ -579,22 +579,15 @@ class ContainerNotifier extends _$ContainerNotifier {
       return;
     }
     if (!result.succeeded) {
-      final detail = userFacingOutput(
-        errOut,
-        result.streamError == null ? raw : '',
-      );
+      final detail = containerExecErrorDetail(result);
       Loggers.app.warning(
-        'Container refresh command failed (exit ${result.exitCode}): '
-        '${detail ?? result.streamError ?? 'no stderr'}',
+        'Container refresh command failed (exit ${result.exitCode}): $detail',
         result.streamError,
         result.streamErrorStackTrace,
       );
       _setRefreshError(
         target,
-        ContainerErr(
-          type: ContainerErrType.unknown,
-          message: detail ?? '${result.streamError ?? libL10n.fail}',
-        ),
+        ContainerErr(type: ContainerErrType.unknown, message: detail),
       );
       await _finishRefresh(refreshGeneration);
       return;
@@ -621,7 +614,7 @@ class ContainerNotifier extends _$ContainerNotifier {
         target,
         ContainerErr(
           type: ContainerErrType.notInstalled,
-          message: userFacingOutput(errOut, raw),
+          message: containerExecErrorDetail(result),
         ),
       );
       await _finishRefresh(refreshGeneration);
@@ -964,8 +957,7 @@ class ContainerNotifier extends _$ContainerNotifier {
         message: l10n.containerSudoPasswordIncorrect,
       );
     }
-    final detail =
-        userFacingOutput(result.stderr, result.stdout) ?? libL10n.fail;
+    final detail = containerExecErrorDetail(result);
     if (result.outputIncomplete) {
       await _finishRun();
       return ContainerErr(type: ContainerErrType.unknown, message: detail);
@@ -1056,6 +1048,17 @@ String? userFacingOutput(String stderr, String stdout) {
   }
   return null;
 }
+
+/// An execution failure ready to show in the container page.
+///
+/// A stream error means stdout may end in the middle of an otherwise valid
+/// response, so it must not be presented as the reason for the failure.
+String containerExecErrorDetail(ExecResult result) =>
+    userFacingOutput(
+      result.stderr,
+      result.streamError == null ? result.stdout : '',
+    ) ??
+    '${result.streamError ?? libL10n.fail}';
 
 /// The command line for one container-runtime call.
 ///

--- a/test/container_test.dart
+++ b/test/container_test.dart
@@ -4,6 +4,7 @@ import 'package:server_box/data/model/container/image.dart';
 import 'package:server_box/data/model/container/ps.dart';
 import 'package:server_box/data/model/container/status.dart';
 import 'package:server_box/data/model/container/type.dart';
+import 'package:server_box/data/model/server/server_exec.dart';
 import 'package:server_box/data/provider/container.dart';
 
 void main() {
@@ -901,6 +902,25 @@ not-json
         ),
         'sh: docker: not found',
       );
+    });
+
+    test('stream errors hide partial stdout but keep stderr', () {
+      final error = StateError('stdout connection lost');
+      final partial = ExecResult(
+        exitCode: 0,
+        stdout: '{"partial": true}',
+        stderr: '',
+        streamError: error,
+      );
+      final withStderr = ExecResult(
+        exitCode: 0,
+        stdout: '{"partial": true}',
+        stderr: 'permission denied',
+        streamError: error,
+      );
+
+      expect(containerExecErrorDetail(partial), '$error');
+      expect(containerExecErrorDetail(withStderr), 'permission denied');
     });
   });
 }

--- a/test/container_test.dart
+++ b/test/container_test.dart
@@ -922,5 +922,16 @@ not-json
       expect(containerExecErrorDetail(partial), '$error');
       expect(containerExecErrorDetail(withStderr), 'permission denied');
     });
+
+    test('incomplete output hides partial stdout without a stream error', () {
+      final result = ExecResult(
+        exitCode: 0,
+        stdout: '{"partial": true}',
+        stderr: '',
+        outputIncomplete: true,
+      );
+
+      expect(containerExecErrorDetail(result), isNot(contains('partial')));
+    });
   });
 }

--- a/test/server_exec_test.dart
+++ b/test/server_exec_test.dart
@@ -1,4 +1,8 @@
+import 'dart:async';
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:server_box/core/utils/ssh_exec.dart';
 import 'package:server_box/data/model/container/type.dart';
 import 'package:server_box/data/model/server/server_exec.dart';
 import 'package:server_box/data/provider/container.dart';
@@ -31,6 +35,52 @@ class _RecordingExec implements ServerExec {
 }
 
 void main() {
+  group('collectSshExecOutput', () {
+    test('accepts streams that close before the command exit arrives', () async {
+      final stdout = StreamController<List<int>>();
+      final stderr = StreamController<List<int>>();
+      final commandDone = Completer<void>();
+      final collecting = collectSshExecOutput(
+        stdout: stdout.stream,
+        stderr: stderr.stream,
+        commandDone: commandDone.future,
+        drainTimeout: const Duration(milliseconds: 20),
+      );
+
+      stdout.add(utf8.encode('container json'));
+      await stdout.close();
+      await stderr.close();
+      commandDone.complete();
+
+      final result = await collecting;
+      expect(result.stdout, 'container json');
+      expect(result.stderr, isEmpty);
+      expect(result.outputIncomplete, isFalse);
+    });
+
+    test('still reports a stream held open after command exit', () async {
+      final stdout = StreamController<List<int>>();
+      final stderr = StreamController<List<int>>();
+      final commandDone = Completer<void>();
+      final collecting = collectSshExecOutput(
+        stdout: stdout.stream,
+        stderr: stderr.stream,
+        commandDone: commandDone.future,
+        drainTimeout: const Duration(milliseconds: 20),
+      );
+
+      stdout.add(utf8.encode('partial output'));
+      commandDone.complete();
+
+      final result = await collecting;
+      expect(result.stdout, 'partial output');
+      expect(result.outputIncomplete, isTrue);
+
+      await stdout.close();
+      await stderr.close();
+    });
+  });
+
   group('ExecResult', () {
     test('accepts output when the SSH server omits a clean exit status', () {
       const result = ExecResult(

--- a/test/server_exec_test.dart
+++ b/test/server_exec_test.dart
@@ -36,27 +36,30 @@ class _RecordingExec implements ServerExec {
 
 void main() {
   group('collectSshExecOutput', () {
-    test('accepts streams that close before the command exit arrives', () async {
-      final stdout = StreamController<List<int>>();
-      final stderr = StreamController<List<int>>();
-      final commandDone = Completer<void>();
-      final collecting = collectSshExecOutput(
-        stdout: stdout.stream,
-        stderr: stderr.stream,
-        commandDone: commandDone.future,
-        drainTimeout: const Duration(milliseconds: 20),
-      );
+    test(
+      'accepts streams that close before the command exit arrives',
+      () async {
+        final stdout = StreamController<List<int>>();
+        final stderr = StreamController<List<int>>();
+        final commandDone = Completer<void>();
+        final collecting = collectSshExecOutput(
+          stdout: stdout.stream,
+          stderr: stderr.stream,
+          commandDone: commandDone.future,
+          drainTimeout: const Duration(milliseconds: 20),
+        );
 
-      stdout.add(utf8.encode('container json'));
-      await stdout.close();
-      await stderr.close();
-      commandDone.complete();
+        stdout.add(utf8.encode('container json'));
+        await stdout.close();
+        await stderr.close();
+        commandDone.complete();
 
-      final result = await collecting;
-      expect(result.stdout, 'container json');
-      expect(result.stderr, isEmpty);
-      expect(result.outputIncomplete, isFalse);
-    });
+        final result = await collecting;
+        expect(result.stdout, 'container json');
+        expect(result.stderr, isEmpty);
+        expect(result.outputIncomplete, isFalse);
+      },
+    );
 
     test('still reports a stream held open after command exit', () async {
       final stdout = StreamController<List<int>>();
@@ -79,6 +82,32 @@ void main() {
       await stdout.close();
       await stderr.close();
     });
+
+    test('preserves output received before a stream error', () async {
+      final stdout = StreamController<List<int>>();
+      final stderr = StreamController<List<int>>();
+      final commandDone = Completer<void>();
+      final error = StateError('stdout connection lost');
+      final collecting = collectSshExecOutput(
+        stdout: stdout.stream,
+        stderr: stderr.stream,
+        commandDone: commandDone.future,
+        drainTimeout: const Duration(milliseconds: 20),
+      );
+
+      stdout
+        ..add(utf8.encode('partial container json'))
+        ..addError(error);
+      commandDone.complete();
+      await stderr.close();
+
+      final result = await collecting;
+      expect(result.stdout, 'partial container json');
+      expect(result.streamError, same(error));
+      expect(result.outputIncomplete, isFalse);
+
+      await stdout.close();
+    });
   });
 
   group('ExecResult', () {
@@ -97,6 +126,17 @@ void main() {
         exitCode: null,
         stdout: '',
         stderr: 'permission denied',
+      );
+
+      expect(result.succeeded, isFalse);
+    });
+
+    test('rejects a command whose output stream failed', () {
+      final result = ExecResult(
+        exitCode: 0,
+        stdout: 'partial output',
+        stderr: '',
+        streamError: StateError('connection lost'),
       );
 
       expect(result.succeeded, isFalse);


### PR DESCRIPTION
## Summary

- Register SSH stdout and stderr completion futures before awaiting the command exit status.
- Prevent valid Docker and Podman JSON output from being falsely reported as incomplete after the drain timeout.
- Add container refresh diagnostics and regression coverage for normal and genuinely incomplete streams.

## Testing

- flutter test test/server_exec_test.dart test/container_test.dart
- flutter analyze lib/core/utils/ssh_exec.dart lib/data/provider/container.dart test/server_exec_test.dart
- Manual Android container refresh verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH command output handling, including data received before command completion.
  * Detects and reports stream read failures, even when commands return a successful exit code.
  * Preserves available output and provides clearer diagnostics for incomplete or failed SSH responses.
  * Improved container refresh and command-operation errors with clearer output and stream error details.
  * Ensures SSH sessions close safely after command execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->