### PR TITLE
chore(deps): 7-day Dependabot cooldown, and re-anchor the fl_lib gitlink

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,16 @@ version: 2
 # A group can only span the directories of a single `updates` entry, and an
 # entry is one ecosystem. So cargo, pub and npm are three entries and cannot be
 # fewer; `directories` is what lets the npm one cover all four at once.
+#
+# `cooldown: default-days: 7` on each of them is the same week that
+# `minimumReleaseAge = 604800` in the maintainer's bunfig applies locally: a
+# version published in the last seven days is not proposed here either, so a
+# PR no longer arrives asking for something this machine would refuse to
+# install. Without it, `default-days` is 3.
+#
+# It covers **version updates only** — GitHub does not apply cooldown to
+# security updates, which is the right way round: a fix for a known advisory
+# should not sit for a week, and those PRs keep arriving the day they exist.
 updates:
   # Rust: the workspace root, not the member directories. Cargo.lock lives here
   # and nowhere else, so a run scoped to a member can only widen that member's
@@ -18,6 +28,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       rust:
         patterns:
@@ -27,6 +39,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       flutter:
         patterns:
@@ -50,6 +64,8 @@ updates:
       - "/packages/webui"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       web:
         patterns:
@@ -63,6 +79,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
Two unrelated one-liners, kept together rather than as two PRs.

## Cooldown

`minimumReleaseAge = 604800` in the maintainer's bunfig refuses to install anything published in the last seven days. Dependabot knew nothing about that and kept proposing versions the machine would then decline — #1414, #1427, #1436 and now #1438 are all the same starlight/astro upgrade, arriving five days early and sitting there.

```yaml
    cooldown:
      default-days: 7
```

on all four entries. Explicit rather than omitted: with `cooldown` unset the default is 3 days, and `semver-major-days`/`-minor-`/`-patch-` fall back to `default-days` when not given, so one line covers every bump type.

**Security updates are unaffected**, by GitHub's design rather than by anything here: cooldown applies to version updates only. That is the right way round — a fix for a known advisory should not wait a week, and #1424, #1432 and #1439 were all merged the day they existed.

Validated against SchemaStore's `dependabot-2.0.json`: 0 errors. Every ecosystem used here (cargo, pub, npm, github-actions) is in GitHub's cooldown support table.

## fl_lib gitlink

lollipopkit/fl_lib#51 was squashed onto that repository's main as `ee1c720`. The gitlink still named `0024513` — the PR branch's head, which once that branch is deleted is reachable from nothing on main. Every checkout here uses `submodules: recursive`, so that is the whole CI rather than one job.

The two commits have an identical tree (`git diff ee1c7200 0024513` is empty), so no code changes; it only re-anchors the pointer. Merging this is what makes deleting `feat/update-machine-arch` in fl_lib safe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Dependency updates are now subject to a seven-day cooldown to help provide more predictable update timing.
  - Security-related updates remain exempt from the cooldown for faster delivery.
  - Updated supporting components to incorporate the latest available improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->