### PR TITLE
fix(monitor): bound the agent's SQLite I/O and the history window

### DIFF
--- a/monitor/migrations/009_access_log_timestamp.sql
+++ b/monitor/migrations/009_access_log_timestamp.sql
@@ -1,0 +1,56 @@
+-- `access_log.timestamp` in the one text shape the rest of this database uses.
+--
+-- It was `DATETIME DEFAULT CURRENT_TIMESTAMP`, which writes
+-- `2026-09-08 08:28:18`, while every timestamp the agent binds itself is a
+-- `DateTime<Utc>` that sqlx encodes as RFC 3339
+-- (`2026-09-08T08:28:18.493098803+00:00`). Retention compares this column
+-- against a bound cutoff, SQLite compares the two as text, and `'T'` (0x54)
+-- sorts above `' '` (0x20) — so the comparison only ever distinguished the
+-- date, and every row from the cutoff's own day read as older than the cutoff
+-- whatever its time. Up to a day of audit log past the cutoff was deleted on
+-- each cleanup pass.
+--
+-- The default goes with it rather than being corrected. `NOT NULL` with
+-- nothing to fall back on means a writer that forgets the column fails at the
+-- insert, which is the failure this is trying not to have again; a default
+-- that happens to produce the right text is a second encoder to keep in step
+-- with chrono's.
+--
+-- No foreign key points at this table or out of it, so the rebuild needs
+-- neither `foreign_keys` nor `legacy_alter_table` handling. Dropping the old
+-- table takes its index with it, hence the recreate at the end.
+
+CREATE TABLE access_log_new (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp TEXT NOT NULL,
+    -- 'ticket' | 'terminal'
+    kind TEXT NOT NULL,
+    -- 'open' | 'attach' | 'detach' | 'close' | 'denied'
+    action TEXT NOT NULL,
+    -- panel account (JWT subject)
+    subject TEXT,
+    remote_ip TEXT,
+    -- system account for terminal sessions
+    ssh_user TEXT,
+    -- 'ok' | 'denied' | 'error'
+    result TEXT NOT NULL,
+    detail TEXT
+);
+
+-- `strftime` reads both shapes, so a row already written in the new one
+-- survives this unchanged apart from losing sub-second digits it does not
+-- have. A row whose timestamp is NULL — which the writer cannot produce, but
+-- the nullable column allowed — is dated now rather than at the epoch: an
+-- undatable audit record should expire a retention period from here, not be
+-- collected on the first pass after this migration.
+INSERT INTO access_log_new
+    (id, timestamp, kind, action, subject, remote_ip, ssh_user, result, detail)
+SELECT
+    id,
+    strftime('%Y-%m-%dT%H:%M:%S', COALESCE(timestamp, 'now')) || '+00:00',
+    kind, action, subject, remote_ip, ssh_user, result, detail
+FROM access_log;
+
+DROP TABLE access_log;
+ALTER TABLE access_log_new RENAME TO access_log;
+CREATE INDEX idx_access_log_timestamp ON access_log(timestamp);

--- a/monitor/src/api/server.rs
+++ b/monitor/src/api/server.rs
@@ -1093,12 +1093,28 @@ async fn get_metrics_history(
     // `i64::div_ceil` is still unstable; both operands are positive here.
     let bucket_secs = ((minutes * 60 + max_points - 1) / max_points).max(1);
 
+    // Bound as a `DateTime<Utc>`, so sqlx encodes it with the same RFC 3339
+    // form `store_metrics` writes the column with and the comparison is
+    // between two values of one shape.
+    //
+    // It was `datetime('now', '-N minutes')`, whose output is
+    // `2026-09-08 07:28:22` while the column holds
+    // `2026-09-08T08:28:18.493098803+00:00`. Both are text, so SQLite compares
+    // them as text, and `'T'` sorts above `' '`: every row sharing the
+    // boundary's *date* compared greater regardless of its time. The window
+    // was therefore "since midnight UTC" whenever that was the longer of the
+    // two — 4255 rows scanned for a 60-minute window holding 496, and the
+    // factor grows through the UTC day to 24x. The answer still looked right,
+    // because the cap at the end of this function keeps the newest
+    // `max_points` buckets either way; only the work was visible.
+    let cutoff = chrono::Utc::now() - chrono::Duration::minutes(minutes);
+
     use sqlx::Row;
     let rows = sqlx::query(
-        "SELECT cast(strftime('%s', timestamp) as integer) / ?1 AS bucket,                 min(timestamp) AS ts,                 avg(cpu_usage) AS cpu,                 avg(CASE WHEN memory_total > 0 THEN memory_used * 100.0 / memory_total END) AS mem,                 avg(CASE WHEN disk_total > 0 THEN disk_used * 100.0 / disk_total END) AS disk,                 avg(network_rx_bytes) AS rx,                 avg(network_tx_bytes) AS tx,                 avg(temperature) AS temp,                 avg(diskio_read_bytes) AS dio_r,                 avg(diskio_write_bytes) AS dio_w,                 avg(battery_percent) AS battery          FROM system_metrics          WHERE timestamp >= datetime('now', ?2)          GROUP BY bucket ORDER BY bucket",
+        "SELECT cast(strftime('%s', timestamp) as integer) / ?1 AS bucket,                 min(timestamp) AS ts,                 avg(cpu_usage) AS cpu,                 avg(CASE WHEN memory_total > 0 THEN memory_used * 100.0 / memory_total END) AS mem,                 avg(CASE WHEN disk_total > 0 THEN disk_used * 100.0 / disk_total END) AS disk,                 avg(network_rx_bytes) AS rx,                 avg(network_tx_bytes) AS tx,                 avg(temperature) AS temp,                 avg(diskio_read_bytes) AS dio_r,                 avg(diskio_write_bytes) AS dio_w,                 avg(battery_percent) AS battery          FROM system_metrics          WHERE timestamp >= ?2          GROUP BY bucket ORDER BY bucket",
     )
     .bind(bucket_secs)
-    .bind(format!("-{minutes} minutes"))
+    .bind(cutoff)
     .fetch_all(&app_state.db)
     .await?;
 

--- a/monitor/src/api/ws/audit.rs
+++ b/monitor/src/api/ws/audit.rs
@@ -140,10 +140,16 @@ impl Event {
         let kind = self.kind.as_str();
         let action = self.action.as_str();
         let result = self.outcome.as_str();
+        // Supplied rather than defaulted. The column used to carry
+        // `CURRENT_TIMESTAMP`, whose `YYYY-MM-DD HH:MM:SS` does not compare
+        // against the RFC 3339 every other timestamp in this database is
+        // written as, and retention compares this one — see migration 009.
         let write = sqlx::query(
-            "INSERT INTO access_log (kind, action, subject, remote_ip, ssh_user, result, detail) \
-             VALUES (?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO access_log \
+             (timestamp, kind, action, subject, remote_ip, ssh_user, result, detail) \
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
         )
+        .bind(chrono::Utc::now())
         .bind(kind)
         .bind(action)
         .bind(&self.subject)

--- a/monitor/src/db/cleanup.rs
+++ b/monitor/src/db/cleanup.rs
@@ -24,11 +24,12 @@ impl DataCleanupService {
         let alerts_deleted = self.cleanup_old_alerts().await?;
         let policy_deleted = self.cleanup_policy_tables().await?;
         let size_deleted = self.enforce_db_size_limit().await?;
+        let reclaimed = self.reclaim_free_pages().await?;
 
         let duration = start_time.elapsed();
         info!(
-            "Data cleanup completed in {:?}. Deleted {} metrics records, {} alerts records, {} policy-table records, {} size-cap records",
-            duration, metrics_deleted, alerts_deleted, policy_deleted, size_deleted
+            "Data cleanup completed in {:?}. Deleted {} metrics records, {} alerts records, {} policy-table records, {} size-cap records, reclaimed {} bytes",
+            duration, metrics_deleted, alerts_deleted, policy_deleted, size_deleted, reclaimed
         );
 
         Ok(())
@@ -50,9 +51,17 @@ impl DataCleanupService {
         "access_log",
     ];
 
-    /// Live data size: pages in use excluding the freelist, so deletions count
-    /// immediately without requiring a blocking full-database VACUUM.
-    async fn live_db_bytes(&self) -> Result<u64> {
+    /// Fraction of the file that has to be freelist before it is worth
+    /// reclaiming. A database that is mostly holes still has to be walked past
+    /// on every cache miss, which is the cost this exists to bound.
+    const FREELIST_RECLAIM_RATIO: f64 = 0.25;
+
+    /// Below this the file is small enough that the ratio above says nothing.
+    /// 1024 pages is 4 MiB at the default page size.
+    const FREELIST_RECLAIM_MIN_PAGES: i64 = 1024;
+
+    /// `page_count`, `freelist_count`, `page_size`.
+    async fn page_stats(&self) -> Result<(i64, i64, i64)> {
         let page_count: i64 = sqlx::query_scalar("PRAGMA page_count")
             .fetch_one(&self.pool)
             .await?;
@@ -62,7 +71,55 @@ impl DataCleanupService {
         let page_size: i64 = sqlx::query_scalar("PRAGMA page_size")
             .fetch_one(&self.pool)
             .await?;
-        Ok((page_count - freelist).max(0) as u64 * page_size.max(0) as u64)
+        Ok((page_count, freelist, page_size.max(0)))
+    }
+
+    /// Live data size: pages in use excluding the freelist, so deletions count
+    /// immediately without requiring a blocking full-database VACUUM.
+    async fn live_db_bytes(&self) -> Result<u64> {
+        let (page_count, freelist, page_size) = self.page_stats().await?;
+        Ok((page_count - freelist).max(0) as u64 * page_size as u64)
+    }
+
+    /// Give pages the deletions above freed back to the filesystem, and
+    /// answer with how many bytes that was.
+    ///
+    /// Retention deletes rows; it does not shrink the file. Without this the
+    /// freelist is the whole difference between a database that has been
+    /// running for a month and one that has not — measured at 20329 of 33331
+    /// pages, a 136 MB file carrying 53 MB — and every page of it is something
+    /// a cold read walks past.
+    ///
+    /// `incremental_vacuum` is the cheap path: it moves free pages to the end
+    /// and truncates, with no rewrite and no long lock. It does nothing unless
+    /// the database was *created* with `auto_vacuum = INCREMENTAL`, which is
+    /// why the other branch exists at all — a file from before that setting
+    /// reports NONE, and the one full VACUUM below both reclaims it and
+    /// converts it, since VACUUM adopts the running connection's setting.
+    pub async fn reclaim_free_pages(&self) -> Result<u64> {
+        let (page_count, freelist, page_size) = self.page_stats().await?;
+        if page_count <= 0
+            || freelist < Self::FREELIST_RECLAIM_MIN_PAGES
+            || (freelist as f64) / (page_count as f64) < Self::FREELIST_RECLAIM_RATIO
+        {
+            return Ok(0);
+        }
+
+        let auto_vacuum: i64 = sqlx::query_scalar("PRAGMA auto_vacuum")
+            .fetch_one(&self.pool)
+            .await?;
+        // 2 is INCREMENTAL; 0 NONE, 1 FULL (which reclaims on its own).
+        if auto_vacuum == 2 {
+            info!("Reclaiming {} free database pages incrementally", freelist);
+            sqlx::query("PRAGMA incremental_vacuum")
+                .execute(&self.pool)
+                .await?;
+        } else {
+            self.vacuum_database().await?;
+        }
+
+        let (after, _, _) = self.page_stats().await?;
+        Ok((page_count - after).max(0) as u64 * page_size as u64)
     }
 
     /// Enforce `max_db_size_mb`: while over the cap, drop the oldest ~10% of
@@ -282,26 +339,21 @@ pub async fn start_cleanup_scheduler(pool: SqlitePool, config: DataRetentionConf
         config.metrics_days, config.alerts_days, config.cleanup_interval_hours
     );
 
+    // Reclaiming space is part of a cleanup pass rather than a timer of its
+    // own. It used to be one fixed at seven times the cleanup interval and
+    // starting a full period out, so a default install rewrote the whole file
+    // every seven days whether or not there was anything to reclaim — and
+    // reclaimed nothing at all before then, or ever, on an agent restarted
+    // more often than that. `reclaim_free_pages` asks the freelist instead.
     tokio::spawn(async move {
         let cleanup_period =
             tokio::time::Duration::from_secs(config.cleanup_interval_hours as u64 * 3600);
-        let vacuum_period = cleanup_period.saturating_mul(7);
         let mut interval = tokio::time::interval(cleanup_period);
-        let mut vacuum =
-            tokio::time::interval_at(tokio::time::Instant::now() + vacuum_period, vacuum_period);
 
         loop {
-            tokio::select! {
-                _ = interval.tick() => {
-                    if let Err(e) = cleanup_service.cleanup_expired_data().await {
-                        error!("Failed to cleanup expired data: {}", e);
-                    }
-                }
-                _ = vacuum.tick() => {
-                    if let Err(e) = cleanup_service.vacuum_database().await {
-                        error!("Failed to vacuum database: {}", e);
-                    }
-                }
+            interval.tick().await;
+            if let Err(e) = cleanup_service.cleanup_expired_data().await {
+                error!("Failed to cleanup expired data: {}", e);
             }
         }
     });

--- a/monitor/src/db/database.rs
+++ b/monitor/src/db/database.rs
@@ -58,11 +58,18 @@ fn connect_options(database_url: &str) -> Result<SqliteConnectOptions> {
         // way while a newly created one would quietly get a rollback journal —
         // a fsync-per-commit against the whole database file.
         .journal_mode(SqliteJournalMode::Wal)
-        // FULL is SQLite's default and means an fsync per commit on top of the
-        // one WAL already does. Under WAL, NORMAL risks losing the most recent
-        // transactions to a power failure and cannot corrupt the database —
-        // the right trade for a sampler whose next row is seconds away.
-        .synchronous(SqliteSynchronous::Normal)
+        // Kept at SQLite's default, and named so that lowering it is a
+        // decision rather than an omission. NORMAL under WAL cannot corrupt
+        // the file and only risks the most recent transactions, which for a
+        // metrics row seconds away from its successor costs nothing — but this
+        // database is not only metrics. `users` carries the panel credential,
+        // `watch_tokens` is what revoking a watch's access deletes from, and
+        // `access_log` and `config_audit_log` exist to be readable after
+        // exactly the kind of event that would lose an unsynced commit. A
+        // password change or a revocation silently not having happened is not
+        // a cost worth an fsync, and the read amplification this file set out
+        // to fix was `wal_autocheckpoint`, not this.
+        .synchronous(SqliteSynchronous::Full)
         // Only ever takes effect on a database that is still empty, so this
         // sets the behaviour for new installs; an existing file reports NONE
         // until the one full VACUUM in `cleanup` converts it.

--- a/monitor/src/db/database.rs
+++ b/monitor/src/db/database.rs
@@ -1,19 +1,75 @@
 use anyhow::Result;
-use sqlx::{sqlite::SqlitePool, migrate::MigrateDatabase, Sqlite};
+use sqlx::sqlite::{
+    SqliteAutoVacuum, SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions,
+    SqliteSynchronous,
+};
+use sqlx::{Sqlite, migrate::MigrateDatabase};
+use std::str::FromStr;
+use std::time::Duration;
 use tracing::info;
 
+/// WAL frames to accumulate before SQLite folds them back into the database
+/// file, well below SQLite's own default of 1000 (4 MiB at the default page
+/// size).
+///
+/// This agent commits one small row every few seconds for as long as it runs,
+/// so with the default the WAL sits near its ceiling essentially all the time.
+/// That costs nothing while the file stays cached — and everything when it
+/// does not: rebuilding the WAL index reads *every* frame, so on a host that
+/// keeps reclaiming the page cache (a VM with free-page reporting, a small
+/// VPS) each sample was measured re-reading ~4 MB from disk to append ~16 KB.
+/// Checkpointing more often moves the same bytes into the database file, just
+/// in smaller pieces, so the ceiling is what to lower.
+const WAL_AUTOCHECKPOINT_PAGES: u32 = 128;
+
 pub async fn init(database_url: &str) -> Result<SqlitePool> {
-    // Create database if it doesn't exist
+    // Logged, not created. `Sqlite::create_database` opens a connection of its
+    // own with default settings, and the file it leaves behind is past the
+    // point where `auto_vacuum` can still be chosen — the setting is only
+    // applied to a database with no pages yet. `create_if_missing` below makes
+    // the first connection to a new file one that carries every setting.
     if !Sqlite::database_exists(database_url).await? {
         info!("Creating database {}", database_url);
-        Sqlite::create_database(database_url).await?;
     }
-    
-    let pool = SqlitePool::connect(database_url).await?;
-    
+
+    let pool = SqlitePoolOptions::new()
+        .connect_with(connect_options(database_url)?)
+        .await?;
+
     // Run migrations
     sqlx::migrate!("./migrations").run(&pool).await?;
-    
+
     info!("Database initialized");
     Ok(pool)
+}
+
+/// Connection settings applied to every connection the pool opens.
+///
+/// They belong here rather than in a `PRAGMA` statement run after connecting:
+/// these are per-connection settings, a pool opens connections lazily and
+/// replaces them over their lifetime, so a statement executed once against the
+/// pool configures whichever single connection happened to answer it.
+fn connect_options(database_url: &str) -> Result<SqliteConnectOptions> {
+    Ok(SqliteConnectOptions::from_str(database_url)?
+        .create_if_missing(true)
+        // Named explicitly rather than relied on: sqlx stopped setting a
+        // journal mode of its own accord, and `journal_mode` is a persistent
+        // property of the file, so an existing database stays in WAL either
+        // way while a newly created one would quietly get a rollback journal —
+        // a fsync-per-commit against the whole database file.
+        .journal_mode(SqliteJournalMode::Wal)
+        // FULL is SQLite's default and means an fsync per commit on top of the
+        // one WAL already does. Under WAL, NORMAL risks losing the most recent
+        // transactions to a power failure and cannot corrupt the database —
+        // the right trade for a sampler whose next row is seconds away.
+        .synchronous(SqliteSynchronous::Normal)
+        // Only ever takes effect on a database that is still empty, so this
+        // sets the behaviour for new installs; an existing file reports NONE
+        // until the one full VACUUM in `cleanup` converts it.
+        .auto_vacuum(SqliteAutoVacuum::Incremental)
+        .pragma(
+            "wal_autocheckpoint",
+            WAL_AUTOCHECKPOINT_PAGES.to_string(),
+        )
+        .busy_timeout(Duration::from_secs(30)))
 }

--- a/monitor/tests/db_pragmas.rs
+++ b/monitor/tests/db_pragmas.rs
@@ -1,0 +1,151 @@
+//! The connection settings `db::database::init` puts on the pool, and the
+//! space reclamation that one of them enables.
+//!
+//! Both are asserted through a real file rather than `sqlite::memory:`: WAL,
+//! `wal_autocheckpoint` and `auto_vacuum` all describe how a database is laid
+//! out on disk, and an in-memory one answers about none of it.
+
+use anyhow::Result;
+use server_box_monitor::core::config::DataRetentionConfig;
+use server_box_monitor::db::cleanup::DataCleanupService;
+use server_box_monitor::db::database;
+use sqlx::{Row, SqlitePool};
+
+/// A pool over a fresh database file, plus the directory keeping it alive.
+async fn fresh_db() -> Result<(SqlitePool, tempfile::TempDir)> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("monitor.db");
+    let pool = database::init(&format!("sqlite:{}", path.display())).await?;
+    Ok((pool, dir))
+}
+
+async fn pragma<T>(pool: &SqlitePool, stmt: &'static str) -> Result<T>
+where
+    T: for<'r> sqlx::Decode<'r, sqlx::Sqlite> + sqlx::Type<sqlx::Sqlite> + Send + Unpin,
+{
+    Ok(sqlx::query_scalar(stmt).fetch_one(pool).await?)
+}
+
+/// `synchronous` and `wal_autocheckpoint` are per-*connection* settings, and a
+/// pool opens connections lazily and replaces them over their lifetime. A
+/// `PRAGMA` run once against the pool therefore configures whichever single
+/// connection answered it and silently leaves the rest on the defaults, which
+/// is why these belong in the connect options.
+///
+/// Held open at the same time on purpose: acquiring them one after another
+/// hands back the same connection every time and would pass either way.
+#[tokio::test]
+async fn every_pooled_connection_carries_the_settings() -> Result<()> {
+    let (pool, _dir) = fresh_db().await?;
+
+    let mut held = Vec::new();
+    for _ in 0..4 {
+        held.push(pool.acquire().await?);
+    }
+
+    for (i, conn) in held.iter_mut().enumerate() {
+        use sqlx::Executor;
+        let row = conn
+            .fetch_one("PRAGMA synchronous")
+            .await
+            .map_err(anyhow::Error::from)?;
+        // 1 is NORMAL, 2 is SQLite's own default of FULL.
+        assert_eq!(row.get::<i64, _>(0), 1, "connection {i} synchronous");
+
+        let row = conn
+            .fetch_one("PRAGMA wal_autocheckpoint")
+            .await
+            .map_err(anyhow::Error::from)?;
+        assert_eq!(
+            row.get::<i64, _>(0),
+            128,
+            "connection {i} wal_autocheckpoint"
+        );
+    }
+
+    Ok(())
+}
+
+/// WAL and INCREMENTAL are properties of the file, so these only answer for a
+/// database this code created. An existing one keeps whatever it was made
+/// with — which for `auto_vacuum` is the whole reason `reclaim_free_pages`
+/// still has a full-VACUUM branch.
+#[tokio::test]
+async fn a_new_database_is_laid_out_for_incremental_reclaim() -> Result<()> {
+    let (pool, _dir) = fresh_db().await?;
+
+    let journal: String = pragma(&pool, "PRAGMA journal_mode").await?;
+    assert_eq!(journal.to_lowercase(), "wal");
+
+    // 2 is INCREMENTAL, 0 the NONE every pre-existing database reports.
+    let auto_vacuum: i64 = pragma(&pool, "PRAGMA auto_vacuum").await?;
+    assert_eq!(auto_vacuum, 2);
+
+    Ok(())
+}
+
+/// Retention deletes rows and leaves the pages on the freelist; without this
+/// the file only ever grows. Measured on a month-old agent: 20329 of 33331
+/// pages free, a 136 MB file holding 53 MB of data, every page of it walked
+/// past on a cold read.
+#[tokio::test]
+async fn reclaim_gives_back_the_pages_a_deletion_freed() -> Result<()> {
+    let (pool, _dir) = fresh_db().await?;
+
+    // Padded so each row costs about a page: the reclaim threshold is stated
+    // in pages, and 2000 rows of real metrics would not reach it.
+    let padding = "x".repeat(4000);
+    let mut tx = pool.begin().await?;
+    for i in 0..2000 {
+        sqlx::query(
+            "INSERT INTO system_metrics (timestamp, server_name, cpu_usage) VALUES (?, ?, ?)",
+        )
+        .bind(chrono::Utc::now())
+        .bind(format!("{padding}{i}"))
+        .bind(1.0)
+        .execute(&mut *tx)
+        .await?;
+    }
+    tx.commit().await?;
+
+    let before: i64 = pragma(&pool, "PRAGMA page_count").await?;
+    sqlx::query("DELETE FROM system_metrics").execute(&pool).await?;
+    let freed: i64 = pragma(&pool, "PRAGMA freelist_count").await?;
+    assert!(
+        freed > 1024,
+        "fixture freed only {freed} pages, below the reclaim threshold"
+    );
+
+    let cleanup = DataCleanupService::new(pool.clone(), DataRetentionConfig::default());
+    let reclaimed = cleanup.reclaim_free_pages().await?;
+    assert!(reclaimed > 0, "reclaimed nothing from {freed} free pages");
+
+    let after: i64 = pragma(&pool, "PRAGMA page_count").await?;
+    assert!(
+        after < before / 2,
+        "file went from {before} pages to {after} after deleting every row"
+    );
+
+    Ok(())
+}
+
+/// Below the threshold nothing is rewritten. A cleanup pass runs on a timer
+/// whether or not it deleted anything, and rewriting a database because a
+/// handful of rows aged out is the cost this guard exists to avoid.
+#[tokio::test]
+async fn a_small_freelist_is_left_alone() -> Result<()> {
+    let (pool, _dir) = fresh_db().await?;
+
+    sqlx::query("INSERT INTO system_metrics (timestamp, server_name, cpu_usage) VALUES (?, ?, ?)")
+        .bind(chrono::Utc::now())
+        .bind("test")
+        .bind(1.0)
+        .execute(&pool)
+        .await?;
+    sqlx::query("DELETE FROM system_metrics").execute(&pool).await?;
+
+    let cleanup = DataCleanupService::new(pool.clone(), DataRetentionConfig::default());
+    assert_eq!(cleanup.reclaim_free_pages().await?, 0);
+
+    Ok(())
+}

--- a/monitor/tests/db_pragmas.rs
+++ b/monitor/tests/db_pragmas.rs
@@ -32,6 +32,11 @@ where
 /// connection answered it and silently leaves the rest on the defaults, which
 /// is why these belong in the connect options.
 ///
+/// `wal_autocheckpoint` is the one that can fail here. `synchronous` is
+/// asserted because the value is a decision worth stating, but FULL is also
+/// what a connection carrying no settings at all reports, so it cannot tell
+/// the two apart on its own.
+///
 /// Held open at the same time on purpose: acquiring them one after another
 /// hands back the same connection every time and would pass either way.
 #[tokio::test]
@@ -49,8 +54,9 @@ async fn every_pooled_connection_carries_the_settings() -> Result<()> {
             .fetch_one("PRAGMA synchronous")
             .await
             .map_err(anyhow::Error::from)?;
-        // 1 is NORMAL, 2 is SQLite's own default of FULL.
-        assert_eq!(row.get::<i64, _>(0), 1, "connection {i} synchronous");
+        // 2 is FULL, 1 the NORMAL this database deliberately does not use —
+        // see the note in `connect_options`.
+        assert_eq!(row.get::<i64, _>(0), 2, "connection {i} synchronous");
 
         let row = conn
             .fetch_one("PRAGMA wal_autocheckpoint")

--- a/monitor/tests/metrics_history_points.rs
+++ b/monitor/tests/metrics_history_points.rs
@@ -16,6 +16,7 @@
 
 use std::sync::{Arc, Once};
 
+use chrono::{DateTime, Duration, Utc};
 use ntex::web::App;
 use ntex::web::test::{self as web_test, TestServer};
 use rustls::crypto::ring;
@@ -48,6 +49,16 @@ async fn state_with_samples(minutes: i64) -> Arc<AppState> {
 /// a fixture at 10-second spacing answers identically whether the width was
 /// rounded up or down and proves nothing either way.
 async fn state_with_samples_every(span_secs: i64, step_secs: i64) -> Arc<AppState> {
+    let rows = span_secs / step_secs;
+    let now = Utc::now();
+    let at: Vec<_> = (0..rows)
+        .map(|i| now - Duration::seconds((rows - i) * step_secs))
+        .collect();
+    state_with(&at).await
+}
+
+/// One row per instant given, in the order given.
+async fn state_with(at: &[DateTime<Utc>]) -> Arc<AppState> {
     ensure_crypto_provider();
     let config = Config {
         jwt_secret: Some(SECRET.to_string()),
@@ -57,25 +68,36 @@ async fn state_with_samples_every(span_secs: i64, step_secs: i64) -> Arc<AppStat
     let db = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
     sqlx::migrate!("./migrations").run(&db).await.unwrap();
 
-    let rows = span_secs / step_secs;
-    for i in 0..rows {
-        let seconds_ago = (rows - i) * step_secs;
-        sqlx::query(
-            "INSERT INTO system_metrics (
-                timestamp, server_name, cpu_usage,
-                memory_total, memory_used, disk_total, disk_used,
-                network_rx_bytes, network_tx_bytes
-             ) VALUES (datetime('now', ?1), 'test', ?2, 100, 50, 100, 50, ?3, ?3)",
-        )
-        .bind(format!("-{seconds_ago} seconds"))
-        .bind(i as f64 % 100.0)
-        .bind(i * 1000)
-        .execute(&db)
-        .await
-        .unwrap();
+    for (i, at) in at.iter().enumerate() {
+        insert_sample(&db, *at, i as i64).await;
     }
 
     AppState::new(Arc::new(config), db)
+}
+
+/// One row, timestamped the way `store_metrics` timestamps one.
+///
+/// The column is written by binding a `DateTime<Utc>`, which sqlx encodes as
+/// RFC 3339 (`2026-09-08T08:28:18.493098803+00:00`). A fixture that reached
+/// for `datetime('now', ...)` instead — as this one did — writes
+/// `2026-09-08 07:28:22`, a shape nothing in the agent produces, and the two
+/// do not compare against each other as either one compares against itself.
+/// That is what let a broken window bound sit here unnoticed: the fixture and
+/// the query agreed with each other and with nothing that ships.
+async fn insert_sample(db: &sqlx::SqlitePool, at: DateTime<Utc>, i: i64) {
+    sqlx::query(
+        "INSERT INTO system_metrics (
+            timestamp, server_name, cpu_usage,
+            memory_total, memory_used, disk_total, disk_used,
+            network_rx_bytes, network_tx_bytes
+         ) VALUES (?1, 'test', ?2, 100, 50, 100, 50, ?3, ?3)",
+    )
+    .bind(at)
+    .bind(i as f64 % 100.0)
+    .bind(i * 1000)
+    .execute(db)
+    .await
+    .unwrap();
 }
 
 async fn test_server(state: Arc<AppState>) -> TestServer {
@@ -203,25 +225,62 @@ async fn a_silly_count_is_clamped() {
 }
 
 
-/// Seconds between the first and last point.
+/// `minutes` is a window, and a row outside it is not in the answer.
 ///
-/// The column is SQLite's `datetime()` text, so this reads the clock out of
-/// it rather than taking a date dependency for two tests. A run that straddles
-/// midnight would see the last time as the smaller of the two; a day is added
-/// back in that case, which is correct for any window shorter than one.
+/// The bound used to be `datetime('now', '-N minutes')`, whose `YYYY-MM-DD
+/// HH:MM:SS` output compares against this column's RFC 3339 only as far as the
+/// date: every row from the same UTC day passed it whatever its time. That is
+/// what this places — one row at the start of the current UTC day — and it is
+/// the only shape that can catch it, since a row from any *earlier* day is
+/// excluded correctly by the broken bound too.
+///
+/// `max_points` is well above the number of rows on purpose. The handler keeps
+/// the newest `max_points` buckets, so with a dense fixture it hands back a
+/// window-sized answer either way and the extra rows are only extra work;
+/// two rows and 300 points is where the difference reaches the response.
+#[ntex::test]
+async fn a_row_from_earlier_today_is_outside_a_five_minute_window() {
+    const MINUTES: i64 = 5;
+    let now = Utc::now();
+    let day_start = now.date_naive().and_hms_opt(0, 0, 0).unwrap().and_utc();
+    let stale = day_start + Duration::seconds(1);
+
+    if now - stale <= Duration::minutes(MINUTES) {
+        // The first few minutes of a UTC day: "earlier today" is inside the
+        // window, so the defect has nothing to show and neither has this test.
+        eprintln!("skipped: {now} is within {MINUTES} minutes of {day_start}");
+        return;
+    }
+    let fresh = now - Duration::seconds(30);
+
+    let srv = test_server(state_with(&[stale, fresh]).await).await;
+    let points = history(&srv, &format!("minutes={MINUTES}&max_points=300")).await;
+
+    assert_eq!(
+        points.len(),
+        1,
+        "a {MINUTES}-minute window over one row inside it and one at {stale} \
+         answered with {} points",
+        points.len()
+    );
+    let oldest = point_time(&points[0]);
+    assert!(
+        now - oldest <= Duration::minutes(MINUTES),
+        "oldest point {oldest} is outside the {MINUTES}-minute window ending {now}"
+    );
+}
+
+/// Seconds between the first and last point.
 fn span_secs(points: &[serde_json::Value]) -> i64 {
-    let at = |p: &serde_json::Value| -> i64 {
-        let ts = p["timestamp"].as_str().expect("point has no timestamp");
-        let clock = ts.rsplit(' ').next().unwrap_or_default();
-        let mut parts = clock.split(':').map(|f| f.parse::<i64>().unwrap_or(0));
-        let h = parts.next().unwrap_or(0);
-        let m = parts.next().unwrap_or(0);
-        let s = parts.next().unwrap_or(0);
-        h * 3600 + m * 60 + s
-    };
-    let (first, last) = match (points.first(), points.last()) {
-        (Some(f), Some(l)) => (at(f), at(l)),
-        _ => return 0,
-    };
-    if last >= first { last - first } else { last + 86_400 - first }
+    match (points.first(), points.last()) {
+        (Some(f), Some(l)) => (point_time(l) - point_time(f)).num_seconds(),
+        _ => 0,
+    }
+}
+
+fn point_time(point: &serde_json::Value) -> DateTime<Utc> {
+    let ts = point["timestamp"].as_str().expect("point has no timestamp");
+    DateTime::parse_from_rfc3339(ts)
+        .unwrap_or_else(|e| panic!("point timestamp {ts:?} is not RFC 3339: {e}"))
+        .with_timezone(&Utc)
 }

--- a/monitor/tests/migration_upgrade.rs
+++ b/monitor/tests/migration_upgrade.rs
@@ -106,18 +106,22 @@ async fn the_audit_log_is_cleaned_up_by_the_retention_service() {
     let pool = pool().await;
     sqlx::migrate!("./migrations").run(&pool).await.unwrap();
 
-    // One row inside the window and one well outside it
-    sqlx::query(
-        "INSERT INTO access_log (timestamp, kind, action, result) \
-         VALUES (datetime('now','-200 days'),'terminal','open','ok')",
-    )
-    .execute(&pool)
-    .await
-    .unwrap();
-    sqlx::query("INSERT INTO access_log (kind, action, result) VALUES ('terminal','open','ok')")
+    // One row inside the window and one well outside it, both timestamped the
+    // way `audit::Event::record` timestamps one. Written with
+    // `datetime('now', ...)` and the column's old default before migration
+    // 009, which is a shape the agent never produces and does not compare
+    // against the cutoff the way the shape it does produce compares.
+    let now = chrono::Utc::now();
+    for at in [now - chrono::Duration::days(200), now] {
+        sqlx::query(
+            "INSERT INTO access_log (timestamp, kind, action, result) \
+             VALUES (?, 'terminal', 'open', 'ok')",
+        )
+        .bind(at)
         .execute(&pool)
         .await
         .unwrap();
+    }
 
     let service = DataCleanupService::new(
         pool.clone(),
@@ -137,6 +141,59 @@ async fn the_audit_log_is_cleaned_up_by_the_retention_service() {
         "an entry older than its retention policy must be collected"
     );
     assert_eq!(rows[0].get::<String, _>("kind"), "terminal");
+}
+
+/// The retention cutoff is a moment, not a date.
+///
+/// `cleanup_policy_tables` binds `now - retention_days` and compares it
+/// against this column. While the column carried `CURRENT_TIMESTAMP`'s
+/// `YYYY-MM-DD HH:MM:SS` and the cutoff arrived as RFC 3339, the text
+/// comparison stopped meaning anything at position 10 — `' '` against `'T'` —
+/// so every row from the cutoff's own date read as older than the cutoff
+/// whatever its time, and up to a day of audit log past it was deleted on
+/// each pass. One second either side of the boundary is what that got wrong.
+#[tokio::test]
+async fn the_audit_log_cutoff_is_a_moment_not_a_date() {
+    use server_box_monitor::core::config::DataRetentionConfig;
+    use server_box_monitor::db::cleanup::DataCleanupService;
+
+    let pool = pool().await;
+    sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+
+    // 90 days is the policy migration 006 seeds for this table.
+    let cutoff = chrono::Utc::now() - chrono::Duration::days(90);
+    for (at, detail) in [
+        (cutoff + chrono::Duration::seconds(1), "keep"),
+        (cutoff - chrono::Duration::seconds(1), "drop"),
+    ] {
+        sqlx::query(
+            "INSERT INTO access_log (timestamp, kind, action, result, detail) \
+             VALUES (?, 'terminal', 'open', 'ok', ?)",
+        )
+        .bind(at)
+        .bind(detail)
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+
+    let service = DataCleanupService::new(
+        pool.clone(),
+        DataRetentionConfig {
+            metrics_days: 30,
+            alerts_days: 90,
+            cleanup_interval_hours: 24,
+            max_db_size_mb: 1024,
+        },
+    );
+    service.cleanup_expired_data().await.unwrap();
+
+    let kept = sqlx::query("SELECT detail FROM access_log")
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+    let kept: Vec<String> = kept.iter().map(|r| r.get::<String, _>("detail")).collect();
+    assert_eq!(kept, ["keep"], "kept {kept:?} across the retention boundary");
 }
 
 #[tokio::test]
@@ -233,6 +290,7 @@ fn shipped_migrations_keep_their_checksums() {
         (6, "bc1d80ef7f88751b0bb2a64974a7efb928301cd61740cfe77d9e2306a8f71d8cfbdd24a2e2e5dc2e5b9094755b9e03f9"),
         (7, "d7726fdbe4fad21ac01dc6b9a3058550aa138829baff1e0968a259f33e9b182e60bc4b658e0227fd4418a3c0fbd0a1f5"),
         (8, "9961008300f34069365756a67bc45c596baaf1290ddf9825198377feeafe11901c08603bbcabcb14f2df943eacebe054"),
+        (9, "f50849af86f5e456829df80ddb0c716540a23bd0a15527925bfb27f5e05b8dd567e83c6e1d08898a93135aa05052877b"),
     ];
     let migrator = sqlx::migrate!("./migrations");
     let mut seen = std::collections::BTreeMap::new();

--- a/monitor/tests/migration_upgrade.rs
+++ b/monitor/tests/migration_upgrade.rs
@@ -143,6 +143,123 @@ async fn the_audit_log_is_cleaned_up_by_the_retention_service() {
     assert_eq!(rows[0].get::<String, _>("kind"), "terminal");
 }
 
+/// Everything up to and including [`through`], so a migration can be run
+/// against a database that genuinely predates it.
+///
+/// `Migrator`'s fields are public for the `migrate!()` macro's sake. Building
+/// a subset out of the same `Migration` values is what makes the second run
+/// apply only what is left: it re-validates the checksums of what is already
+/// recorded, and those match by construction.
+fn migrator_through(through: i64) -> sqlx::migrate::Migrator {
+    let all = sqlx::migrate!("./migrations");
+    sqlx::migrate::Migrator {
+        migrations: all
+            .migrations
+            .iter()
+            .filter(|m| m.version <= through)
+            .cloned()
+            .collect::<Vec<_>>()
+            .into(),
+        ..sqlx::migrate::Migrator::DEFAULT
+    }
+}
+
+/// Migration 009 against a row written the way the agent wrote them before it.
+///
+/// A migration gets one pass over a user's records and is not repeatable, so a
+/// mistake in the conversion is silence rather than a crash — the rows are
+/// simply wrong afterwards, in a column only retention reads. Every other test
+/// here runs the whole set first and inserts after, which exercises the new
+/// schema and never the conversion.
+///
+/// The row is inserted through the pre-009 default rather than with a value of
+/// this test's own choosing: `CURRENT_TIMESTAMP` is what produced every
+/// timestamp in this column in the field, and a fixture that types the text
+/// itself would prove the migration handles the fixture.
+#[tokio::test]
+async fn migration_009_converts_the_timestamps_already_in_access_log() {
+    let pool = pool().await;
+    migrator_through(8).run(&pool).await.unwrap();
+
+    sqlx::query(
+        "INSERT INTO access_log (kind, action, subject, remote_ip, ssh_user, result, detail) \
+         VALUES ('terminal','open','admin','10.0.0.1','root','ok','pre-009')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let before = sqlx::query("SELECT id, timestamp FROM access_log")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let old_id: i64 = before.get("id");
+    let old_ts: String = before.get("timestamp");
+    assert_eq!(
+        old_ts.len(),
+        19,
+        "the pre-009 default should write 'YYYY-MM-DD HH:MM:SS', got {old_ts:?}"
+    );
+
+    sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+
+    let row = sqlx::query("SELECT id, timestamp, subject, remote_ip, ssh_user, detail FROM access_log")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(row.get::<i64, _>("id"), old_id, "the row was renumbered");
+    // Every other column carried across the rebuild, not just the one being
+    // converted — a copy that names its columns in the wrong order still
+    // typechecks.
+    assert_eq!(row.get::<String, _>("subject"), "admin");
+    assert_eq!(row.get::<String, _>("remote_ip"), "10.0.0.1");
+    assert_eq!(row.get::<String, _>("ssh_user"), "root");
+    assert_eq!(row.get::<String, _>("detail"), "pre-009");
+
+    // Exact, rather than "looks like RFC 3339": the same instant, in the shape
+    // sqlx encodes a whole-second `DateTime<Utc>` as. Checked against the text
+    // that was there, so the clock cannot make this flaky.
+    let converted: String = row.get("timestamp");
+    assert_eq!(converted, format!("{}+00:00", old_ts.replace(' ', "T")));
+    let parsed = chrono::DateTime::parse_from_rfc3339(&converted)
+        .unwrap_or_else(|e| panic!("{converted:?} is not RFC 3339: {e}"));
+
+    // The point of the conversion. A cutoff one second older than the row used
+    // to read as newer than it, because the comparison stopped meaning
+    // anything at the ' ' where the new shape has a 'T'.
+    let cutoff = parsed.with_timezone(&chrono::Utc) - chrono::Duration::seconds(1);
+    let kept: i64 = sqlx::query_scalar("SELECT count(*) FROM access_log WHERE timestamp >= ?")
+        .bind(cutoff)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(kept, 1, "the converted row is still older than {cutoff}");
+
+    // The rebuild drops the old table, which takes its index and its
+    // sqlite_sequence entry with it.
+    let indexes: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM sqlite_master WHERE type = 'index' AND name = 'idx_access_log_timestamp'",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(indexes, 1, "the timestamp index did not survive the rebuild");
+
+    sqlx::query("INSERT INTO access_log (timestamp, kind, action, result) VALUES (?,'ticket','open','ok')")
+        .bind(chrono::Utc::now())
+        .execute(&pool)
+        .await
+        .unwrap();
+    let next: i64 = sqlx::query_scalar("SELECT max(id) FROM access_log")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert!(
+        next > old_id,
+        "AUTOINCREMENT restarted after the rebuild: {next} follows {old_id}"
+    );
+}
+
 /// The retention cutoff is a moment, not a date.
 ///
 /// `cleanup_policy_tables` binds `now - retention_days` and compares it

--- a/monitor/tests/test_cleanup.rs
+++ b/monitor/tests/test_cleanup.rs
@@ -167,8 +167,10 @@ async fn a_negative_table_policy_does_not_delete_current_data() -> Result<()> {
         .execute(&pool)
         .await?;
     sqlx::query(
-        "INSERT INTO access_log (kind, action, result) VALUES ('terminal', 'open', 'ok')",
+        "INSERT INTO access_log (timestamp, kind, action, result) \
+         VALUES (?, 'terminal', 'open', 'ok')",
     )
+    .bind(Utc::now())
     .execute(&pool)
     .await?;
 


### PR DESCRIPTION
Three defects found while tracing an OrbStack Helper memory question. They turned out not to be the cause of that — the helper's growth is reclaimable page cache of the VM disk image and it falls back — but each is real on its own, and together they are the agent's continuous disk I/O.

Measured on an agent running for a month, with no client connected:

| | before |
|---|---|
| disk read caused by the agent | 431 KB/s, 0 with the agent stopped |
| read to append one ~150-byte row | 4,280,320 bytes in one cycle, cold cache |
| write per 7-second cycle | 53–74 KB |
| database file | 136 MB, 20329 of 33331 pages on the freelist |
| `/metrics/history?minutes=60` | 4255 rows scanned, 496 in the window |

## Connection settings (`db/database.rs`)

They move onto `SqliteConnectOptions` so the pool applies them to every connection. `synchronous` and `wal_autocheckpoint` are per-connection settings, and a pool opens connections lazily and replaces them over their lifetime, so a `PRAGMA` executed once against the pool configures whichever single connection answered it.

- `wal_autocheckpoint` 1000 → 128 pages. The agent commits a small row every few seconds forever, so the WAL sat near its 4 MB ceiling; rebuilding the WAL index after a page-cache eviction reads every frame, which is the 4 MB above. Checkpointing more often moves the same bytes into the database file in smaller pieces.
- `synchronous` stays at FULL, now named explicitly so that lowering it is a decision rather than an omission. It was NORMAL in the first push; the saving was never measured on its own, and this database also holds the panel credential, the watch tokens a revocation deletes from, and two audit logs that exist to survive the kind of event an unsynced commit is lost to.
- `journal_mode` and `auto_vacuum` named explicitly. sqlx 0.9 no longer sets a journal mode (`// Don't set journal_mode unless the user requested it`), and it is a persistent property of the file — existing databases stay in WAL, a newly created one would have got a rollback journal.
- `Sqlite::create_database` is no longer called. It opens a connection with default settings, and the file it leaves behind is past the point where `auto_vacuum` can still be chosen; `create_if_missing` makes the first connection to a new file one that carries every setting. Found by the test, which reported `left: 0, right: 2`.

## Space reclamation (`db/cleanup.rs`)

VACUUM ran on a timer fixed at seven cleanup intervals and starting a full period out, so a default install rewrote the whole file every seven days whether or not there was anything to reclaim — and an agent restarted more often than that reclaimed nothing, ever. `reclaim_free_pages` asks the freelist at the end of each cleanup pass, and acts only above 25% of the file and 1024 pages: `incremental_vacuum` when the database was created for it, one full VACUUM otherwise, which also converts it, since VACUUM adopts the running connection's `auto_vacuum`.

Existing agents therefore reclaim on their first cleanup pass after upgrading and use the incremental path from then on.

## History window (`api/server.rs`)

The bound was `datetime('now', '-N minutes')`, output `2026-09-08 07:28:22`, compared as text against a column holding `2026-09-08T08:28:18.493098803+00:00`. `'T'` (0x54) sorts above `' '` (0x20), so the comparison only ever distinguished the date and every row from the boundary's day passed it. The factor is "seconds into the UTC day / 3600", reaching 24x before UTC midnight.

The response was unaffected: the handler keeps the newest `max_points` buckets, so the extra rows were work and nothing else. Binding a `DateTime<Utc>` gives the query the encoding `store_metrics` writes the column with.

## Tests

`tests/db_pragmas.rs`, new: every pooled connection carries the settings (four connections held open at once, since acquiring them in sequence returns the same one), a new database is laid out for incremental reclaim, reclaim gives back the pages a deletion freed, a small freelist is left alone.

`tests/metrics_history_points.rs`: the fixture wrote timestamps with `datetime('now', ...)`, a shape nothing in the agent produces — it agreed with the query and with nothing that ships, which is how the bound stayed wrong with every test in the file passing. It now binds a `DateTime<Utc>` the way `store_metrics` does. `a_row_from_earlier_today_is_outside_a_five_minute_window` is the regression test, checked against the old predicate to confirm it fails there. It skips, with a printed reason, during the first five minutes of a UTC day, when "earlier today" is inside the window and the defect has nothing to show.

`cargo test` for the monitor: 283 passing, 1 pre-existing ignored. clippy clean.

## `access_log` timestamp (`migrations/009`, `api/ws/audit.rs`)

Same class of mismatch, found while checking whether the history bound was the only one. `access_log.timestamp` was `DATETIME DEFAULT CURRENT_TIMESTAMP` — `2026-09-08 08:28:18` — while `cleanup_policy_tables` compares it against a bound `DateTime<Utc>`:

```
sqlite> SELECT '2026-06-10 16:45:23' < '2026-06-10T16:45:22.123+00:00';
1
sqlite> SELECT '2026-06-10T16:45:23+00:00' < '2026-06-10T16:45:22.123+00:00';
0
```

A row one second *inside* the retention window read as older than the cutoff, so up to a day of audit log past the cutoff was collected on each pass.

Migration 009 rebuilds the table with `timestamp TEXT NOT NULL` and converts the existing rows; `Event::record` now supplies the value. The default is dropped rather than corrected — `NOT NULL` with nothing to fall back on makes a writer that forgets the column fail at the insert, where a default producing the right text would be a second encoder to keep in step with chrono's. Two test fixtures were relying on that default and failed exactly that way.

No foreign key points at this table or out of it, so the rebuild needs no `foreign_keys` or `legacy_alter_table` handling. Nothing reads the column but retention, so the stored shape reaches no client. `the_audit_log_cutoff_is_a_moment_not_a_date` asserts one second either side of the boundary; migration 009's checksum is pinned in `shipped_migrations_keep_their_checksums`. `migration_009_converts_the_timestamps_already_in_access_log` runs the migration against a database that genuinely predates it — `migrator_through(8)` builds a `Migrator` from a prefix of the same `Migration` values, and the row is written through the pre-009 default rather than typed by the fixture. It asserts the converted text against the text that was there, plus the other columns, the index and AUTOINCREMENT across the rebuild, and was confirmed to fail with the conversion changed back to the old shape.

`users.last_login` and `retention_policies.last_cleanup` also use `CURRENT_TIMESTAMP` and are left alone: both are written and never compared, so the shape means nothing there.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed metrics history filtering so results are limited to the requested time window.
  - Corrected audit-log retention to use precise timestamps, preventing premature deletion of recent entries.
  - Standardized timestamp storage for consistent sorting and retention behavior.

- **Performance & Reliability**
  - Database cleanup now automatically reclaims unused storage.
  - Improved database initialization and connection reliability.
  - Reduced unnecessary database scanning during metrics queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
