### PR TITLE
fix(website): take svelte past the three open advisories

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -19,7 +19,7 @@
         "@tailwindcss/vite": "^4.3.3",
         "clsx": "^2.1.1",
         "shadcn-svelte": "^1.6.0",
-        "svelte": "^5.55.5",
+        "svelte": "^5.57.0",
         "tailwind-merge": "^3.5.0",
         "tailwind-variants": "^3.2.2",
         "tailwindcss": "^4.2.4",
@@ -399,7 +399,9 @@
       "link": true
     },
     "node_modules/@sveltejs/acorn-typescript": {
-      "version": "1.0.9",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.13.tgz",
+      "integrity": "sha512-wgKggnhZVL9Bfx1OaKKTrYY9BFRk6C8UAkQNUcIv1+llzYrIqy+RZm5HPKzn0NpEBvTVhTqB4kQyllZywsRBRQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -791,13 +793,10 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/trusted-types": {
-      "version": "2.0.7",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/acorn": {
-      "version": "8.16.0",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -856,7 +855,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.7.1",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.9.2.tgz",
+      "integrity": "sha512-po4PAY5c53tw5XMocSnf8A/5OHhbbUftpr93aEN6BBoAdntUmK7vu7wOATqvt7cXO7m1Cl4gMVn6p7n6n4mj0w==",
       "dev": true,
       "license": "MIT"
     },
@@ -880,7 +881,9 @@
       "license": "MIT"
     },
     "node_modules/esrap": {
-      "version": "2.2.5",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.3.7.tgz",
+      "integrity": "sha512-n2nf7fZR3c9yXf0BPEuHuXqT+KW0SJVj4cN5FMEkpCZ3scLjOQWpiccyCxVzCC2q1wubTghuEGzngJY/7Ah0Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1382,22 +1385,23 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.55.5",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.57.0.tgz",
+      "integrity": "sha512-NdbDn7fl4be1ViUG0oq/lvG6OZy3oENolV2ONjiqqsfVoeAfzaQAKUcEX3MrQod/Bebv1PgwET9rfXhgn9s4Kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
         "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@sveltejs/acorn-typescript": "^1.0.5",
+        "@sveltejs/acorn-typescript": "^1.0.10",
         "@types/estree": "^1.0.5",
-        "@types/trusted-types": "^2.0.7",
         "acorn": "^8.12.1",
         "aria-query": "5.3.1",
         "axobject-query": "^4.1.0",
         "clsx": "^2.1.1",
-        "devalue": "^5.6.4",
+        "devalue": "^5.8.1",
         "esm-env": "^1.2.1",
-        "esrap": "^2.2.4",
+        "esrap": "^2.2.12",
         "is-reference": "^3.0.3",
         "locate-character": "^3.0.0",
         "magic-string": "^0.30.11",

--- a/website/package.json
+++ b/website/package.json
@@ -18,7 +18,7 @@
     "@tailwindcss/vite": "^4.3.3",
     "clsx": "^2.1.1",
     "shadcn-svelte": "^1.6.0",
-    "svelte": "^5.55.5",
+    "svelte": "^5.57.0",
     "tailwind-merge": "^3.5.0",
     "tailwind-variants": "^3.2.2",
     "tailwindcss": "^4.2.4",
@@ -27,8 +27,8 @@
     "vite": "^8.2.2"
   },
   "dependencies": {
+    "@serverbox/webui": "file:../packages/webui",
     "gsap": "^3.15.0",
-    "typesafe-i18n": "^5.27.1",
-    "@serverbox/webui": "file:../packages/webui"
+    "typesafe-i18n": "^5.27.1"
   }
 }


### PR DESCRIPTION
`website/package-lock.json` pinned svelte 5.55.5, which carries the three medium Dependabot alerts on this repository (GHSA-f3cj-j4f6-wq85, GHSA-pr6f-5x2q-rwfp, GHSA-rcqx-6q8c-2c42), first patched in 5.55.7. Nothing open covered it — #1433 was the version-update group and svelte was not among its six, and no security PR had been opened for it.

`^5.57.0` rather than `^5.55.7`, for two reasons: it is the version `packages/webui` already declares, and website bundles that package's source, so the two sharing one svelte is the state worth keeping. It is also 9 days old, which clears the 7-day supply-chain cooldown that is holding #1438.

npm reordered the `dependencies` block into its canonical order while writing the lockfile; that part of the diff is not a change.

Verified with a clean `npm ci` followed by a build, and the page rendered at a 393px viewport.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the website’s Svelte framework dependency to version 5.57.0.
  - Reordered dependency entries without changing their versions or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->