### PR TITLE
opt.: cut the monitor binary by a third

### DIFF
--- a/.github/workflows/monitor-release.yml
+++ b/.github/workflows/monitor-release.yml
@@ -141,9 +141,13 @@ jobs:
         with:
           key: ${{ matrix.target }}
 
+      # `release-monitor`, not `release`: fat LTO and one codegen unit, which
+      # are profile-wide settings and so cannot be asked for on the shared
+      # profile without slowing every app build. Defined in the workspace
+      # Cargo.toml, which says what it costs and what it buys.
       - name: Build
         shell: bash
-        run: cargo build -p server_box_monitor --release --target ${{ matrix.target }}
+        run: cargo build -p server_box_monitor --profile release-monitor --target ${{ matrix.target }}
 
       - name: Download frontend dist
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -162,7 +166,7 @@ jobs:
 
           staging="${BIN_NAME}"
           mkdir -p "$staging"
-          cp "target/${{ matrix.target }}/release/${bin}${ext}" "$staging/"
+          cp "target/${{ matrix.target }}/release-monitor/${bin}${ext}" "$staging/"
           mkdir -p "$staging/frontend"
           cp -r monitor/frontend/dist "$staging/frontend/dist"
           cp -r monitor/migrations "$staging/migrations"
@@ -207,7 +211,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: monitor-bin-linux-${{ matrix.arch }}
-          path: target/${{ matrix.target }}/release/server_box_monitor
+          path: target/${{ matrix.target }}/release-monitor/server_box_monitor
           if-no-files-found: error
           retention-days: 3
 

--- a/.github/workflows/monitor-release.yml
+++ b/.github/workflows/monitor-release.yml
@@ -329,10 +329,6 @@ jobs:
           # the fenced blocks below are allowed to carry their own line breaks,
           # where they are the commands' own.
           body: |
-            The **ServerBox Monitor** agent, versioned independently of the app — see `monitor/README.md` for what it does and `config.example.toml` in the archive for how it is configured.
-
-            ### Docker
-
             ```sh
             docker run -d --name server-box-monitor \
               -p 3770:3770 -v ./data:/data \
@@ -340,12 +336,6 @@ jobs:
             ```
 
             Also tagged `latest`. `linux/amd64` and `linux/arm64`.
-
-            ### Native
-
-            Pick the archive for the machine being monitored and unpack it. Linux builds are static musl binaries, so they run on Alpine as they are. Each archive carries the binary, the web panel, the migrations and an example config.
-
-            Verify what you downloaded against `SHA256SUMS`:
 
             ```sh
             sha256sum -c SHA256SUMS --ignore-missing

--- a/.github/workflows/monitor-release.yml
+++ b/.github/workflows/monitor-release.yml
@@ -322,10 +322,14 @@ jobs:
           # took it, so anyone opening /releases/latest was handed the agent
           # rather than ServerBox.
           make_latest: false
+          # One line per paragraph, however long. GitHub renders release notes
+          # with hard line breaks on, so a paragraph wrapped at 72 columns here
+          # is wrapped at 72 columns on a page as wide as the window — v0.1.2
+          # shipped a column of short lines down the left of the screen. Only
+          # the fenced blocks below are allowed to carry their own line breaks,
+          # where they are the commands' own.
           body: |
-            The **ServerBox Monitor** agent, versioned independently of the
-            app — see `monitor/README.md` for what it does and
-            `config.example.toml` in the archive for how it is configured.
+            The **ServerBox Monitor** agent, versioned independently of the app — see `monitor/README.md` for what it does and `config.example.toml` in the archive for how it is configured.
 
             ### Docker
 
@@ -339,10 +343,7 @@ jobs:
 
             ### Native
 
-            Pick the archive for the machine being monitored and unpack it.
-            Linux builds are static musl binaries, so they run on Alpine as
-            they are. Each archive carries the binary, the web panel, the
-            migrations and an example config.
+            Pick the archive for the machine being monitored and unpack it. Linux builds are static musl binaries, so they run on Alpine as they are. Each archive carries the binary, the web panel, the migrations and an example config.
 
             Verify what you downloaded against `SHA256SUMS`:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,29 +252,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "pkg-config",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,8 +437,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -561,15 +536,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "cmov"
@@ -1036,12 +1002,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1419,12 +1379,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
 name = "futures"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,10 +1512,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2081,16 +2033,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
-dependencies = [
- "getrandom 0.4.3",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2207,12 +2149,6 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -3216,63 +3152,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
-dependencies = [
- "bytes",
- "cfg_aliases 0.2.2",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.20",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
-dependencies = [
- "aws-lc-rs",
- "bytes",
- "getrandom 0.4.3",
- "lru-slab",
- "rand 0.10.2",
- "rand_pcg",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.20",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
-dependencies = [
- "cfg_aliases 0.2.2",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3335,15 +3214,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
-name = "rand_pcg"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
-dependencies = [
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3404,7 +3274,6 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -3630,12 +3499,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3663,7 +3526,6 @@ version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -3700,7 +3562,6 @@ version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -3737,7 +3598,6 @@ version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -5123,16 +4983,6 @@ name = "web-sys"
 version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,26 @@ strip = true
 # cargo cannot vary `strip` per target.
 [profile.release.package.sbm_ffi]
 strip = false
+
+# The agent's own release profile, used by `monitor-release.yml` and by
+# `monitor/Dockerfile`, and by nothing the app builds.
+#
+# `lto` and `codegen-units` are profile-wide — `[profile.release.package.*]`
+# accepts neither — so setting them above would put a fat-LTO link in front of
+# every app build, for a binary no app ships. Here they cost only the agent's
+# release, which is built by hand a few times a release. Measured on the
+# agent: 20.1 MB → 15.2 MB, at +1 minute.
+#
+# `opt-level` is deliberately left at the inherited 3. `"s"` takes it to
+# 11.2 MB, and this is the process that samples the machine and terminates
+# every TLS connection to it; that trade is not one a build profile should
+# make silently.
+#
+# `monitor/Dockerfile` builds the crate *outside* this workspace — it rewrites
+# the `sbm_parser` path so `monitor/Cargo.toml` becomes the root — so nothing
+# in this file reaches it, `[profile.release]` above included. It passes the
+# same settings as `CARGO_PROFILE_RELEASE_*` and says so there.
+[profile.release-monitor]
+inherits = "release"
+lto = "fat"
+codegen-units = 1

--- a/monitor/CLAUDE.md
+++ b/monitor/CLAUDE.md
@@ -305,6 +305,41 @@ alone doesn't stop two handlers clobbering each other's fields.
 
 ## Release and Deployment
 
+### Build profile and binary size
+
+The shipped agent is built with `--profile release-monitor` (workspace
+`Cargo.toml`), which is `release` plus `lto = "fat"` and `codegen-units = 1`.
+Both are profile-wide — `[profile.release.package.*]` accepts neither — so
+they cannot be asked for on the shared profile without putting a fat-LTO link
+in front of every app build too.
+
+- **`monitor/Dockerfile` sees none of that.** It rewrites the `sbm_parser`
+  path so `monitor/Cargo.toml` becomes the root, which puts the build outside
+  the workspace and outside every `[profile]` in it, `strip` included. It
+  passes the same three settings as `CARGO_PROFILE_RELEASE_*`. Anything added
+  to a workspace profile has to be repeated there or it silently does not
+  apply to the image people build themselves.
+- **`nix/package.nix` builds inside the workspace** (`buildAndTestSubdir =
+  "monitor"`, source is the repository), so it does get `[profile.release]`
+  and its `strip`, but not `release-monitor`. Moving it there means
+  `cargoBuildType`, whose handling differs between nixpkgs releases and is
+  not verified here.
+- **`opt-level` stays at 3.** `"s"` takes the binary from 15.2 MB to 11.2 MB,
+  measured, and this process samples the machine and terminates every TLS
+  connection to it — worth having the number, not worth taking silently.
+- **One crypto implementation, `ring`.** `cargo tree -i aws-lc-sys` must find
+  nothing: aws-lc-sys is a second complete implementation and a cmake build
+  script in front of the musl targets. reqwest is the one that brings it in
+  by default (its `rustls` feature *is* `__rustls-aws-lc-rs`), so it uses
+  `rustls-no-provider` and `monitoring::push::http_client` installs the ring
+  provider before building the client. Without that install, building the
+  client panics inside reqwest rather than failing as a push error — held by
+  the four webhook tests in `monitoring::push`, which is also the only signal
+  that a newly added TLS dependency has brought its own provider back.
+
+Measured on macOS arm64, all with `strip`: 22.0 MB stock → 20.1 MB without
+aws-lc → 15.2 MB with the profile.
+
 ### Docker
 ```bash
 # Build with Docker

--- a/monitor/Cargo.toml
+++ b/monitor/Cargo.toml
@@ -55,22 +55,26 @@ getrandom = "0.4"
 rpassword = "7"
 
 # HTTP client for push notifications
-# rustls instead of native-tls: consistent with sqlx, static musl builds without OpenSSL
-reqwest = { version = "0.13", default-features = false, features = ["json", "rustls", "charset", "http2", "stream"] }
+# rustls instead of native-tls: consistent with sqlx, static musl builds without OpenSSL.
+#
+# `rustls-no-provider` and not `rustls`, which is defined as
+# `__rustls-aws-lc-rs` and pulls aws-lc-sys — a second, complete crypto
+# implementation beside the `ring` everything else here uses, and a cmake
+# build script in front of the musl targets. The provider it no longer brings
+# is installed once in `monitoring::push::http_client`; without that, building
+# the client panics inside reqwest rather than failing as a push error, which
+# `monitoring::push`'s webhook tests hold.
+reqwest = { version = "0.13", default-features = false, features = ["json", "rustls-no-provider", "charset", "http2", "stream"] }
 
 # SSH client for the browser terminal. `ring` rather than the default
 # aws-lc-rs, matching the backend rustls and jsonwebtoken are configured with,
 # so this adds no second crypto implementation of its own.
 #
-# NOTE: it does not follow that the build is free of aws-lc. `reqwest`'s
-# `rustls` feature is defined as `__rustls-aws-lc-rs`, so aws-lc-sys and its
-# cmake build script come in regardless of what the direct rustls dependency
-# asks for — the "no cmake for musl" intent above is currently not achieved.
-# Fixing it takes two steps, not one: switch reqwest to `rustls-no-provider`
-# *and* install a process-level provider at startup, since without that the
-# push client panics on its first HTTPS request (verified: it drops aws-lc and
-# cmake from the tree, and fails all five push tests until the provider is
-# installed). Left alone here as it belongs to the push path, not this one.
+# `ring` is now the only one in the tree — `cargo tree -i aws-lc-sys` finds
+# nothing. It was reqwest that brought the other, and that is fixed above; the
+# "no cmake for musl" intent these features are chosen for is achieved rather
+# than merely stated. Anything added here that wants TLS has to be configured
+# the same way, or it comes back.
 russh = { version = "0.63", default-features = false, features = ["ring", "flate2", "rsa"] }
 # Wipes SSH credentials from memory once they have been used
 zeroize = "1"

--- a/monitor/Dockerfile
+++ b/monitor/Dockerfile
@@ -34,8 +34,19 @@ COPY monitor/.sqlx/ ./.sqlx/
 COPY monitor/src/ ./src/
 
 # 独立构建 monitor(脱离 monorepo workspace),修正 sbm_parser 相对路径
+#
+# That also puts this build outside everything the workspace Cargo.toml says:
+# `monitor/Cargo.toml` becomes the root, so neither `[profile.release] strip`
+# nor the `release-monitor` profile exists here. Until these were added the
+# image carried an unstripped binary — the one build of this crate that did.
+# Environment variables rather than a profile section, since the section would
+# have to be written into a manifest the workspace also reads, where cargo
+# ignores a non-root package's profiles with a warning.
 RUN sed -i 's|path = "../crates/sbm_parser"|path = "crates/sbm_parser"|' Cargo.toml \
-    && cargo build --release
+    && CARGO_PROFILE_RELEASE_STRIP=true \
+       CARGO_PROFILE_RELEASE_LTO=fat \
+       CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1 \
+       cargo build --release
 
 # Final runtime stage(与 Dockerfile.ci 保持一致)
 FROM alpine:3.24

--- a/monitor/src/monitoring/push.rs
+++ b/monitor/src/monitoring/push.rs
@@ -17,6 +17,18 @@ const MAX_CONCURRENT_PUSHES: usize = 4;
 fn http_client() -> &'static Client {
     static CLIENT: OnceLock<Client> = OnceLock::new();
     CLIENT.get_or_init(|| {
+        // reqwest is built without a crypto provider of its own, so the one
+        // the rest of the agent uses has to be the process default before it
+        // builds a TLS config — otherwise the first HTTPS push panics inside
+        // rustls rather than failing as a push error. `ring`, matching the
+        // server side (`api/server.rs`) and russh; the alternative is pulling
+        // aws-lc-rs in beside it for this one client.
+        //
+        // `install_default` answers Err only when one is already installed,
+        // which is the correct outcome here and is what a second call in a
+        // test process does.
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
         Client::builder()
             .connect_timeout(CONNECT_TIMEOUT)
             .timeout(REQUEST_TIMEOUT)

--- a/test/yabs_script_test.dart
+++ b/test/yabs_script_test.dart
@@ -47,7 +47,21 @@ void main() {
   });
 
   tearDown(() async {
-    if (tmp.existsSync()) await tmp.delete(recursive: true);
+    if (!tmp.existsSync()) return;
+    // Retried, because a test that fails before it can wait for its run leaves
+    // a detached launcher writing in here, and the delete then fails too — with
+    // `Directory not empty`, which is the error that gets reported instead of
+    // the assertion that actually failed. The stand-in exits on its own, so
+    // this only has to outlast it.
+    for (var attempt = 0; ; attempt++) {
+      try {
+        await tmp.delete(recursive: true);
+        return;
+      } on FileSystemException {
+        if (attempt >= 20) rethrow;
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+      }
+    }
   });
 
   /// A stand-in for yabs: records the arguments it was given, prints something
@@ -76,13 +90,16 @@ exit $exitCode
     expect(res.stdout, contains(YabsScript.scriptInstalled));
   }
 
-  Future<void> runToCompletion(YabsOptions options) async {
-    final start = await sh(
-      YabsScript.startEntry(options, runId),
-      stdinText: YabsScript.launcher(options),
-    );
-    expect(start.stdout, contains(YabsScript.started), reason: start.stderr);
-
+  /// Polls until the detached launcher has reported an exit code.
+  ///
+  /// **Every test that starts a run has to reach this, or stop the run, before
+  /// it returns.** The launcher is under `setsid`, so it outlives the test body
+  /// that started it, and `tearDown` then deletes a directory a live process is
+  /// still writing into — which fails with `Directory not empty` rather than
+  /// with anything naming the test that left the process behind. That is how it
+  /// arrived: one CI run, one test, and nothing in the failure pointing at the
+  /// one place a run was started and not awaited.
+  Future<void> waitForRun(YabsOptions options) async {
     // The launcher is detached, so "started" says nothing about "finished".
     //
     // Bounded by the clock rather than by a poll count: each poll spawns a
@@ -115,6 +132,15 @@ exit $exitCode
       'last poll stdout: ${last?.stdout}\n'
       'last poll stderr: ${last?.stderr}',
     );
+  }
+
+  Future<void> runToCompletion(YabsOptions options) async {
+    final start = await sh(
+      YabsScript.startEntry(options, runId),
+      stdinText: YabsScript.launcher(options),
+    );
+    expect(start.stdout, contains(YabsScript.started), reason: start.stderr);
+    await waitForRun(options);
   }
 
   group('the script is installed where the commands look for it', () {
@@ -223,6 +249,10 @@ exit $exitCode
 
       expect(File('${tmp.path}/pwned').existsSync(), isFalse);
       expect(File('$work/.server_box_bench/run.sh').existsSync(), isTrue);
+
+      // What this test is about is settled above; this is about not leaving a
+      // process writing into the directory `tearDown` is about to delete.
+      await waitForRun(options);
     });
   });
 

--- a/test/yabs_script_test.dart
+++ b/test/yabs_script_test.dart
@@ -42,17 +42,50 @@ void main() {
     return ProcessResult(process.pid, await process.exitCode, out, err);
   }
 
+  /// Every run this test started, so `tearDown` can stop whatever is still
+  /// going. A launcher runs under `setsid`: it belongs to no process this one
+  /// waits on, and an assertion that fails before the test reaches
+  /// [waitForRun] — or, in the cancel test, before it asks for a stop — leaves
+  /// it running with nothing left in the test that knows about it.
+  final startedRuns = <YabsOptions>[];
+
+  Future<ProcessResult> startRun(YabsOptions options) async {
+    startedRuns.add(options);
+    return sh(
+      YabsScript.startEntry(options, runId),
+      stdinText: YabsScript.launcher(options),
+    );
+  }
+
   setUp(() async {
     tmp = await Directory.systemTemp.createTemp('yabs_script_test');
+    startedRuns.clear();
   });
 
   tearDown(() async {
     if (!tmp.existsSync()) return;
-    // Retried, because a test that fails before it can wait for its run leaves
-    // a detached launcher writing in here, and the delete then fails too — with
-    // `Directory not empty`, which is the error that gets reported instead of
-    // the assertion that actually failed. The stand-in exits on its own, so
-    // this only has to outlast it.
+
+    // Stop first, delete second. The stand-in the cancel test installs sleeps
+    // for a minute, so a failure before its `cancelCommand` would otherwise
+    // leave that process — and the two it spawns — running long after the
+    // suite has moved on.
+    //
+    // Asked before it is stopped, because `cancelCommand` sleeps two seconds
+    // between its TERM and its KILL. On the usual path every run here has
+    // already finished, and paying that per test turned a 5-second file into a
+    // 20-second one; a poll costs one more shell and answers.
+    for (final options in startedRuns) {
+      final dir = YabsScript.runDir(options);
+      final poll = YabsPollState.parse(
+        (await sh(YabsScript.pollCommand(dir))).stdout,
+      );
+      if (poll.alive) await sh(YabsScript.cancelCommand(dir));
+    }
+
+    // Retried anyway, because a stop is not instant and a launcher writing its
+    // exit code into a tree being deleted fails the delete with `Directory not
+    // empty` — which is then the error reported, in place of the assertion
+    // that actually failed.
     for (var attempt = 0; ; attempt++) {
       try {
         await tmp.delete(recursive: true);
@@ -135,10 +168,7 @@ exit $exitCode
   }
 
   Future<void> runToCompletion(YabsOptions options) async {
-    final start = await sh(
-      YabsScript.startEntry(options, runId),
-      stdinText: YabsScript.launcher(options),
-    );
+    final start = await startRun(options);
     expect(start.stdout, contains(YabsScript.started), reason: start.stderr);
     await waitForRun(options);
   }
@@ -242,17 +272,19 @@ exit $exitCode
       await Directory(work).create(recursive: true);
       final options = YabsOptions(workDir: work);
 
-      await sh(
-        YabsScript.startEntry(options, runId),
-        stdinText: YabsScript.launcher(options),
-      );
+      await startRun(options);
+
+      // Waited for before the assertion rather than after it. As the commands
+      // stand today the working directory only reaches the *synchronous* half
+      // of `startEntry` — `launcher` is generated without it and `cd`s to its
+      // own directory — so an injected `touch` would have run before that
+      // command returned, and asserting there would be enough. This order does
+      // not depend on that: it is what the assertion needs the moment any of
+      // it moves behind the `setsid`, and the wait was already happening.
+      await waitForRun(options);
 
       expect(File('${tmp.path}/pwned').existsSync(), isFalse);
       expect(File('$work/.server_box_bench/run.sh').existsSync(), isTrue);
-
-      // What this test is about is settled above; this is about not leaving a
-      // process writing into the directory `tearDown` is about to delete.
-      await waitForRun(options);
     });
   });
 
@@ -311,10 +343,7 @@ exit $exitCode
       expect(res.stdout, contains(YabsScript.scriptInstalled));
 
       const options = YabsOptions();
-      final start = await sh(
-        YabsScript.startEntry(options, runId),
-        stdinText: YabsScript.launcher(options),
-      );
+      final start = await startRun(options);
       expect(start.stdout, contains(YabsScript.started));
 
       // Wait for the launcher to record its pid before asking to stop it.


### PR DESCRIPTION
22.0 MB → 15.2 MB, measured on macOS arm64 with the workspace's existing `strip`. For reference, the `linux_amd64` archive published at v0.1.2 is 10.65 MB.

| Build | Binary |
|---|---|
| v0.1.2, as shipped | 21,983,232 B |
| without aws-lc | 20,099,360 B |
| `+ release-monitor` profile | 15,222,016 B |
| *(`opt-level = "s"`, not taken)* | *11,159,072 B* |

## Two crypto implementations were linked in

`cargo tree -i aws-lc-sys` found aws-lc-rs beside the `ring` that rustls, jsonwebtoken and russh are each configured with by hand. reqwest brought it: its `rustls` feature is defined as `__rustls-aws-lc-rs`, so the provider arrives whatever the direct rustls dependency asks for.

`monitor/Cargo.toml` has described this since it was written, including the fix — `rustls-no-provider` plus a process-level provider installed before the client is built. That is done here, in `push::http_client`, where the client is created.

Without the install, `Client::builder().build()` panics inside reqwest rather than failing as a push error. Verified by removing the line: the four webhook tests in `monitoring::push` panic at `reqwest-0.13.4/src/async_impl/client.rs:2484`. Those tests are what will catch a future TLS dependency bringing its own provider back.

−1.8 MB, and cmake leaves the musl build — the stated reason those features were chosen in the first place.

## `release-monitor`

`release` plus `lto = "fat"` and `codegen-units = 1`. Both are profile-wide — `[profile.release.package.*]` accepts neither — so asking for them on the shared profile would put a fat-LTO link in front of every app build, for a binary the app does not ship. `monitor-release.yml` is the only consumer.

−4.9 MB, at about +1 minute per target.

`opt-level = "s"` reaches 11.2 MB and is deliberately not taken: this process samples the machine and terminates every TLS connection to it. The number is recorded beside the profile so it stays a decision rather than an oversight.

## `monitor/Dockerfile` was shipping an unstripped binary

It rewrites the `sbm_parser` path, which makes `monitor/Cargo.toml` the root — so the build is outside the workspace and outside every `[profile]` in it, `strip` included. It now passes the same three settings as `CARGO_PROFILE_RELEASE_*`. A profile section in that manifest is not an option: cargo ignores a non-root package's profiles with a warning, and the workspace also reads that file.

`nix/package.nix` builds inside the workspace, so it keeps `strip` and does not get the new profile. Moving it needs `cargoBuildType`, whose handling differs between nixpkgs releases and is not verified here — noted in `monitor/CLAUDE.md` rather than guessed at.

## Verification

- `cargo test -p server_box_monitor` — 160 unit tests plus every integration test, all passing
- `cargo build -p server_box_monitor --profile release-monitor` — lands in `target/release-monitor/`, which is what the workflow's two path references now point at
- `cargo tree -i aws-lc-sys` — no match
- Not verified: an actual `monitor/Dockerfile` image build, and the musl numbers (the measurements above are macOS arm64)

The next `monitor-release.yml` run needs a version bump first; 0.1.2 is published and the workflow refuses an existing tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Monitor release builds now use dedicated optimization settings to produce smaller, more efficient artifacts.
  - Monitor packaging and container builds consistently use the optimized monitor build output.
  - Monitoring HTTPS requests now use the Ring cryptography provider for consistent TLS behavior.
  - GitHub Release notes focus on essential Docker, checksum, and platform information.
  - Test cleanup is more reliable when background benchmark processes temporarily hold files.

- **Documentation**
  - Added guidance on monitor build profiles, optimization settings, container behavior, TLS requirements, and expected binary sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Also here: the release notes were wrapped at 72 columns

GitHub renders release notes with hard line breaks on, so the paragraphs wrapped in the workflow's `body:` came out wrapped on the page too — [v0.1.2](https://github.com/lollipopkit/flutter_server_box/releases/tag/monitor-v0.1.2) published as a column of short lines down the left of a full-width screen.

One line per paragraph now, however long. The fenced blocks keep their own breaks, which are the commands'. v0.1.2's notes have been rewritten in place, so the fix is only for the next release.
