### PR TITLE
fix: drop snap images, swap areas and container layers from the disk list

### DIFF
--- a/crates/sbm_parser/src/types.rs
+++ b/crates/sbm_parser/src/types.rs
@@ -151,10 +151,15 @@ pub fn disk_should_calc(fs: &str, mount: &str) -> bool {
 /// `overlay` and `overlayfs` are the current and pre-4.0 spellings of docker's
 /// own layers. `fuse-overlayfs` is what a rootless podman or docker mounts,
 /// one row per container carrying the host filesystem's own numbers.
+///
+/// `ramfs` is systemd's credential mounts, one per unit that takes a
+/// credential. Most `df` builds report `-` for its usage, which fails to parse
+/// and drops the row before any of this; naming it here does not depend on
+/// that, since a build reporting `0%` instead leaves a row of 0 B.
 fn is_virtual_fs(fs: &str) -> bool {
     matches!(
         fs,
-        "shm" | "tmpfs" | "devtmpfs" | "overlay" | "overlayfs" | "fuse-overlayfs"
+        "shm" | "tmpfs" | "ramfs" | "devtmpfs" | "overlay" | "overlayfs" | "fuse-overlayfs"
     )
 }
 

--- a/crates/sbm_parser/src/types.rs
+++ b/crates/sbm_parser/src/types.rs
@@ -121,23 +121,55 @@ pub struct Disk {
 }
 
 /// Whether a `df` row describes storage worth reporting (Dart `_shouldCalc`):
-/// exclude kernel mounts; include /dev-prefixed sources, network mounts (//),
-/// /mnt mount points; exclude shm/overlay/tmpfs/devtmpfs sources; include the rest
+/// exclude kernel mounts, read-only images and swap areas; include /dev-prefixed
+/// sources, network mounts (//), /mnt mount points; exclude
+/// shm/overlay/fuse-overlayfs/tmpfs/devtmpfs sources; include the rest
 pub fn disk_should_calc(fs: &str, mount: &str) -> bool {
     // Checked before the inclusions below, so that a source spelled like a
     // block device cannot bring these back: a host that exposes many device
     // nodes publishes one devtmpfs row per node, two dozen lines all claiming
     // 0 B used of the same size.
-    if is_kernel_mount(mount) {
+    if is_kernel_mount(mount) || is_read_only_image(fs, mount) || is_swap_area(fs, mount) {
         return false;
     }
     if fs.starts_with("/dev") || fs.starts_with("//") || mount.starts_with("/mnt") {
         return true;
     }
+    // `overlay` covers the old `overlayfs` spelling too, but not the
+    // `fuse-overlayfs` a rootless podman or docker uses: that one publishes a
+    // row per container carrying the host filesystem's own numbers.
     !(fs.starts_with("shm")
         || fs.starts_with("overlay")
+        || fs == "fuse-overlayfs"
         || fs.starts_with("tmpfs")
         || fs.starts_with("devtmpfs"))
+}
+
+/// A read-only image mounted as a filesystem — a snap's squashfs, the same
+/// image handed to a container through `snapfuse`, a mounted ISO — rather than
+/// storage anyone manages. Each is full by construction, so it reports 100%
+/// and contributes its whole size to the total; a snap-heavy Ubuntu publishes
+/// twenty of them, which is the entire device list.
+///
+/// Matched on the image, never on `/dev/loop`: a loop device carrying a
+/// writable filesystem is storage someone mounted on purpose, and it is the
+/// `df` fallback hosts (busybox, no lsblk) where that is most likely.
+/// `fs` is a filesystem type under `lsblk` and a source under `df`, so the
+/// two sources are recognised by different halves of this.
+fn is_read_only_image(fs: &str, mount: &str) -> bool {
+    matches!(
+        fs,
+        "squashfs" | "erofs" | "iso9660" | "snapfuse" | "fuse.snapfuse"
+    ) || mount.starts_with("/snap/")
+        || mount.starts_with("/var/lib/snapd/snap/")
+}
+
+/// A swap area, which `lsblk` lists beside filesystems. It has no mount point
+/// and no `FSSIZE`, so the row reads `0 B / 0 B`, and swap is reported on its
+/// own from `/proc/meminfo` anyway. `df` lists only mounted filesystems and
+/// never produces one of these.
+fn is_swap_area(fs: &str, mount: &str) -> bool {
+    fs == "swap" || mount == "[SWAP]"
 }
 
 /// `/dev`, `/proc`, `/sys`, and anything mounted inside them.

--- a/crates/sbm_parser/src/types.rs
+++ b/crates/sbm_parser/src/types.rs
@@ -122,8 +122,11 @@ pub struct Disk {
 
 /// Whether a `df` row describes storage worth reporting (Dart `_shouldCalc`):
 /// exclude kernel mounts, read-only images and swap areas; include /dev-prefixed
-/// sources, network mounts (//), /mnt mount points; exclude
-/// shm/overlay/fuse-overlayfs/tmpfs/devtmpfs sources; include the rest
+/// sources, network mounts (//), /mnt mount points; exclude the virtual
+/// filesystems [`is_virtual_fs`] names; include the rest
+///
+/// Takes one of a row's two identifiers, whichever the caller has. Prefer
+/// [`Disk::is_storage`] where both are available.
 pub fn disk_should_calc(fs: &str, mount: &str) -> bool {
     // Checked before the inclusions below, so that a source spelled like a
     // block device cannot bring these back: a host that exposes many device
@@ -135,14 +138,24 @@ pub fn disk_should_calc(fs: &str, mount: &str) -> bool {
     if fs.starts_with("/dev") || fs.starts_with("//") || mount.starts_with("/mnt") {
         return true;
     }
-    // `overlay` covers the old `overlayfs` spelling too, but not the
-    // `fuse-overlayfs` a rootless podman or docker uses: that one publishes a
-    // row per container carrying the host filesystem's own numbers.
-    !(fs.starts_with("shm")
-        || fs.starts_with("overlay")
-        || fs == "fuse-overlayfs"
-        || fs.starts_with("tmpfs")
-        || fs.starts_with("devtmpfs"))
+    !is_virtual_fs(fs)
+}
+
+/// A kernel-backed filesystem with nothing stored behind it, by exact name.
+///
+/// Matched exactly rather than by prefix, because `fs` is a *source* under
+/// `df` and a source carries user-chosen text: a ZFS pool named `tmpfspool`,
+/// or an export from an NFS host named `shm-nas`, each begin with one of these
+/// and each is storage.
+///
+/// `overlay` and `overlayfs` are the current and pre-4.0 spellings of docker's
+/// own layers. `fuse-overlayfs` is what a rootless podman or docker mounts,
+/// one row per container carrying the host filesystem's own numbers.
+fn is_virtual_fs(fs: &str) -> bool {
+    matches!(
+        fs,
+        "shm" | "tmpfs" | "devtmpfs" | "overlay" | "overlayfs" | "fuse-overlayfs"
+    )
 }
 
 /// A read-only image mounted as a filesystem — a snap's squashfs, the same
@@ -170,6 +183,22 @@ fn is_read_only_image(fs: &str, mount: &str) -> bool {
 /// never produces one of these.
 fn is_swap_area(fs: &str, mount: &str) -> bool {
     fs == "swap" || mount == "[SWAP]"
+}
+
+impl Disk {
+    /// Whether this describes storage worth reporting, rather than a kernel
+    /// mount, a read-only image, a container layer or a swap area
+    /// (Dart `Disk.isStorage`).
+    ///
+    /// [`disk_should_calc`] is handed a source by `df` and a filesystem type
+    /// by `lsblk`, never both, and takes a different branch for each. A [`Disk`]
+    /// carries both, so it is asked with each — otherwise a row identified only
+    /// by its type, such as a squashfs whose mount point is not under `/snap`,
+    /// or a swap area whose mount is empty rather than `[SWAP]`, is missed.
+    pub fn is_storage(&self) -> bool {
+        disk_should_calc(&self.path, &self.mount)
+            && disk_should_calc(self.fs_type.as_deref().unwrap_or(&self.path), &self.mount)
+    }
 }
 
 /// `/dev`, `/proc`, `/sys`, and anything mounted inside them.
@@ -369,7 +398,7 @@ pub struct SmartAttributeFlags {
 /// nodes carrying their own data are not descended into
 pub fn disk_usage(disks: &[Disk]) -> (u64, u64) {
     fn visit(disk: &Disk, seen: &mut Vec<String>, used: &mut u64, size: &mut u64) {
-        if !disk_should_calc(&disk.path, &disk.mount) {
+        if !disk.is_storage() {
             return;
         }
         let unique = format!("{}:{}", disk.path, disk.kname.as_deref().unwrap_or("unknown"));

--- a/crates/sbm_parser/tests/dart_compat.rs
+++ b/crates/sbm_parser/tests/dart_compat.rs
@@ -431,6 +431,56 @@ fn disk_parse_df_drops_container_layers() {
     assert_eq!(disks[2].mount, "/mnt/image");
 }
 
+/// A `df` source is user-chosen text. Excluding the virtual filesystems by
+/// prefix took every one of these with them: a ZFS pool may be named
+/// `tmpfspool`, an NFS export may come from a host named `shm-nas`, and both
+/// are storage.
+#[test]
+fn disk_parse_df_keeps_storage_named_like_a_virtual_fs() {
+    let raw = "Filesystem 1K-blocks Used Available Use% Mounted on\n\
+        tmpfspool/data 961873408 12345678 949527730 2% /srv/pool\n\
+        shm-nas:/vol1 961873408 12345678 949527730 2% /srv/nfs\n\
+        overlay-01:/export 961873408 12345678 949527730 2% /srv/export\n\
+        devtmpfs-backup:/snapshots 961873408 12345678 949527730 2% /srv/backup\n\
+        tmpfs 800412 1792 798620 1% /run\n\
+        overlay 51343636 12057216 36648004 25% /var/lib/docker/overlay2/9c1f/merged\n";
+    let disks = linux::parse_disk(raw);
+
+    let mounts: Vec<&str> = disks.iter().map(|d| d.mount.as_str()).collect();
+    assert_eq!(mounts, ["/srv/pool", "/srv/nfs", "/srv/export", "/srv/backup"]);
+}
+
+/// `disk_usage` is the Rust side of `DiskUsage.parse`, and takes a [`Disk`]
+/// that carries both a source and a filesystem type where the parser is handed
+/// one or the other. Asking with the path alone missed a row identified only by
+/// its type: a squashfs mounted outside `/snap`, or a swap area whose mount is
+/// empty rather than `[SWAP]`.
+#[test]
+fn disk_usage_drops_rows_identified_only_by_filesystem_type() {
+    let row = |path: &str, fs_type: &str, mount: &str, size: u64| Disk {
+        path: path.to_string(),
+        fs_type: (!fs_type.is_empty()).then(|| fs_type.to_string()),
+        mount: mount.to_string(),
+        used: size,
+        size,
+        ..Disk::default()
+    };
+    let root = row("/dev/vda1", "ext4", "/", 51343636);
+    let disks = [
+        root.clone(),
+        // A squashfs image mounted somewhere the mount-point rule cannot name
+        row("/dev/loop3", "squashfs", "/opt/appimage/mnt", 296960),
+        // A swap partition whose mount `lsblk` left empty
+        row("/dev/vda2", "swap", "", 4194304),
+        // A rootless container layer, recognised by its source
+        row("fuse-overlayfs", "", "/home/u/.local/share/x/merged", 51343636),
+    ];
+
+    let (used, size) = disk_usage(&disks);
+    assert_eq!(used, root.used);
+    assert_eq!(size, root.size);
+}
+
 /// Dart 'parse ImmortalWrt df -k output without shrinking units'
 #[test]
 fn disk_parse_immortalwrt() {

--- a/crates/sbm_parser/tests/dart_compat.rs
+++ b/crates/sbm_parser/tests/dart_compat.rs
@@ -412,8 +412,10 @@ fn disk_parse_df_drops_read_only_images() {
 /// spelling, but not the `fuse-overlayfs` a rootless podman or docker mounts —
 /// one row per container, each carrying the host filesystem's numbers.
 ///
-/// `ramfs` is here as the case that needs no rule: systemd's credential mounts
-/// report a `-` usage, which fails to parse and drops the row already.
+/// The `ramfs` row here is systemd's credential mount in the shape most `df`
+/// builds print it, a `-` usage that fails to parse and drops the row before
+/// any rule applies — see disk_parse_df_drops_ramfs_reporting_a_usage for the
+/// shape that does need one.
 #[test]
 fn disk_parse_df_drops_container_layers() {
     let disks = linux::parse_disk(include_str!("fixtures/df_nonstorage.txt"));
@@ -429,6 +431,22 @@ fn disk_parse_df_drops_container_layers() {
     assert_eq!(disks[0].mount, "/");
     assert_eq!(disks[2].path, "/dev/loop7");
     assert_eq!(disks[2].mount, "/mnt/image");
+}
+
+/// `ramfs` holds systemd's credentials, one mount per unit that takes one.
+/// It survived on a `df` that prints a parseable `0%` rather than the `-` most
+/// print, leaving a row of 0 B per unit — the same shape swap areas had.
+#[test]
+fn disk_parse_df_drops_ramfs_reporting_a_usage() {
+    let raw = "Filesystem 1K-blocks Used Available Use% Mounted on\n\
+        /dev/vda1 51343636 12057216 36648004 25% /\n\
+        ramfs 0 0 0 0% /run/credentials/systemd-sysctl.service\n\
+        ramfs 0 0 0 0% /run/credentials/systemd-networkd.service\n";
+    let disks = linux::parse_disk(raw);
+
+    assert!(!disks.iter().any(|d| d.path == "ramfs"));
+    assert_eq!(disks.len(), 1);
+    assert_eq!(disks[0].mount, "/");
 }
 
 /// A `df` source is user-chosen text. Excluding the virtual filesystems by

--- a/crates/sbm_parser/tests/dart_compat.rs
+++ b/crates/sbm_parser/tests/dart_compat.rs
@@ -216,11 +216,16 @@ fn swap_parse_meminfo() {
 
 // ---------- Disk: disk_test.dart ----------
 
-/// Dart 'parse lsblk JSON output': 6 entries (LVM2_member/ext4//swap/vfat/ext2/crypto_LUKS)
+/// Dart 'parse lsblk JSON output': 5 entries
+/// (LVM2_member/ext4//vfat/ext2/crypto_LUKS)
+///
+/// This fixture came off a real machine and carries the swap partition that
+/// machine has. It was the sixth entry until swap areas were dropped.
 #[test]
 fn disk_parse_lsblk_json() {
     let disks = linux::parse_disk(include_str!("fixtures/lsblk.json"));
-    assert_eq!(disks.len(), 6);
+    assert_eq!(disks.len(), 5);
+    assert!(!disks.iter().any(|d| d.mount == "[SWAP]"));
 
     let root = disks.iter().find(|d| d.mount == "/").unwrap();
     assert_eq!(root.fs_type.as_deref(), Some("ext4"));
@@ -334,6 +339,96 @@ fn disk_parse_df_collapses_repeated_mounts() {
     let orbstack: Vec<_> = disks.iter().filter(|d| d.path == "orbstack").collect();
     assert_eq!(orbstack.len(), 2);
     assert_ne!(orbstack[0].used, orbstack[1].used);
+}
+
+/// A snap-heavy Ubuntu mounts one squashfs per installed revision, each 100%
+/// full by construction. They filled the device list ahead of the machine's
+/// actual disks and added their whole size to the total. A mounted ISO is the
+/// same shape and goes the same way.
+#[test]
+fn disk_parse_lsblk_drops_read_only_images() {
+    let disks = linux::parse_disk(include_str!("fixtures/lsblk_nonstorage.json"));
+
+    assert!(!disks.iter().any(|d| d.mount.starts_with("/snap/")));
+    assert!(!disks.iter().any(|d| matches!(
+        d.fs_type.as_deref(),
+        Some("squashfs" | "erofs" | "iso9660")
+    )));
+
+    let root = disks.iter().find(|d| d.mount == "/").unwrap();
+    assert_eq!(root.path, "/dev/vda1");
+    assert_eq!(root.used_percent, 24);
+
+    // A loop device carrying a writable filesystem is storage someone mounted
+    // on purpose, and is not what any of this is about
+    let image = disks.iter().find(|d| d.path == "/dev/loop7").unwrap();
+    assert_eq!(image.mount, "/mnt/image");
+    assert_eq!(image.used_percent, 50);
+}
+
+/// `lsblk` lists a swap partition and a zram device beside the filesystems,
+/// both with an empty FSSIZE, so each rendered as a device holding 0 B of 0 B.
+/// Swap has its own reading, taken from /proc/meminfo.
+#[test]
+fn disk_parse_lsblk_drops_swap_areas() {
+    let disks = linux::parse_disk(include_str!("fixtures/lsblk_nonstorage.json"));
+
+    assert!(!disks.iter().any(|d| d.mount == "[SWAP]"));
+    assert!(!disks.iter().any(|d| d.fs_type.as_deref() == Some("swap")));
+    assert!(!disks.iter().any(|d| d.path == "/dev/zram0"));
+    assert!(!disks.iter().any(|d| d.path == "/dev/vda2"));
+
+    // The partitions either side of the swap one are untouched
+    assert!(disks.iter().any(|d| d.mount == "/"));
+    assert!(disks.iter().any(|d| d.mount == "/boot/efi"));
+}
+
+/// The `df` fallback reports no filesystem type: `/dev/loop0` is
+/// indistinguishable from a mounted disk image by its source, so the mount
+/// point is what names it. `snapfuse` is snapd inside a container, where the
+/// loop device is unavailable.
+#[test]
+fn disk_parse_df_drops_read_only_images() {
+    let disks = linux::parse_disk(include_str!("fixtures/df_nonstorage.txt"));
+
+    assert!(!disks.iter().any(|d| d.path == "snapfuse"));
+    assert!(!disks.iter().any(|d| d.mount.starts_with("/snap/")));
+    assert!(
+        !disks
+            .iter()
+            .any(|d| d.mount.starts_with("/var/lib/snapd/snap/"))
+    );
+
+    // The known limit of this branch: `df` reports no filesystem type, and a
+    // mounted ISO has no mount point that names it the way a snap's does, so
+    // `/dev/sr0` reads as an ordinary block device here. It is dropped under
+    // `lsblk` — see disk_parse_lsblk_drops_read_only_images — which is every
+    // host that has one; `df` is the fallback for busybox and OpenWrt.
+    // Recognising `/dev/sr` by name would trade the rule for a device list.
+    assert!(disks.iter().any(|d| d.path == "/dev/sr0"));
+}
+
+/// `overlay` already covered docker's own layers and the old `overlayfs`
+/// spelling, but not the `fuse-overlayfs` a rootless podman or docker mounts —
+/// one row per container, each carrying the host filesystem's numbers.
+///
+/// `ramfs` is here as the case that needs no rule: systemd's credential mounts
+/// report a `-` usage, which fails to parse and drops the row already.
+#[test]
+fn disk_parse_df_drops_container_layers() {
+    let disks = linux::parse_disk(include_str!("fixtures/df_nonstorage.txt"));
+
+    assert!(!disks.iter().any(|d| d.path == "overlay"));
+    assert!(!disks.iter().any(|d| d.path == "fuse-overlayfs"));
+    assert!(!disks.iter().any(|d| d.path == "ramfs"));
+
+    // What is left is the root filesystem, the ISO this branch cannot name,
+    // and the deliberately mounted image
+    assert_eq!(disks.len(), 3);
+    assert_eq!(disks[0].path, "/dev/vda1");
+    assert_eq!(disks[0].mount, "/");
+    assert_eq!(disks[2].path, "/dev/loop7");
+    assert_eq!(disks[2].mount, "/mnt/image");
 }
 
 /// Dart 'parse ImmortalWrt df -k output without shrinking units'

--- a/crates/sbm_parser/tests/fixtures/df_nonstorage.txt
+++ b/crates/sbm_parser/tests/fixtures/df_nonstorage.txt
@@ -1,0 +1,10 @@
+Filesystem     1K-blocks      Used Available Use% Mounted on
+/dev/vda1       51343636  12057216  36648004  25% /
+/dev/loop0        296960    296960         0 100% /snap/copilot-cli/57
+/dev/loop6         66944     66944         0 100% /var/lib/snapd/snap/core24/1587
+snapfuse          129024    129024         0 100% /snap/lxd/31333
+overlay         51343636  12057216  36648004  25% /var/lib/docker/overlay2/9c1f/merged
+fuse-overlayfs  51343636  12057216  36648004  25% /home/u/.local/share/containers/storage/overlay/7a2e/merged
+ramfs                  0         0         0    - /run/credentials/systemd-sysctl.service
+/dev/sr0         4718592   4718592         0 100% /media/cdrom
+/dev/loop7       1032256    515072    517184  50% /mnt/image

--- a/crates/sbm_parser/tests/fixtures/lsblk_nonstorage.json
+++ b/crates/sbm_parser/tests/fixtures/lsblk_nonstorage.json
@@ -1,0 +1,17 @@
+{
+   "blockdevices": [
+      {"fstype":"squashfs","path":"/dev/loop0","name":"loop0","kname":"loop0","mountpoint":"/snap/copilot-cli/57","fssize":"304087040","fsused":"304087040","fsavail":"0","fsuse%":"100%","uuid":null},
+      {"fstype":"squashfs","path":"/dev/loop1","name":"loop1","kname":"loop1","mountpoint":"/snap/core22/2411","fssize":"77594624","fsused":"77594624","fsavail":"0","fsuse%":"100%","uuid":null},
+      {"fstype":"erofs","path":"/dev/loop2","name":"loop2","kname":"loop2","mountpoint":"/snap/bare/5","fssize":"131072","fsused":"131072","fsavail":"0","fsuse%":"100%","uuid":null},
+      {"fstype":"ext4","path":"/dev/loop7","name":"loop7","kname":"loop7","mountpoint":"/mnt/image","fssize":"1057030144","fsused":"527433728","fsavail":"529596416","fsuse%":"50%","uuid":"3f2b1c40-0000-4000-8000-000000000001"},
+      {"fstype":"iso9660","path":"/dev/sr0","name":"sr0","kname":"sr0","mountpoint":"/media/cdrom","fssize":"4831838208","fsused":"4831838208","fsavail":"0","fsuse%":"100%","uuid":null},
+      {"fstype":"swap","path":"/dev/zram0","name":"zram0","kname":"zram0","mountpoint":"[SWAP]","fssize":null,"fsused":null,"fsavail":null,"fsuse%":null,"uuid":null},
+      {"fstype":null,"path":"/dev/vda","name":"vda","kname":"vda","mountpoint":null,"fssize":null,"fsused":null,"fsavail":null,"fsuse%":null,"uuid":null,
+         "children": [
+            {"fstype":"ext4","path":"/dev/vda1","name":"vda1","kname":"vda1","mountpoint":"/","fssize":"52576284672","fsused":"12346589184","fsavail":"37527699456","fsuse%":"24%","uuid":"3f2b1c40-0000-4000-8000-000000000002"},
+            {"fstype":"swap","path":"/dev/vda2","name":"vda2","kname":"vda2","mountpoint":"[SWAP]","fssize":null,"fsused":null,"fsavail":null,"fsuse%":null,"uuid":"3f2b1c40-0000-4000-8000-000000000003"},
+            {"fstype":"vfat","path":"/dev/vda15","name":"vda15","kname":"vda15","mountpoint":"/boot/efi","fssize":"109422592","fsused":"6330368","fsavail":"103092224","fsuse%":"6%","uuid":"A1B2-C3D4"}
+         ]
+      }
+   ]
+}

--- a/lib/data/model/server/disk.dart
+++ b/lib/data/model/server/disk.dart
@@ -41,6 +41,18 @@ class Disk extends Equatable {
 
   // Parsing implementation migrated to the shared Rust library sbm_parser
 
+  /// Whether this describes storage worth showing, rather than a kernel mount,
+  /// a read-only image, a container layer or a swap area.
+  ///
+  /// The parser drops the rest while reading `lsblk`/`df`. A [Disk] built from
+  /// a monitor agent's `disk_details` never went through it, so an agent older
+  /// than a given rule still sends what that rule removes.
+  ///
+  /// [_shouldCalc] is handed a source by `df` and a filesystem type by `lsblk`,
+  /// never both, and takes a different branch for each. A [Disk] carries both,
+  /// so it is asked with each.
+  bool get isStorage =>
+      _shouldCalc(path, mount) && _shouldCalc(fsTyp ?? path, mount);
 
   @override
   List<Object?> get props => [
@@ -166,7 +178,7 @@ class DiskUsage {
     var size = BigInt.zero;
 
     void visit(Disk disk) {
-      if (!_shouldCalc(disk.path, disk.mount)) return;
+      if (!disk.isStorage) return;
       // Use a combination of path and kernel name to uniquely identify disks
       // This helps distinguish between multiple physical disks in BTRFS RAID setups
       final uniqueId = '${disk.path}:${disk.kname ?? "unknown"}';
@@ -194,14 +206,20 @@ bool _shouldCalc(String fs, String mount) {
   // publishes one devtmpfs row per node, two dozen lines all claiming 0 B used
   // of the same size.
   if (_isKernelMount(mount)) return false;
+  if (_isReadOnlyImage(fs, mount)) return false;
+  if (_isSwapArea(fs, mount)) return false;
 
   if (fs.startsWith('/dev')) return true;
   // Some NAS may have mounted path like this `//192.168.1.2/`
   if (fs.startsWith('//')) return true;
   if (mount.startsWith('/mnt')) return true;
 
+  // `overlay` covers the old `overlayfs` spelling too, but not the
+  // `fuse-overlayfs` a rootless podman or docker uses: that one publishes a
+  // row per container carrying the host filesystem's own numbers.
   if (fs.startsWith('shm') ||
       fs.startsWith('overlay') ||
+      fs == 'fuse-overlayfs' ||
       fs.startsWith('tmpfs') ||
       fs.startsWith('devtmpfs')) {
     return false;
@@ -209,6 +227,36 @@ bool _shouldCalc(String fs, String mount) {
 
   return true;
 }
+
+/// A read-only image mounted as a filesystem — a snap's squashfs, the same
+/// image handed to a container through `snapfuse`, a mounted ISO — rather than
+/// storage anyone manages. Each is full by construction, so it reports 100%
+/// and contributes its whole size to the total; a snap-heavy Ubuntu publishes
+/// twenty of them, which is the entire device list.
+///
+/// Matched on the image, never on `/dev/loop`: a loop device carrying a
+/// writable filesystem is storage someone mounted on purpose.
+///
+/// Mirrors `is_read_only_image` in `crates/sbm_parser/src/types.rs`, and takes
+/// the same overloaded first argument: a filesystem type where one is known, a
+/// source otherwise.
+bool _isReadOnlyImage(String fs, String mount) {
+  return const {
+        'squashfs',
+        'erofs',
+        'iso9660',
+        'snapfuse',
+        'fuse.snapfuse',
+      }.contains(fs) ||
+      mount.startsWith('/snap/') ||
+      mount.startsWith('/var/lib/snapd/snap/');
+}
+
+/// A swap area, which `lsblk` lists beside filesystems. It has no mount point
+/// and no `FSSIZE`, so the row reads `0 B / 0 B`, and swap is reported on its
+/// own from `/proc/meminfo` anyway. `df` lists only mounted filesystems and
+/// never produces one of these.
+bool _isSwapArea(String fs, String mount) => fs == 'swap' || mount == '[SWAP]';
 
 /// `/dev`, `/proc`, `/sys`, and anything mounted inside them.
 ///

--- a/lib/data/model/server/disk.dart
+++ b/lib/data/model/server/disk.dart
@@ -230,10 +230,16 @@ bool _shouldCalc(String fs, String mount) {
 /// own layers. `fuse-overlayfs` is what a rootless podman or docker mounts,
 /// one row per container carrying the host filesystem's own numbers.
 ///
+/// `ramfs` is systemd's credential mounts, one per unit that takes a
+/// credential. Most `df` builds report `-` for its usage, which fails to parse
+/// and drops the row before any of this; naming it here does not depend on
+/// that, since a build reporting `0%` instead leaves a row of 0 B.
+///
 /// Mirrors `is_virtual_fs` in `crates/sbm_parser/src/types.rs`.
 bool _isVirtualFs(String fs) => const {
   'shm',
   'tmpfs',
+  'ramfs',
   'devtmpfs',
   'overlay',
   'overlayfs',

--- a/lib/data/model/server/disk.dart
+++ b/lib/data/model/server/disk.dart
@@ -214,19 +214,31 @@ bool _shouldCalc(String fs, String mount) {
   if (fs.startsWith('//')) return true;
   if (mount.startsWith('/mnt')) return true;
 
-  // `overlay` covers the old `overlayfs` spelling too, but not the
-  // `fuse-overlayfs` a rootless podman or docker uses: that one publishes a
-  // row per container carrying the host filesystem's own numbers.
-  if (fs.startsWith('shm') ||
-      fs.startsWith('overlay') ||
-      fs == 'fuse-overlayfs' ||
-      fs.startsWith('tmpfs') ||
-      fs.startsWith('devtmpfs')) {
-    return false;
-  }
+  if (_isVirtualFs(fs)) return false;
 
   return true;
 }
+
+/// A kernel-backed filesystem with nothing stored behind it, by exact name.
+///
+/// Matched exactly rather than by prefix, because [fs] is a *source* under
+/// `df` and a source carries user-chosen text: a ZFS pool named `tmpfspool`,
+/// or an export from an NFS host named `shm-nas`, each begin with one of these
+/// and each is storage.
+///
+/// `overlay` and `overlayfs` are the current and pre-4.0 spellings of docker's
+/// own layers. `fuse-overlayfs` is what a rootless podman or docker mounts,
+/// one row per container carrying the host filesystem's own numbers.
+///
+/// Mirrors `is_virtual_fs` in `crates/sbm_parser/src/types.rs`.
+bool _isVirtualFs(String fs) => const {
+  'shm',
+  'tmpfs',
+  'devtmpfs',
+  'overlay',
+  'overlayfs',
+  'fuse-overlayfs',
+}.contains(fs);
 
 /// A read-only image mounted as a filesystem — a snap's squashfs, the same
 /// image handed to a container through `snapfuse`, a mounted ISO — rather than

--- a/lib/data/model/server/monitor_metrics_mapper.dart
+++ b/lib/data/model/server/monitor_metrics_mapper.dart
@@ -193,6 +193,8 @@ void _applyDisks(ServerStatus ss, MonitorMetrics m) {
             avail: BigInt.from(_toKib(d.total - d.used)),
           ),
         )
+        // An agent older than a given parser rule still sends what it removes
+        .where((d) => d.isStorage)
         .toList();
   }
   try {

--- a/test/disk_test.dart
+++ b/test/disk_test.dart
@@ -57,5 +57,77 @@ void main() {
       // This would use the "unknown" fallback for kname
     });
 
+    // The parser drops all of these; a Disk that reached the app another way —
+    // a monitor agent older than the rule — must not reach the total either
+    Disk full(String path, String fsTyp, String mount, int size) => Disk(
+      path: path,
+      fsTyp: fsTyp,
+      mount: mount,
+      usedPercent: 100,
+      used: BigInt.from(size),
+      size: BigInt.from(size),
+      avail: BigInt.zero,
+    );
+
+    final root = Disk(
+      path: '/dev/vda1',
+      fsTyp: 'ext4',
+      mount: '/',
+      usedPercent: 25,
+      used: BigInt.from(12057216),
+      size: BigInt.from(51343636),
+      avail: BigInt.from(36648004),
+    );
+
+    void expectOnlyRoot(List<Disk> disks) {
+      final usage = DiskUsage.parse([root, ...disks]);
+      expect(usage.used, BigInt.from(12057216));
+      expect(usage.size, BigInt.from(51343636));
+    }
+
+    test('DiskUsage skips read-only images', () {
+      expectOnlyRoot([
+        full('/dev/loop0', 'squashfs', '/snap/copilot-cli/57', 296960),
+        full('snapfuse', 'fuse.snapfuse', '/snap/lxd/31333', 129024),
+        full('/dev/loop6', '', '/var/lib/snapd/snap/core24/1587', 66944),
+        full('/dev/sr0', 'iso9660', '/media/cdrom', 4718592),
+      ]);
+    });
+
+    test('DiskUsage skips swap areas', () {
+      expectOnlyRoot([
+        full('/dev/vda2', 'swap', '[SWAP]', 0),
+        full('/dev/zram0', 'swap', '[SWAP]', 0),
+      ]);
+    });
+
+    test('DiskUsage skips container layers', () {
+      expectOnlyRoot([
+        full('overlay', '', '/var/lib/docker/overlay2/9c1f/merged', 51343636),
+        full(
+          'fuse-overlayfs',
+          '',
+          '/home/u/.local/share/containers/storage/overlay/7a2e/merged',
+          51343636,
+        ),
+      ]);
+    });
+
+    test('DiskUsage keeps a loop device carrying a writable filesystem', () {
+      final usage = DiskUsage.parse([
+        Disk(
+          path: '/dev/loop7',
+          fsTyp: 'ext4',
+          mount: '/mnt/image',
+          usedPercent: 50,
+          used: BigInt.from(515072),
+          size: BigInt.from(1032256),
+          avail: BigInt.from(517184),
+        ),
+      ]);
+
+      expect(usage.used, BigInt.from(515072));
+      expect(usage.size, BigInt.from(1032256));
+    });
   });
 }

--- a/test/disk_test.dart
+++ b/test/disk_test.dart
@@ -113,6 +113,32 @@ void main() {
       ]);
     });
 
+    test('DiskUsage keeps storage named like a virtual filesystem', () {
+      // A source carries user-chosen text. Excluding the virtual filesystems
+      // by prefix took every one of these with them.
+      Disk storage(String path, String mount) => Disk(
+        path: path,
+        mount: mount,
+        usedPercent: 2,
+        used: BigInt.from(12345678),
+        size: BigInt.from(961873408),
+        avail: BigInt.from(949527730),
+      );
+
+      final disks = [
+        storage('tmpfspool/data', '/srv/pool'),
+        storage('shm-nas:/vol1', '/srv/nfs'),
+        storage('overlay-01:/export', '/srv/export'),
+        storage('devtmpfs-backup:/snapshots', '/srv/backup'),
+      ];
+      for (final disk in disks) {
+        expect(disk.isStorage, isTrue, reason: disk.path);
+      }
+
+      final usage = DiskUsage.parse(disks);
+      expect(usage.size, BigInt.from(961873408) * BigInt.from(4));
+    });
+
     test('DiskUsage keeps a loop device carrying a writable filesystem', () {
       final usage = DiskUsage.parse([
         Disk(

--- a/test/monitor_metrics_test.dart
+++ b/test/monitor_metrics_test.dart
@@ -199,6 +199,47 @@ void main() {
       expect(status.disk.single.usedPercent, 25);
     });
 
+    test('and its snap images are dropped from the detail list', () {
+      // The parser drops these now, but an agent older than that change keeps
+      // sending one row per installed snap revision.
+      final status = applyMonitorMetrics(
+        InitStatus.status,
+        MonitorMetrics.fromJson(
+          legacyBody({
+            'disk_details': const [
+              {
+                'path': '/dev/vda1',
+                'mount': '/',
+                'fs_type': 'ext4',
+                'used': 1024,
+                'total': 4096,
+                'usage_percent': 25.0,
+              },
+              {
+                'path': '/dev/loop0',
+                'mount': '/snap/copilot-cli/57',
+                'fs_type': 'squashfs',
+                'used': 304087040,
+                'total': 304087040,
+                'usage_percent': 100.0,
+              },
+              {
+                'path': 'snapfuse',
+                'mount': '/snap/lxd/31333',
+                'used': 132120576,
+                'total': 132120576,
+                'usage_percent': 100.0,
+              },
+            ],
+          }),
+        ),
+      );
+
+      expect(status.disk.length, 1);
+      expect(status.disk.single.path, '/dev/vda1');
+      expect(status.diskUsage?.size, BigInt.from(4));
+    });
+
     test('and aggregate network data replaces stale temperature detail', () {
       final status = InitStatus.status;
       status.temps.setAll({'old': 99});


### PR DESCRIPTION
Reported with a screenshot: a server's **Devices** list was eight `/dev/loopN (/snap/...)` rows at 100% before the machine's actual disks appeared.

## What was wrong

A snap-heavy Ubuntu mounts one squashfs per installed revision. Each is full by construction, so besides filling the list, every one added its whole size to the disk total — the reported machine was off by more than a gigabyte of phantom "used".

Two more classes turned up while checking what else survives the filter. I fed constructed `df` and `lsblk` output through the parser rather than guessing:

| Class | Behaviour | Path |
|---|---|---|
| Read-only images | snap squashfs, `snapfuse`, mounted ISO — 100% full, counted in the total | `lsblk` and `df` |
| Swap areas | `lsblk` lists them beside filesystems with an empty `FSSIZE`, rendering as `0 B / 0 B` | `lsblk` |
| `fuse-overlayfs` | rootless podman/docker publishes a row per container carrying the host filesystem's own numbers | `df` fallback |

## The rules

`disk_should_calc` (`crates/sbm_parser/src/types.rs`) excludes all three before deciding, alongside the existing kernel-mount check.

Read-only images are matched **on the image, never on `/dev/loop`**. A loop device carrying a writable filesystem is storage someone mounted on purpose, and the `df` fallback hosts — busybox, OpenWrt, no `lsblk` — are exactly where that is most likely. `/dev/loop7 → /mnt/image` with ext4 stays visible, and there is a test for it.

Swap already has its own reading from `/proc/meminfo`, so the block-device row was duplicate information with a broken number.

Container layers are matched by exact filesystem name — `overlay`, `overlayfs`, `fuse-overlayfs`. The first two are docker's own layers in their current and pre-4.0 spellings; the third is what a rootless podman or docker mounts.

These were prefix matches until review (`overlay` covering `overlayfs` for free). A `df` source is user-chosen text, so a prefix reached too far: a ZFS pool named `tmpfspool`, or an export from an NFS host named `shm-nas`, each begin with one of these names and each is storage. See the second commit.

## Dart side

The parser drops these while reading `lsblk`/`df`, but a `Disk` built from a monitor agent's `disk_details` never went through it — an agent older than a given rule still sends what that rule removes. So the rules are mirrored in `lib/data/model/server/disk.dart` and applied in `monitor_metrics_mapper.dart`.

The call sites now ask one thing, `Disk.isStorage`, which runs `_shouldCalc` against both the source and the filesystem type. The parser is handed one or the other and branches differently for each; a parsed `Disk` carries both.

## Known limit

`df -k` reports no filesystem type, so a mounted ISO reads as an ordinary `/dev/sr0` there and is not dropped. It *is* dropped under `lsblk`, which is every host that has an optical drive; `df` is the fallback for busybox and OpenWrt. Recognising `/dev/sr` by name would trade a rule about images for a list of device names, so `disk_parse_df_drops_read_only_images` records the behaviour with a positive assertion instead — if someone changes it, that test says so.

## Checked and deliberately not changed

Verified by running the parser, so these need no rule:

- `ramfs` (systemd credential mounts), `nsfs`, `gvfsd-fuse` — `df` reports `-` for usage, which fails to parse and drops the row already. Confirmed both spellings of systemd's credential mount on an orbstack NixOS machine (tmpfs there) and against the ramfs form.
- docker bind volumes, btrfs subvolumes — same source and same numbers, already collapsed by `parse_df`'s dedup.
- cgroup2, efivarfs, binfmt_misc, hugetlbfs, mqueue, pstore, bpf — all mounted under `/sys`, `/proc` or `/dev`.

Left visible on purpose: `/boot` and `/boot/efi`, LVM and `/dev/mapper/*`, NFS/CIFS/SSHFS, everything under `/mnt`.

Not done, as agreed: ZFS snapshot auto-mounts (`/.zfs/snapshot/`) need `snapdir=visible` to appear at all, and flatpak's `portal` is desktop-only.

## Tests

`crates/sbm_parser/tests/fixtures/lsblk.json` came off a real machine and carries that machine's swap partition — `disk_parse_lsblk_json` had been asserting 6 entries with swap as one of them. It is 5 now, which is the clearest evidence this was not a constructed problem.

Four new parser tests over two new fixtures (`lsblk_nonstorage.json`, `df_nonstorage.txt`), plus three `DiskUsage` cases and one mapper case on the Dart side.

- `cargo test -p sbm_parser` — 88 + 45 pass
- `cargo check --workspace --all-targets` — clean
- `flutter test test/disk_test.dart test/monitor_metrics_test.dart test/server_status_update_req_test.dart` — pass
- `flutter analyze` on the touched files — clean

## Note for reviewers

The filter is in Rust, so a hot reload will not pick it up — this needs an app rebuild to see.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disk usage reporting by excluding non-storage entries such as read-only images, swap areas, snap mounts, container overlays, kernel mounts, ramfs, and other virtual filesystems.
  * Preserved writable loop-backed filesystems and storage sources whose names resemble virtual filesystem prefixes.
  * Ensured disk details and aggregate usage remain accurate when legacy payloads include image-based mounts.

* **Tests**
  * Added coverage for non-storage filtering and accurate disk usage totals across supported filesystem types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
