### PR TITLE
fix(windows): expand default script paths

### DIFF
--- a/crates/sbm_parser/src/script.rs
+++ b/crates/sbm_parser/src/script.rs
@@ -502,11 +502,29 @@ fn shell_quote_ps(s: &str) -> String {
     format!("'{}'", s.replace('\'', "''"))
 }
 
+/// A remote Windows path is normally user-controlled data and must stay a
+/// literal. The app's two built-in script directories are the exception: they
+/// start with a PowerShell environment expression because the remote user's
+/// actual home/temp directory is not known locally.
+fn shell_path_ps(s: &str) -> String {
+    for env in ["$env:TEMP", "$env:USERPROFILE"] {
+        if s == env {
+            return env.to_owned();
+        }
+        if let Some(tail) = s.strip_prefix(env)
+            && let Some(path) = tail.strip_prefix(['/', '\\'])
+        {
+            return format!("(Join-Path {env} {})", shell_quote_ps(path));
+        }
+    }
+    shell_quote_ps(s)
+}
+
 pub fn install_command(system: SystemType, script_dir: &str, script_path: &str) -> String {
     match system {
         SystemType::Windows => {
-            let qdir = shell_quote_ps(script_dir);
-            let qpath = shell_quote_ps(script_path);
+            let qdir = shell_path_ps(script_dir);
+            let qpath = shell_path_ps(script_path);
             encoded_powershell_command(&format!(
                 "New-Item -ItemType Directory -Force -Path {qdir} | Out-Null; \
 $sb = New-Object System.Text.StringBuilder; \
@@ -548,7 +566,7 @@ pub fn exec_command(system: SystemType, script_path: &str, func: ShellFunc) -> S
     match system {
         SystemType::Windows => encoded_powershell_command(&format!(
             "& {} -{}",
-            shell_quote_ps(script_path),
+            shell_path_ps(script_path),
             func.flag()
         )),
         _ => format!("sh {} -{}", shell_quote_unix(script_path), func.flag()),

--- a/crates/sbm_parser/tests/script_compat.rs
+++ b/crates/sbm_parser/tests/script_compat.rs
@@ -323,6 +323,40 @@ fn install_commands() {
     assert!(decoded.contains(WINDOWS_INSTALL_EOF));
 }
 
+#[test]
+fn windows_default_script_paths_expand_remote_environment() {
+    let install = install_command(
+        SystemType::Windows,
+        r"$env:USERPROFILE/.config/server_box",
+        r"$env:USERPROFILE/.config/server_box\srvboxm.ps1",
+    );
+    let decoded = decode_utf16le_b64(install.rsplit(' ').next().unwrap());
+    assert!(
+        decoded.contains(
+            "New-Item -ItemType Directory -Force -Path (Join-Path $env:USERPROFILE '.config/server_box')"
+        ),
+        "{decoded}"
+    );
+    assert!(
+        decoded.contains(
+            "Set-Content -Path (Join-Path $env:USERPROFILE '.config/server_box\\srvboxm.ps1')"
+        ),
+        "{decoded}"
+    );
+    assert!(!decoded.contains("-Path '$env:USERPROFILE"), "{decoded}");
+
+    let exec = exec_command(
+        SystemType::Windows,
+        r"$env:TEMP/server_box\srvboxm.ps1",
+        ShellFunc::Status,
+    );
+    let decoded = decode_utf16le_b64(exec.rsplit(' ').next().unwrap());
+    assert_eq!(
+        decoded,
+        "& (Join-Path $env:TEMP 'server_box\\srvboxm.ps1') -s"
+    );
+}
+
 /// The two halves have to agree: the command stops at a line the payload is
 /// responsible for putting there, and neither is any use alone.
 #[test]
@@ -405,6 +439,17 @@ fn exec_commands() {
     let encoded = win.split_whitespace().last().unwrap();
     assert!(
         decode_utf16le_b64(encoded).contains("& 'C:\\Program Files\\Server Box\\status.ps1' -s")
+    );
+
+    let custom = exec_command(
+        SystemType::Windows,
+        r"C:\Server $($env:USERNAME)\it's\status.ps1",
+        ShellFunc::Status,
+    );
+    let encoded = custom.split_whitespace().last().unwrap();
+    assert_eq!(
+        decode_utf16le_b64(encoded),
+        "& 'C:\\Server $($env:USERNAME)\\it''s\\status.ps1' -s"
     );
 }
 


### PR DESCRIPTION
## Summary

- expand the built-in Windows TEMP and USERPROFILE script paths on the remote host
- keep custom Windows script directories safely single-quoted as literal paths
- cover both script installation and execution with regression tests

## Testing

- `cargo test -p sbm_parser`
- `cargo clippy -p sbm_parser --all-targets -- -D warnings`

Fixes #1399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows PowerShell path handling so environment-based paths such as `$env:TEMP` and `$env:USERPROFILE` expand correctly during installation and execution.
  * Preserved embedded PowerShell path expressions while safely quoting paths containing apostrophes or other literal text.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->