### PR TITLE
chore(deps): group Dependabot by toolchain rather than by directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,16 @@
 version: 2
+
+# One group per language, not per directory: `rust`, `flutter`, `web`. What a
+# review of a dependency bump needs is everything that moves together, and for
+# this repository that boundary is the toolchain — four npm directories are one
+# JavaScript upgrade, three of them linked to each other by `file:`.
+#
+# A group can only span the directories of a single `updates` entry, and an
+# entry is one ecosystem. So cargo, pub and npm are three entries and cannot be
+# fewer; `directories` is what lets the npm one cover all four at once.
 updates:
-  # Rust workspace (monitor + shared crates + FFI).
-  #
-  # The workspace root, not the member directories: Cargo.lock lives here and
-  # nowhere else, so a run scoped to a member can only widen that member's
+  # Rust: the workspace root, not the member directories. Cargo.lock lives here
+  # and nowhere else, so a run scoped to a member can only widen that member's
   # manifest and leaves the lock pinning the old version. It also covers every
   # member without listing them — sbm_native was a member for months that no
   # listing here ever named.
@@ -12,17 +19,7 @@ updates:
     schedule:
       interval: weekly
     groups:
-      rust-deps:
-        patterns:
-          - "*"
-
-  # monitor web frontend
-  - package-ecosystem: npm
-    directory: "/monitor/frontend"
-    schedule:
-      interval: weekly
-    groups:
-      frontend-deps:
+      rust:
         patterns:
           - "*"
 
@@ -31,46 +28,37 @@ updates:
     schedule:
       interval: weekly
     groups:
-      flutter-deps:
+      flutter:
         patterns:
           - "*"
 
-  # `/docs` and `/website` keep a `package-lock.json` for these two entries to
-  # work at all: Dependabot writes a manifest and its lockfile together, and a
+  # Every JavaScript directory in one entry, so a week's upgrade arrives as one
+  # PR rather than four. packages/webui belongs with them rather than on its
+  # own: monitor/frontend and website consume it as a `file:` dependency and
+  # build from its source, so a bump there is only reviewable next to them.
+  #
+  # Each of these keeps a `package-lock.json`, and that is what makes any of it
+  # work: Dependabot writes a manifest and its lockfile together, and a
   # `bun.lock` is not one it writes. With bun it bumped docs/package.json alone
   # and CI's frozen install refused every such PR — see the `docs` job in
   # analysis.yml.
   - package-ecosystem: npm
-    directory: "/docs"
+    directories:
+      - "/monitor/frontend"
+      - "/docs"
+      - "/website"
+      - "/packages/webui"
     schedule:
       interval: weekly
     groups:
-      docs-deps:
+      web:
         patterns:
           - "*"
 
-  - package-ecosystem: npm
-    directory: "/website"
-    schedule:
-      interval: weekly
-    groups:
-      website-deps:
-        patterns:
-          - "*"
-
-  - package-ecosystem: npm
-    directory: "/packages/webui"
-    schedule:
-      interval: weekly
-    groups:
-      webui-deps:
-        patterns:
-          - "*"
-
-  # Grouped like the other two: the actions in a workflow are bumped for one
-  # reason at a time (a runner's Node version, most of them), and a review that
-  # sees them together is the one that can tell. Ungrouped, a single week's run
-  # opened four PRs against the same two files.
+  # Its own group for the same reason as the three above: the actions in a
+  # workflow are bumped for one reason at a time (a runner's Node version, most
+  # of them), and a review that sees them together is the one that can tell.
+  # Ungrouped, a single week's run opened four PRs against the same two files.
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
Six groups named after directories become three named after what they are.

| before | after |
|---|---|
| `rust-deps` (cargo `/`) | `rust` (cargo `/`) |
| `flutter-deps` (pub `/`) | `flutter` (pub `/`) |
| `frontend-deps` (npm `/monitor/frontend`) | `web` (npm, all four directories) |
| `docs-deps` (npm `/docs`) | ″ |
| `website-deps` (npm `/website`) | ″ |
| `webui-deps` (npm `/packages/webui`) | ″ |
| `github-actions` | `github-actions` |

A week's JavaScript upgrade arrives as one PR instead of four. `packages/webui` belongs in there rather than on its own: `monitor/frontend` and `website` consume it as a `file:` dependency and build from its source, so a bump there was only ever reviewable next to its two consumers.

A group can only span the directories of a single `updates` entry, and an entry is one ecosystem — so cargo, pub and npm cannot be fewer than three entries. `directories` is what collapses the npm side.

Not changed by this: **security updates**. They come from Dependabot alerts, one PR per advisory, and ignore `groups` unless a second group is added with `applies-to: security-updates`. That is deliberate for now — a batched security PR is harder to bisect and one member that cannot be fixed stalls the rest.

Validated against SchemaStore's `dependabot-2.0.json`: 0 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update configuration to consolidate npm update checks into a shared weekly schedule.
  * Standardized Rust and Flutter dependency group names.
  * Expanded configuration comments describing dependency grouping and toolchain coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->