### PR TITLE
fix(monitor): shorten the WAL after reclaiming

### DIFF
--- a/monitor/src/db/cleanup.rs
+++ b/monitor/src/db/cleanup.rs
@@ -183,15 +183,32 @@ impl DataCleanupService {
     /// whose file was already reclaimed still has the WAL that reclaiming
     /// left, and nothing else would ever shorten it.
     ///
-    /// Best effort. TRUNCATE answers with a row saying it was blocked rather
-    /// than failing, and a WAL that stays long for another day is worth less
-    /// than anything this would be worth interrupting.
+    /// Best effort, and a WAL that stays long for another day is worth less
+    /// than anything this would be worth interrupting — but the outcome is
+    /// read, because "blocked" is not an error here. A reader holding the WAL
+    /// makes TRUNCATE answer `busy = 1` and *succeed*, so discarding the row
+    /// leaves the one case worth knowing about looking exactly like the one
+    /// that worked: a WAL growing on disk with nothing in the log about it.
     async fn shorten_wal(&self) {
-        if let Err(e) = sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
-            .execute(&self.pool)
+        use sqlx::Row;
+
+        match sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
+            .fetch_one(&self.pool)
             .await
         {
-            warn!("Could not shorten the WAL: {}", e);
+            // (busy, log, checkpointed). `log` is the frames still in the WAL,
+            // which is what says how much was left behind.
+            Ok(row) => {
+                let busy: i64 = row.try_get("busy").unwrap_or_default();
+                if busy != 0 {
+                    let frames: i64 = row.try_get("log").unwrap_or_default();
+                    warn!(
+                        "Could not shorten the WAL: a reader held it, {} frames left",
+                        frames
+                    );
+                }
+            }
+            Err(e) => warn!("Could not shorten the WAL: {}", e),
         }
     }
 

--- a/monitor/src/db/cleanup.rs
+++ b/monitor/src/db/cleanup.rs
@@ -25,6 +25,7 @@ impl DataCleanupService {
         let policy_deleted = self.cleanup_policy_tables().await?;
         let size_deleted = self.enforce_db_size_limit().await?;
         let reclaimed = self.reclaim_free_pages().await?;
+        self.shorten_wal().await;
 
         let duration = start_time.elapsed();
         info!(
@@ -165,6 +166,33 @@ impl DataCleanupService {
             );
         }
         Ok(deleted_total)
+    }
+
+    /// Shorten the WAL file to `journal_size_limit`.
+    ///
+    /// A checkpoint resets the WAL, it does not shorten the file, so the file
+    /// stays as large as the largest transaction ever written through it —
+    /// and VACUUM writes the whole database through it. Measured on a real
+    /// agent upgrading: 84 MB reclaimed from the database and a 52 MB WAL left
+    /// where it went. `journal_size_limit` covers this on its own only when a
+    /// checkpoint gets to *reset* the WAL, which a passive one under a
+    /// connection pool often cannot, so this asks for the reset outright.
+    ///
+    /// A step of the cleanup pass rather than part of [`reclaim_free_pages`],
+    /// which returns early when there is nothing on the freelist: an agent
+    /// whose file was already reclaimed still has the WAL that reclaiming
+    /// left, and nothing else would ever shorten it.
+    ///
+    /// Best effort. TRUNCATE answers with a row saying it was blocked rather
+    /// than failing, and a WAL that stays long for another day is worth less
+    /// than anything this would be worth interrupting.
+    async fn shorten_wal(&self) {
+        if let Err(e) = sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)")
+            .execute(&self.pool)
+            .await
+        {
+            warn!("Could not shorten the WAL: {}", e);
+        }
     }
 
     async fn trim_oldest(&self, table: &'static str, keep: i64) -> Result<u64> {

--- a/monitor/src/db/database.rs
+++ b/monitor/src/db/database.rs
@@ -22,6 +22,24 @@ use tracing::info;
 /// in smaller pieces, so the ceiling is what to lower.
 const WAL_AUTOCHECKPOINT_PAGES: u32 = 128;
 
+/// Size the WAL file is truncated back to after a checkpoint that leaves it
+/// larger, in bytes.
+///
+/// A checkpoint resets the WAL, it does not shorten the file, and SQLite's
+/// default `journal_size_limit` of -1 means it never will — so the file stays
+/// as large as the largest transaction ever written through it. One
+/// transaction here is far larger than the rest: VACUUM rewrites the whole
+/// database, and `cleanup::reclaim_free_pages` runs one on the first pass
+/// after an upgrade. Measured on a real agent, that reclaimed 84 MB from the
+/// database and left a 52 MB WAL behind it, which is most of the point of
+/// reclaiming given back.
+///
+/// Twice [`WAL_AUTOCHECKPOINT_PAGES`] at the default 4 KiB page, so it is a
+/// backstop for the outlier rather than something that fires on every
+/// checkpoint: the WAL sits at roughly the autocheckpoint ceiling in normal
+/// use and never reaches this.
+const WAL_SIZE_LIMIT_BYTES: u32 = WAL_AUTOCHECKPOINT_PAGES * 4096 * 2;
+
 pub async fn init(database_url: &str) -> Result<SqlitePool> {
     // Logged, not created. `Sqlite::create_database` opens a connection of its
     // own with default settings, and the file it leaves behind is past the
@@ -78,5 +96,6 @@ fn connect_options(database_url: &str) -> Result<SqliteConnectOptions> {
             "wal_autocheckpoint",
             WAL_AUTOCHECKPOINT_PAGES.to_string(),
         )
+        .pragma("journal_size_limit", WAL_SIZE_LIMIT_BYTES.to_string())
         .busy_timeout(Duration::from_secs(30)))
 }

--- a/monitor/tests/db_pragmas.rs
+++ b/monitor/tests/db_pragmas.rs
@@ -13,10 +13,28 @@ use sqlx::{Row, SqlitePool};
 
 /// A pool over a fresh database file, plus the directory keeping it alive.
 async fn fresh_db() -> Result<(SqlitePool, tempfile::TempDir)> {
+    Ok(fresh_db_at().await?.0)
+}
+
+/// As [`fresh_db`], and the path of the file itself for the tests that weigh
+/// it.
+async fn fresh_db_at() -> Result<((SqlitePool, tempfile::TempDir), std::path::PathBuf)> {
     let dir = tempfile::tempdir()?;
     let path = dir.path().join("monitor.db");
     let pool = database::init(&format!("sqlite:{}", path.display())).await?;
-    Ok((pool, dir))
+    Ok(((pool, dir), path))
+}
+
+fn size_of(path: &std::path::Path) -> u64 {
+    std::fs::metadata(path).map(|m| m.len()).unwrap_or(0)
+}
+
+/// The WAL SQLite keeps beside `path`, which is the database's own name with
+/// `-wal` appended rather than a replaced extension.
+fn wal_path(path: &std::path::Path) -> std::path::PathBuf {
+    let mut name = path.as_os_str().to_os_string();
+    name.push("-wal");
+    name.into()
 }
 
 async fn pragma<T>(pool: &SqlitePool, stmt: &'static str) -> Result<T>
@@ -67,6 +85,17 @@ async fn every_pooled_connection_carries_the_settings() -> Result<()> {
             128,
             "connection {i} wal_autocheckpoint"
         );
+
+        let row = conn
+            .fetch_one("PRAGMA journal_size_limit")
+            .await
+            .map_err(anyhow::Error::from)?;
+        // -1 is SQLite's default and means "never shorten the file".
+        assert_eq!(
+            row.get::<i64, _>(0),
+            128 * 4096 * 2,
+            "connection {i} journal_size_limit"
+        );
     }
 
     Ok(())
@@ -97,9 +126,51 @@ async fn a_new_database_is_laid_out_for_incremental_reclaim() -> Result<()> {
 #[tokio::test]
 async fn reclaim_gives_back_the_pages_a_deletion_freed() -> Result<()> {
     let (pool, _dir) = fresh_db().await?;
+    let (before, freed) = fill_then_delete(&pool).await?;
 
-    // Padded so each row costs about a page: the reclaim threshold is stated
-    // in pages, and 2000 rows of real metrics would not reach it.
+    let cleanup = DataCleanupService::new(pool.clone(), DataRetentionConfig::default());
+    let reclaimed = cleanup.reclaim_free_pages().await?;
+    assert!(reclaimed > 0, "reclaimed nothing from {freed} free pages");
+
+    let after: i64 = pragma(&pool, "PRAGMA page_count").await?;
+    assert!(
+        after < before / 2,
+        "file went from {before} pages to {after} after deleting every row"
+    );
+
+    Ok(())
+}
+
+/// Reclaiming has to reach the filesystem, not move the space into the WAL.
+///
+/// VACUUM rewrites the database as one transaction, so the WAL comes out about
+/// the size of the database — and a checkpoint resets a WAL without shortening
+/// the file. On a real agent's first pass after upgrading that was 84 MB
+/// reclaimed and a 52 MB WAL sitting where it went, which is most of the gain
+/// handed straight back.
+#[tokio::test]
+async fn a_cleanup_pass_does_not_leave_the_reclaimed_space_in_the_wal() -> Result<()> {
+    let ((pool, _dir), path) = fresh_db_at().await?;
+    fill_then_delete(&pool).await?;
+
+    let cleanup = DataCleanupService::new(pool.clone(), DataRetentionConfig::default());
+    cleanup.cleanup_expired_data().await?;
+
+    let wal = size_of(&wal_path(&path));
+    assert!(
+        wal <= 128 * 4096 * 2,
+        "the WAL was left at {wal} bytes by the cleanup pass"
+    );
+
+    Ok(())
+}
+
+/// Enough rows to cross the reclaim threshold, then all of them deleted.
+/// Answers with the page count before the delete and the freelist after it.
+///
+/// Padded so each row costs about a page: the threshold is stated in pages,
+/// and 2000 rows of real metrics would not reach it.
+async fn fill_then_delete(pool: &SqlitePool) -> Result<(i64, i64)> {
     let padding = "x".repeat(4000);
     let mut tx = pool.begin().await?;
     for i in 0..2000 {
@@ -114,25 +185,14 @@ async fn reclaim_gives_back_the_pages_a_deletion_freed() -> Result<()> {
     }
     tx.commit().await?;
 
-    let before: i64 = pragma(&pool, "PRAGMA page_count").await?;
-    sqlx::query("DELETE FROM system_metrics").execute(&pool).await?;
-    let freed: i64 = pragma(&pool, "PRAGMA freelist_count").await?;
+    let before: i64 = pragma(pool, "PRAGMA page_count").await?;
+    sqlx::query("DELETE FROM system_metrics").execute(pool).await?;
+    let freed: i64 = pragma(pool, "PRAGMA freelist_count").await?;
     assert!(
         freed > 1024,
         "fixture freed only {freed} pages, below the reclaim threshold"
     );
-
-    let cleanup = DataCleanupService::new(pool.clone(), DataRetentionConfig::default());
-    let reclaimed = cleanup.reclaim_free_pages().await?;
-    assert!(reclaimed > 0, "reclaimed nothing from {freed} free pages");
-
-    let after: i64 = pragma(&pool, "PRAGMA page_count").await?;
-    assert!(
-        after < before / 2,
-        "file went from {before} pages to {after} after deleting every row"
-    );
-
-    Ok(())
+    Ok((before, freed))
 }
 
 /// Below the threshold nothing is rewritten. A cleanup pass runs on a timer


### PR DESCRIPTION
Follow-up to #1444, found by deploying it to a real agent instead of trusting the tests.

#1444 gave the space back to the database file and left it in the WAL. VACUUM rewrites the whole database as one transaction, and a checkpoint *resets* a WAL without shortening the file, so the file stays as large as the largest transaction ever written through it. On the agent taking that upgrade:

```
Data cleanup completed in 820ms. ... reclaimed 84152320 bytes
-rw-r--r-- 1 lk lk 52371456 serverbox_monitor.db
-rw-r--r-- 1 lk lk 52744272 serverbox_monitor.db-wal
```

84 MB reclaimed from a 136 MB database, 52 MB of it handed straight back. Since #1444 is what makes that VACUUM run on the first pass after upgrading, every existing agent with a freelist over the threshold lands here.

## Changes

**`journal_size_limit`** was missing beside `wal_autocheckpoint` — SQLite's default is -1, meaning never shorten. It is now twice the autocheckpoint ceiling (1 MiB at the default page size), so it is a backstop for the outlier rather than something that fires on every checkpoint; the WAL sits at roughly the ceiling in normal use and never reaches it.

**`shorten_wal`** because the pragma alone was not enough. It only applies when a checkpoint gets to reset the WAL, which a passive one under a connection pool often cannot — with the pragma set and nothing else, the test still ended with a 16 MB WAL. `PRAGMA wal_checkpoint(TRUNCATE)` asks for the reset outright. Best effort: TRUNCATE answers with a row saying it was blocked rather than failing.

It is a step of the cleanup pass, not part of `reclaim_free_pages`, which returns early when the freelist is empty. An agent that already took #1444 has a file needing nothing reclaimed and a WAL that reclaiming left behind; nesting it would mean nothing ever shortens that.

## Verification

Against the real agent, restored to the same 136,523,776 byte database and upgraded twice from that identical state:

| | #1444 | with this |
|---|---|---|
| database | 52,371,456 | 52,350,976 |
| WAL | 52,744,272 | **32,992** |
| on disk | 105.1 MB | 52.4 MB |

Steady state after a few minutes: WAL 296,672 bytes, database unchanged.

The read amplification #1444 set out to fix is unaffected — cold page cache, bytes read to append one metrics row:

| | bytes |
|---|---|
| before #1444 | 4,280,320 |
| after #1444 | 307,200 |
| with this | 311,296 |

60-second aggregate on the same agent, same method: device reads 1314 KB/s before #1444, 325 KB/s now.

## Tests

`a_cleanup_pass_does_not_leave_the_reclaimed_space_in_the_wal` builds the same fixture the reclaim test uses, runs a full cleanup pass and weighs the WAL file. Confirmed to fail with `shorten_wal` commented out, at 16,068,032 bytes. `every_pooled_connection_carries_the_settings` gains `journal_size_limit`.

`cargo test` for the monitor: 284 passing, 1 pre-existing ignored. clippy clean.

## Reading the checkpoint's answer

`shorten_wal` first used `execute()` and threw the result row away. A reader holding the WAL makes TRUNCATE answer `busy = 1` and *succeed*, so the one outcome worth knowing about looked exactly like the one that worked — a WAL growing on disk with nothing in the log. It now fetches the row and warns on a non-zero `busy`, reporting `log` (the frames still in the WAL) so the message says how much was left behind. Errors are reported as before.

Confirmed rather than taken from the documentation — a second connection holding a read snapshot over a non-empty WAL:

```
$ sqlite3 -header wt.db "PRAGMA busy_timeout=300; PRAGMA wal_checkpoint(TRUNCATE);"
busy|log|checkpointed
1|1|0
exit=0
```

Not covered by a test: asserting it would mean holding a read transaction open across the pool's 30-second `busy_timeout` and capturing a tracing subscriber, for a log line. The behaviour it rests on is the output above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Database cleanup now reclaims unused storage more effectively.
  - Write-ahead log files are kept within a bounded size after cleanup and checkpointing.
- **Reliability**
  - Cleanup continues when write-ahead log truncation cannot be completed.
- **Diagnostics**
  - Cleanup records when checkpoints are blocked and reports remaining log frames.
  - Log truncation errors are recorded without interrupting the cleanup workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
