### PR TITLE
fix: classify disk sources independently from filesystem types

### DIFF
--- a/crates/sbm_parser/src/linux.rs
+++ b/crates/sbm_parser/src/linux.rs
@@ -103,7 +103,7 @@ fn parse_lsblk(json: &serde_json::Value) -> Vec<Disk> {
         let children = device["children"].as_array().map(Vec::as_slice).unwrap_or(&[]);
         let (size, used, avail, _) = lsblk_fs_fields(device);
         let has_stats = size != 0 || used != 0 || avail != 0;
-        let has_own_fs = fstype.is_some_and(|fs| disk_should_calc(fs, mount));
+        let has_own_fs = fstype.is_some_and(|fs| disk_type_should_calc(fs, mount));
 
         // Container devices without their own filesystem: only expand children
         if !has_stats && !has_own_fs && !children.is_empty() {
@@ -143,7 +143,7 @@ fn lsblk_device(device: &serde_json::Value) -> Option<Disk> {
         .filter_map(lsblk_device)
         .collect();
 
-    if fstype.is_some_and(|fs| disk_should_calc(fs, mount)) || !children.is_empty() {
+    if fstype.is_some_and(|fs| disk_type_should_calc(fs, mount)) || !children.is_empty() {
         Some(lsblk_build(device, children))
     } else {
         None
@@ -158,7 +158,7 @@ fn lsblk_single_device(device: &serde_json::Value) -> Option<Disk> {
     if path.is_empty() || (fstype.is_none() && mount.is_empty()) {
         return None;
     }
-    if !disk_should_calc(fstype.unwrap_or(""), mount) {
+    if !disk_type_should_calc(fstype.unwrap_or(""), mount) {
         return None;
     }
     Some(lsblk_build(device, Vec::new()))

--- a/crates/sbm_parser/src/types.rs
+++ b/crates/sbm_parser/src/types.rs
@@ -120,25 +120,38 @@ pub struct Disk {
     pub children: Vec<Disk>,
 }
 
-/// Whether a `df` row describes storage worth reporting (Dart `_shouldCalc`):
-/// exclude kernel mounts, read-only images and swap areas; include /dev-prefixed
-/// sources, network mounts (//), /mnt mount points; exclude the virtual
-/// filesystems [`is_virtual_fs`] names; include the rest
+/// Whether a `df` source describes storage worth reporting (Dart
+/// `_shouldCalcSource`): exclude kernel mounts, snap mount points and swap
+/// mounts; include /dev-prefixed sources, network mounts (//), /mnt mount
+/// points; exclude the virtual filesystems [`is_virtual_fs`] names; include the
+/// rest.
 ///
-/// Takes one of a row's two identifiers, whichever the caller has. Prefer
-/// [`Disk::is_storage`] where both are available.
-pub fn disk_should_calc(fs: &str, mount: &str) -> bool {
+/// A source carries user-chosen text, so filesystem-type-only rules must not be
+/// applied here. Use [`disk_type_should_calc`] for an `lsblk` filesystem type,
+/// or [`Disk::is_storage`] where both identifiers are available.
+pub fn disk_should_calc(source: &str, mount: &str) -> bool {
     // Checked before the inclusions below, so that a source spelled like a
     // block device cannot bring these back: a host that exposes many device
     // nodes publishes one devtmpfs row per node, two dozen lines all claiming
     // 0 B used of the same size.
-    if is_kernel_mount(mount) || is_read_only_image(fs, mount) || is_swap_area(fs, mount) {
+    if is_kernel_mount(mount) || is_read_only_image_mount(mount) || is_swap_mount(mount) {
         return false;
     }
-    if fs.starts_with("/dev") || fs.starts_with("//") || mount.starts_with("/mnt") {
+    if source.starts_with("/dev") || source.starts_with("//") || mount.starts_with("/mnt") {
         return true;
     }
-    !is_virtual_fs(fs)
+    !is_virtual_fs(source)
+}
+
+/// Whether an `lsblk` filesystem type describes storage worth reporting.
+///
+/// Type-only exclusions live here so a `df` source that happens to be named
+/// `squashfs`, `iso9660` or `swap` remains ordinary user-managed storage.
+pub(crate) fn disk_type_should_calc(fs_type: &str, mount: &str) -> bool {
+    if is_read_only_image_type(fs_type) || fs_type == "swap" {
+        return false;
+    }
+    disk_should_calc(fs_type, mount)
 }
 
 /// A kernel-backed filesystem with nothing stored behind it, by exact name.
@@ -172,22 +185,23 @@ fn is_virtual_fs(fs: &str) -> bool {
 /// Matched on the image, never on `/dev/loop`: a loop device carrying a
 /// writable filesystem is storage someone mounted on purpose, and it is the
 /// `df` fallback hosts (busybox, no lsblk) where that is most likely.
-/// `fs` is a filesystem type under `lsblk` and a source under `df`, so the
-/// two sources are recognised by different halves of this.
-fn is_read_only_image(fs: &str, mount: &str) -> bool {
+fn is_read_only_image_type(fs_type: &str) -> bool {
     matches!(
-        fs,
+        fs_type,
         "squashfs" | "erofs" | "iso9660" | "snapfuse" | "fuse.snapfuse"
-    ) || mount.starts_with("/snap/")
-        || mount.starts_with("/var/lib/snapd/snap/")
+    )
+}
+
+fn is_read_only_image_mount(mount: &str) -> bool {
+    mount.starts_with("/snap/") || mount.starts_with("/var/lib/snapd/snap/")
 }
 
 /// A swap area, which `lsblk` lists beside filesystems. It has no mount point
 /// and no `FSSIZE`, so the row reads `0 B / 0 B`, and swap is reported on its
 /// own from `/proc/meminfo` anyway. `df` lists only mounted filesystems and
 /// never produces one of these.
-fn is_swap_area(fs: &str, mount: &str) -> bool {
-    fs == "swap" || mount == "[SWAP]"
+fn is_swap_mount(mount: &str) -> bool {
+    mount == "[SWAP]"
 }
 
 impl Disk {
@@ -195,14 +209,16 @@ impl Disk {
     /// mount, a read-only image, a container layer or a swap area
     /// (Dart `Disk.isStorage`).
     ///
-    /// [`disk_should_calc`] is handed a source by `df` and a filesystem type
-    /// by `lsblk`, never both, and takes a different branch for each. A [`Disk`]
-    /// carries both, so it is asked with each — otherwise a row identified only
-    /// by its type, such as a squashfs whose mount point is not under `/snap`,
-    /// or a swap area whose mount is empty rather than `[SWAP]`, is missed.
+    /// A [`Disk`] carries both a source and, where known, a filesystem type, so
+    /// each is classified in its own context. Otherwise a `df` source named
+    /// `squashfs` is mistaken for that type, while a squashfs whose mount point
+    /// is not under `/snap` is missed if only the source is checked.
     pub fn is_storage(&self) -> bool {
         disk_should_calc(&self.path, &self.mount)
-            && disk_should_calc(self.fs_type.as_deref().unwrap_or(&self.path), &self.mount)
+            && self
+                .fs_type
+                .as_deref()
+                .is_none_or(|fs_type| disk_type_should_calc(fs_type, &self.mount))
     }
 }
 

--- a/crates/sbm_parser/tests/dart_compat.rs
+++ b/crates/sbm_parser/tests/dart_compat.rs
@@ -468,6 +468,31 @@ fn disk_parse_df_keeps_storage_named_like_a_virtual_fs() {
     assert_eq!(mounts, ["/srv/pool", "/srv/nfs", "/srv/export", "/srv/backup"]);
 }
 
+/// The first `df` column is a user-controlled source, not a filesystem type.
+/// Type-only exclusions must not silently remove a ZFS root dataset or FUSE
+/// source that happens to use one of those exact names.
+#[test]
+fn disk_parse_df_keeps_sources_named_like_filesystem_types() {
+    let raw = "Filesystem 1K-blocks Used Available Use% Mounted on\n\
+        squashfs 961873408 12345678 949527730 2% /srv/squashfs\n\
+        erofs 961873408 12345678 949527730 2% /srv/erofs\n\
+        iso9660 961873408 12345678 949527730 2% /srv/iso9660\n\
+        snapfuse 961873408 12345678 949527730 2% /srv/snapfuse\n\
+        fuse.snapfuse 961873408 12345678 949527730 2% /srv/fuse-snapfuse\n\
+        swap 961873408 12345678 949527730 2% /srv/swap\n";
+    let disks = linux::parse_disk(raw);
+
+    let paths: Vec<&str> = disks.iter().map(|d| d.path.as_str()).collect();
+    assert_eq!(
+        paths,
+        ["squashfs", "erofs", "iso9660", "snapfuse", "fuse.snapfuse", "swap"]
+    );
+
+    let (used, size) = disk_usage(&disks);
+    assert_eq!(used, 12345678 * 6);
+    assert_eq!(size, 961873408 * 6);
+}
+
 /// `disk_usage` is the Rust side of `DiskUsage.parse`, and takes a [`Disk`]
 /// that carries both a source and a filesystem type where the parser is handed
 /// one or the other. Asking with the path alone missed a row identified only by

--- a/lib/data/model/server/disk.dart
+++ b/lib/data/model/server/disk.dart
@@ -48,11 +48,13 @@ class Disk extends Equatable {
   /// a monitor agent's `disk_details` never went through it, so an agent older
   /// than a given rule still sends what that rule removes.
   ///
-  /// [_shouldCalc] is handed a source by `df` and a filesystem type by `lsblk`,
-  /// never both, and takes a different branch for each. A [Disk] carries both,
-  /// so it is asked with each.
+  /// A [Disk] carries both a source and, where known, a filesystem type, so each
+  /// is classified in its own context. Otherwise a `df` source named
+  /// `squashfs` is mistaken for that type, while a squashfs whose mount point
+  /// is not under `/snap` is missed if only the source is checked.
   bool get isStorage =>
-      _shouldCalc(path, mount) && _shouldCalc(fsTyp ?? path, mount);
+      _shouldCalcSource(path, mount) &&
+      (fsTyp == null || _shouldCalcType(fsTyp!, mount));
 
   @override
   List<Object?> get props => [
@@ -200,23 +202,28 @@ class DiskUsage {
   }
 }
 
-bool _shouldCalc(String fs, String mount) {
+bool _shouldCalcSource(String source, String mount) {
   // Checked before the inclusions below, so that a source spelled like a block
   // device cannot bring these back: a host that exposes many device nodes
   // publishes one devtmpfs row per node, two dozen lines all claiming 0 B used
   // of the same size.
   if (_isKernelMount(mount)) return false;
-  if (_isReadOnlyImage(fs, mount)) return false;
-  if (_isSwapArea(fs, mount)) return false;
+  if (_isReadOnlyImageMount(mount)) return false;
+  if (_isSwapMount(mount)) return false;
 
-  if (fs.startsWith('/dev')) return true;
+  if (source.startsWith('/dev')) return true;
   // Some NAS may have mounted path like this `//192.168.1.2/`
-  if (fs.startsWith('//')) return true;
+  if (source.startsWith('//')) return true;
   if (mount.startsWith('/mnt')) return true;
 
-  if (_isVirtualFs(fs)) return false;
+  if (_isVirtualFs(source)) return false;
 
   return true;
+}
+
+bool _shouldCalcType(String fsType, String mount) {
+  if (_isReadOnlyImageType(fsType) || fsType == 'swap') return false;
+  return _shouldCalcSource(fsType, mount);
 }
 
 /// A kernel-backed filesystem with nothing stored behind it, by exact name.
@@ -255,26 +262,23 @@ bool _isVirtualFs(String fs) => const {
 /// Matched on the image, never on `/dev/loop`: a loop device carrying a
 /// writable filesystem is storage someone mounted on purpose.
 ///
-/// Mirrors `is_read_only_image` in `crates/sbm_parser/src/types.rs`, and takes
-/// the same overloaded first argument: a filesystem type where one is known, a
-/// source otherwise.
-bool _isReadOnlyImage(String fs, String mount) {
-  return const {
-        'squashfs',
-        'erofs',
-        'iso9660',
-        'snapfuse',
-        'fuse.snapfuse',
-      }.contains(fs) ||
-      mount.startsWith('/snap/') ||
-      mount.startsWith('/var/lib/snapd/snap/');
-}
+/// Mirrors `is_read_only_image_type` in `crates/sbm_parser/src/types.rs`.
+bool _isReadOnlyImageType(String fsType) => const {
+  'squashfs',
+  'erofs',
+  'iso9660',
+  'snapfuse',
+  'fuse.snapfuse',
+}.contains(fsType);
+
+bool _isReadOnlyImageMount(String mount) =>
+    mount.startsWith('/snap/') || mount.startsWith('/var/lib/snapd/snap/');
 
 /// A swap area, which `lsblk` lists beside filesystems. It has no mount point
 /// and no `FSSIZE`, so the row reads `0 B / 0 B`, and swap is reported on its
 /// own from `/proc/meminfo` anyway. `df` lists only mounted filesystems and
 /// never produces one of these.
-bool _isSwapArea(String fs, String mount) => fs == 'swap' || mount == '[SWAP]';
+bool _isSwapMount(String mount) => mount == '[SWAP]';
 
 /// `/dev`, `/proc`, `/sys`, and anything mounted inside them.
 ///

--- a/test/disk_test.dart
+++ b/test/disk_test.dart
@@ -139,6 +139,32 @@ void main() {
       expect(usage.size, BigInt.from(961873408) * BigInt.from(4));
     });
 
+    test('DiskUsage keeps sources named like filesystem types', () {
+      Disk storage(String path) => Disk(
+        path: path,
+        mount: '/srv/$path',
+        usedPercent: 2,
+        used: BigInt.from(12345678),
+        size: BigInt.from(961873408),
+        avail: BigInt.from(949527730),
+      );
+
+      final disks = const [
+        'squashfs',
+        'erofs',
+        'iso9660',
+        'snapfuse',
+        'fuse.snapfuse',
+        'swap',
+      ].map(storage).toList();
+      for (final disk in disks) {
+        expect(disk.isStorage, isTrue, reason: disk.path);
+      }
+
+      final usage = DiskUsage.parse(disks);
+      expect(usage.size, BigInt.from(961873408) * BigInt.from(disks.length));
+    });
+
     test('DiskUsage keeps a loop device carrying a writable filesystem', () {
       final usage = DiskUsage.parse([
         Disk(

--- a/test/monitor_metrics_test.dart
+++ b/test/monitor_metrics_test.dart
@@ -240,6 +240,29 @@ void main() {
       expect(status.diskUsage?.size, BigInt.from(4));
     });
 
+    test('and a source named like an excluded filesystem type is kept', () {
+      final status = applyMonitorMetrics(
+        InitStatus.status,
+        MonitorMetrics.fromJson(
+          legacyBody({
+            'disk_details': const [
+              {
+                'path': 'squashfs',
+                'mount': '/srv/archive',
+                'used': 2048,
+                'total': 8192,
+                'usage_percent': 25.0,
+              },
+            ],
+          }),
+        ),
+      );
+
+      expect(status.disk.single.path, 'squashfs');
+      expect(status.diskUsage?.used, BigInt.from(2));
+      expect(status.diskUsage?.size, BigInt.from(8));
+    });
+
     test('and aggregate network data replaces stale temperature detail', () {
       final status = InitStatus.status;
       status.temps.setAll({'old': 99});


### PR DESCRIPTION
## Summary

- Separate source-based and filesystem-type-based disk filtering.
- Preserve valid storage whose source is named like an excluded filesystem type.
- Keep read-only image and swap exclusions for `lsblk` filesystem types.
- Add Rust and Dart regression coverage for affected disk parsing and metrics paths.

## Testing

- Added regression tests covering `df` sources named `squashfs`, `erofs`, `iso9660`, `snapfuse`, `fuse.snapfuse`, and `swap`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected disk classification so storage sources with names resembling filesystem types (such as `squashfs`, `swap`, or `iso9660`) are retained correctly.
  - Improved handling of read-only image filesystems, virtual filesystems, and swap devices.
  - Ensured disk usage totals and monitor details include valid storage entries consistently.

- **Tests**
  - Added regression coverage for Linux disk parsing, aggregate usage calculations, and monitor disk metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->