### PR TITLE
fix(ssh): restore missing virtual key options

### DIFF
--- a/lib/view/page/setting/seq/virt_key.dart
+++ b/lib/view/page/setting/seq/virt_key.dart
@@ -51,6 +51,13 @@ class _SSHVirtKeySettingPageState extends State<SSHVirtKeySettingPage> {
       if (key == null) continue;
       if (!_order.contains(key)) _order.add(key);
     }
+    // A key absent from both stored lists has never been configured. This is
+    // the normal state for every optional key on an older install, and for a
+    // key added by a newer build. Keep it available in settings, but disabled,
+    // so opening this page does not silently add it to the terminal strip.
+    for (final key in VirtKey.values) {
+      if (!_order.contains(key)) _order.add(key);
+    }
     _enabled = keys.where((k) => !disabled.contains(k.name)).toSet();
   }
 

--- a/test/virt_key_setting_test.dart
+++ b/test/virt_key_setting_test.dart
@@ -1,0 +1,76 @@
+import 'package:fl_lib/fl_lib.dart';
+import 'package:fl_lib/generated/l10n/lib_l10n.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:server_box/core/extension/context/locale.dart' as app_locale;
+import 'package:server_box/data/model/ssh/virtual_key.dart';
+import 'package:server_box/data/res/store.dart';
+import 'package:server_box/data/store/setting.dart';
+import 'package:server_box/generated/l10n/l10n.dart';
+import 'package:server_box/view/page/setting/seq/virt_key.dart';
+
+import 'helpers/test_db.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await openTestDb();
+    getIt.registerSingleton<SettingStore>(SettingStore('setting_test'));
+  });
+
+  tearDown(() async {
+    await getIt.reset();
+    await SqliteDb.close();
+  });
+
+  testWidgets('an unconfigured virtual key remains available to enable', (
+    tester,
+  ) async {
+    Stores.setting.sshVirtKeys.put([VirtKey.esc.name]);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        locale: const Locale('en'),
+        localizationsDelegates: const [
+          LibLocalizations.delegate,
+          ...AppLocalizations.localizationsDelegates,
+        ],
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Builder(
+          builder: (context) {
+            app_locale.l10n = AppLocalizations.of(context)!;
+            context.setLibL10n();
+            return const SSHVirtKeySettingPage();
+          },
+        ),
+      ),
+    );
+    addTearDown(() => tester.pumpWidget(const SizedBox.shrink()));
+
+    await tester.scrollUntilVisible(
+      find.text(VirtKey.underscore.text),
+      300,
+      scrollable: find.byType(Scrollable).last,
+    );
+
+    final row = find.ancestor(
+      of: find.text(VirtKey.underscore.text),
+      matching: find.byType(ListTile),
+    );
+    final checkbox = find.descendant(of: row, matching: find.byType(Checkbox));
+    expect(tester.widget<Checkbox>(checkbox).value, isFalse);
+
+    await tester.tap(checkbox);
+    await tester.pump();
+
+    expect(
+      Stores.setting.sshVirtKeys.fetch(),
+      contains(VirtKey.underscore.name),
+    );
+    expect(
+      Stores.setting.sshVirtKeysDisabled.fetch(),
+      isNot(contains(VirtKey.underscore.name)),
+    );
+  });
+}


### PR DESCRIPTION
## What this changes

- restore every known virtual key to the customization list when it is missing from persisted settings
- keep previously unconfigured keys disabled until the user explicitly enables them, preserving the existing terminal strip
- add a widget regression test covering the underscore key reported in #1396

Fixes #1396

## How it was tested

- `flutter test test/virt_key_setting_test.dart test/virt_key_order_test.dart test/virt_key_availability_test.dart`
- `flutter analyze lib/view/page/setting/seq/virt_key.dart test/virt_key_setting_test.dart`
- GitHub Actions: full `flutter analyze lib test integration_test`, native FFI build, and `flutter test`

## Checklist

- [x] `make analyze` and `make test` pass
- [x] `make gen` was run, if any model / ARB file changed (not applicable)
- [x] `cargo test --workspace` passes, if anything under `crates/` or `monitor/` changed (not applicable)
- [x] No formatter was run over untouched code