### PR TITLE
fix(windows): startup and Agent command review issues

### DIFF
--- a/crates/sbm_parser/src/commands.rs
+++ b/crates/sbm_parser/src/commands.rs
@@ -228,7 +228,15 @@ pub const WINDOWS: &[CommandSpec] = &[
         key: NET,
         cmd: r#"$s1 = @(Get-WmiObject Win32_PerfRawData_Tcpip_NetworkInterface | Select-Object Name, BytesReceivedPersec, BytesSentPersec, Timestamp_Sys100NS); Start-Sleep -Seconds 1; $s2 = @(Get-WmiObject Win32_PerfRawData_Tcpip_NetworkInterface | Select-Object Name, BytesReceivedPersec, BytesSentPersec, Timestamp_Sys100NS); @($s1, $s2) | ConvertTo-Json -Depth 5"#,
     },
-    CommandSpec { key: SYS, cmd: "(Get-ComputerInfo).OsName" },
+    // `Get-ComputerInfo` emits progress records while it assembles the full
+    // object. Through Windows OpenSSH those records can arrive as CLIXML on
+    // stdout, so the status page displayed `<Objs Version="1.1.0.1" ...>` as
+    // the operating system. The CIM property is the same value without the
+    // progress stream.
+    CommandSpec {
+        key: SYS,
+        cmd: "(Get-CimInstance Win32_OperatingSystem).Caption",
+    },
     CommandSpec {
         key: CPU,
         cmd: "Get-WmiObject -Class Win32_Processor | Select-Object Name, LoadPercentage, NumberOfCores, NumberOfLogicalProcessors | ConvertTo-Json",

--- a/crates/sbm_parser/tests/script_compat.rs
+++ b/crates/sbm_parser/tests/script_compat.rs
@@ -468,6 +468,13 @@ fn script_headers() {
     assert!(unix.contains("export LANG=en_US.UTF-8"));
 }
 
+#[test]
+fn windows_system_name_does_not_emit_get_computer_info_progress() {
+    let win = build_script(SystemType::Windows, &opts());
+    assert!(win.contains("(Get-CimInstance Win32_OperatingSystem).Caption"));
+    assert!(!win.contains("(Get-ComputerInfo).OsName"));
+}
+
 /// Dart 'scripts handle all system types properly': env probes + Bsd == Linux
 #[test]
 fn system_types_and_probes() {

--- a/lib/data/model/app/scripts/script_consts.dart
+++ b/lib/data/model/app/scripts/script_consts.dart
@@ -22,7 +22,7 @@ class ScriptConstants {
   /// and then a hand-maintained number in *two* files with a test holding them
   /// level, because `fl_build` regenerates `BuildData` and drops anything it
   /// was not fed.
-  static const int version = 77;
+  static const int version = 78;
 
   static const String scriptFile = 'srvboxm_v$version.sh';
   static const String scriptFileWindows = 'srvboxm_v$version.ps1';

--- a/lib/data/provider/ai/agent_session.dart
+++ b/lib/data/provider/ai/agent_session.dart
@@ -488,8 +488,9 @@ class AgentSession extends _$AgentSession {
   /// but a terminal's.
   Future<bool> insertPendingTool() async {
     final proposal = state.pendingTool;
-    if (proposal == null || !await _preparePendingTool(proposal)) return false;
+    if (proposal == null || state.isExecuting) return false;
     if (!_host.insert(proposal.command)) return false;
+    if (!await _preparePendingTool(proposal)) return false;
     state = state.copyWith(
       history: [
         ...state.history,

--- a/lib/data/provider/ai/agent_session.dart
+++ b/lib/data/provider/ai/agent_session.dart
@@ -141,6 +141,10 @@ class AgentSessionState {
 
   bool get isWorking => isStreaming || isExecuting;
 
+  /// A complete tool proposal can be reviewed even when a compatible API
+  /// leaves its SSE response open after sending the function-call arguments.
+  bool get canReviewPendingTool => pendingTool != null && !isExecuting;
+
   bool get isEmpty => timeline.isEmpty && !isStreaming && pendingTool == null;
 
   AgentSessionState copyWith({
@@ -383,7 +387,7 @@ class AgentSession extends _$AgentSession {
   /// that allows auto-running already excludes everything that needs asking.
   Future<void> runPendingTool({bool autoApproved = false}) async {
     final proposal = state.pendingTool;
-    if (proposal == null || state.isWorking) return;
+    if (proposal == null || !await _preparePendingTool(proposal)) return;
 
     state = state.copyWith(
       isExecuting: true,
@@ -451,7 +455,7 @@ class AgentSession extends _$AgentSession {
 
   Future<void> declinePendingTool() async {
     final proposal = state.pendingTool;
-    if (proposal == null || state.isWorking) return;
+    if (proposal == null || !await _preparePendingTool(proposal)) return;
     state = state.copyWith(
       history: [
         ...state.history,
@@ -484,7 +488,7 @@ class AgentSession extends _$AgentSession {
   /// but a terminal's.
   Future<bool> insertPendingTool() async {
     final proposal = state.pendingTool;
-    if (proposal == null || state.isWorking) return false;
+    if (proposal == null || !await _preparePendingTool(proposal)) return false;
     if (!_host.insert(proposal.command)) return false;
     state = state.copyWith(
       history: [
@@ -505,6 +509,43 @@ class AgentSession extends _$AgentSession {
     );
     await _persist();
     return true;
+  }
+
+  /// Makes an already complete proposal actionable when the provider has not
+  /// closed its SSE response yet.
+  ///
+  /// Tool suggestions are only emitted after their arguments parse into a
+  /// complete [AskAiCommand]. Some OpenAI-compatible providers then keep the
+  /// stream open instead of sending the final completion event. Waiting for
+  /// that event left every review action disabled until the app restarted.
+  /// Stopping at the complete proposal preserves the assistant text and the
+  /// function call that the missing completion would have stored.
+  Future<bool> _preparePendingTool(AskAiCommand proposal) async {
+    if (!identical(state.pendingTool, proposal) || state.isExecuting) {
+      return false;
+    }
+    if (!state.isStreaming) return true;
+
+    final text = (state.streamingContent ?? '').trim();
+    final subscription = _subscription;
+    _subscription = null;
+    state = state.copyWith(
+      turnCompleted: true,
+      isStreaming: false,
+      streamingContent: null,
+      history: [
+        ...state.history,
+        if (text.isNotEmpty) AskAiMessageItem.assistant(text),
+        AskAiFunctionCallItem(command: proposal),
+      ],
+      timeline: text.isNotEmpty
+          ? [...state.timeline, AgentAssistantEntry(text)]
+          : null,
+      error: null,
+    );
+    await subscription?.cancel();
+    await _persist();
+    return identical(state.pendingTool, proposal) && !state.isExecuting;
   }
 
   Future<void> stopWork() async {

--- a/lib/view/page/agent/view.dart
+++ b/lib/view/page/agent/view.dart
@@ -952,16 +952,16 @@ class _AgentConversationViewState extends ConsumerState<AgentConversationView> {
               mainAxisAlignment: MainAxisAlignment.end,
               children: [
                 TextButton(
-                  onPressed: session.isWorking
-                      ? null
-                      : () => unawaited(_notifier.declinePendingTool()),
+                  onPressed: session.canReviewPendingTool
+                      ? () => unawaited(_notifier.declinePendingTool())
+                      : null,
                   child: Text(context.l10n.askAiDecline),
                 ),
                 const SizedBox(width: 8),
                 FilledButton.icon(
-                  onPressed: session.isWorking
-                      ? null
-                      : () => _runPendingTool(proposal),
+                  onPressed: session.canReviewPendingTool
+                      ? () => _runPendingTool(proposal)
+                      : null,
                   icon: const Icon(Icons.play_arrow, size: 18),
                   label: Text(context.l10n.askAiApproveRun),
                 ),

--- a/lib/view/page/ssh/ask_ai_layout.dart
+++ b/lib/view/page/ssh/ask_ai_layout.dart
@@ -4,6 +4,10 @@ enum AskAiHistoryPresentation { bottomSheet, dialog }
 
 const askAiSidePanelBreakpoint = 800.0;
 
+double askAiCommandPreviewMaxHeightFor(double viewportHeight) {
+  return (viewportHeight * 0.3).clamp(120.0, 240.0);
+}
+
 AskAiPanelPlacement askAiPanelPlacementForWidth(double width) {
   return width >= askAiSidePanelBreakpoint
       ? AskAiPanelPlacement.sidePanel

--- a/lib/view/page/ssh/page/ask_ai.dart
+++ b/lib/view/page/ssh/page/ask_ai.dart
@@ -724,7 +724,7 @@ class _AskAiPanelState extends ConsumerState<_AskAiPanel> {
     AgentSessionState session,
   ) {
     final command = session.pendingTool!;
-    final working = session.isWorking;
+    final canReview = session.canReviewPendingTool;
     final (label, color, icon) = switch (command.risk) {
       AskAiCommandRisk.readOnly => (
         context.l10n.askAiRiskReadOnly,
@@ -830,23 +830,23 @@ class _AskAiPanelState extends ConsumerState<_AskAiPanel> {
             alignment: WrapAlignment.end,
             children: [
               TextButton(
-                onPressed: working ? null : _notifier.declinePendingTool,
+                onPressed: canReview ? _notifier.declinePendingTool : null,
                 child: Text(context.l10n.askAiDecline),
               ),
               TextButton.icon(
-                onPressed: working
-                    ? null
-                    : () => copyAgentText(command.command),
+                onPressed: canReview
+                    ? () => copyAgentText(command.command)
+                    : null,
                 icon: const Icon(Icons.copy, size: 17),
                 label: Text(libL10n.copy),
               ),
               OutlinedButton.icon(
-                onPressed: working ? null : _insertPendingCommand,
+                onPressed: canReview ? _insertPendingCommand : null,
                 icon: const Icon(Icons.keyboard_return, size: 17),
                 label: Text(context.l10n.askAiInsertTerminal),
               ),
               FilledButton.icon(
-                onPressed: working ? null : () => _runPendingCommand(command),
+                onPressed: canReview ? () => _runPendingCommand(command) : null,
                 icon: const Icon(Icons.play_arrow, size: 18),
                 label: Text(context.l10n.askAiApproveRun),
               ),

--- a/lib/view/page/ssh/page/ask_ai.dart
+++ b/lib/view/page/ssh/page/ask_ai.dart
@@ -72,8 +72,7 @@ extension _AskAi on SSHPageState {
     // instead measured the window, so the same 800 landed about a rail's width
     // earlier here than everywhere else: on an iPad in portrait this opened
     // beside the terminal while the server list still had one column.
-    final width =
-        context.size?.width ?? MediaQuery.sizeOf(context).width;
+    final width = context.size?.width ?? MediaQuery.sizeOf(context).width;
     final placement = askAiPanelPlacementForWidth(width);
 
     // The panel's tools act on a server, so there has to be one. A terminal on
@@ -250,6 +249,7 @@ extension _AskAi on SSHPageState {
     if (session != null) await _terminateAiCommandSession(session);
   }
 }
+
 /// The Agent for one server, shown beside its terminal.
 ///
 /// A view onto [agentSessionProvider] and nothing more: the conversation, the
@@ -893,10 +893,6 @@ class _AskAiPanelState extends ConsumerState<_AskAiPanel> {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          if (session.pendingTool != null) ...[
-            _buildProposalCard(context, theme, session),
-            const SizedBox(height: 8),
-          ],
           if (error != null) ...[
             AgentErrorBanner(
               message: describeAgentError(context, error),
@@ -1004,6 +1000,10 @@ class _AskAiPanelState extends ConsumerState<_AskAiPanel> {
                   ],
                   if (session.isStreaming)
                     _buildStreamingBubble(context, theme, session),
+                  if (session.pendingTool != null) ...[
+                    _buildProposalCard(context, theme, session),
+                    const SizedBox(height: 10),
+                  ],
                 ],
               ),
             ),

--- a/lib/view/page/ssh/page/ask_ai.dart
+++ b/lib/view/page/ssh/page/ask_ai.dart
@@ -279,6 +279,7 @@ class _AskAiPanel extends ConsumerStatefulWidget {
 
 class _AskAiPanelState extends ConsumerState<_AskAiPanel> {
   final _scrollController = ScrollController();
+  final _commandPreviewScrollController = ScrollController();
   final _inputController = TextEditingController();
   bool _autoStarted = false;
 
@@ -307,6 +308,7 @@ class _AskAiPanelState extends ConsumerState<_AskAiPanel> {
     // session, which outlives this panel on purpose: closing it used to cancel
     // whatever was streaming, which is not what closing a window means.
     _scrollController.dispose();
+    _commandPreviewScrollController.dispose();
     _inputController
       ..removeListener(_handleInputChanged)
       ..dispose();
@@ -725,6 +727,9 @@ class _AskAiPanelState extends ConsumerState<_AskAiPanel> {
   ) {
     final command = session.pendingTool!;
     final canReview = session.canReviewPendingTool;
+    final commandPreviewMaxHeight = askAiCommandPreviewMaxHeightFor(
+      MediaQuery.sizeOf(context).height,
+    );
     final (label, color, icon) = switch (command.risk) {
       AskAiCommandRisk.readOnly => (
         context.l10n.askAiRiskReadOnly,
@@ -793,14 +798,24 @@ class _AskAiPanelState extends ConsumerState<_AskAiPanel> {
           const SizedBox(height: 10),
           Container(
             width: double.infinity,
+            constraints: BoxConstraints(maxHeight: commandPreviewMaxHeight),
             padding: const EdgeInsets.all(10),
             decoration: BoxDecoration(
               color: theme.colorScheme.surface,
               borderRadius: BorderRadius.circular(9),
             ),
-            child: SelectableText(
-              command.command,
-              style: const TextStyle(fontFamily: 'monospace', fontSize: 12.5),
+            child: Scrollbar(
+              controller: _commandPreviewScrollController,
+              child: SingleChildScrollView(
+                controller: _commandPreviewScrollController,
+                child: SelectableText(
+                  command.command,
+                  style: const TextStyle(
+                    fontFamily: 'monospace',
+                    fontSize: 12.5,
+                  ),
+                ),
+              ),
             ),
           ),
           if (command.description.isNotEmpty) ...[

--- a/test/agent_scope_test.dart
+++ b/test/agent_scope_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:fl_lib/fl_lib.dart';
@@ -189,6 +190,41 @@ void main() {
   );
 
   test(
+    'a complete proposal remains reviewable when the stream stays open',
+    () async {
+      final repository = _HangingProposalRepository(proposal);
+      addTearDown(repository.close);
+      final container = ProviderContainer(
+        overrides: [askAiRepositoryProvider.overrideWithValue(repository)],
+      );
+      addTearDown(container.dispose);
+      final t = terminal();
+      container.read(agentScopeHostsProvider).register('srv-open', t.host);
+      final notifier = container.read(
+        agentSessionProvider('srv-open').notifier,
+      );
+
+      await notifier.submitPrompt('check uptime');
+      await settle();
+
+      final waiting = container.read(agentSessionProvider('srv-open'));
+      expect(waiting.isStreaming, isTrue);
+      expect(waiting.pendingTool, proposal);
+      expect(waiting.canReviewPendingTool, isTrue);
+
+      expect(await notifier.insertPendingTool(), isTrue);
+      final reviewed = container.read(agentSessionProvider('srv-open'));
+      expect(t.inserted, ['uptime']);
+      expect(reviewed.isStreaming, isFalse);
+      expect(reviewed.pendingTool, isNull);
+      expect(
+        reviewed.history.whereType<AskAiFunctionCallItem>().single.command,
+        proposal,
+      );
+    },
+  );
+
+  test(
     'a command approved after the terminal closed says so, and does not throw',
     () async {
       final h = harness();
@@ -324,5 +360,34 @@ class _ProposingRepository extends AskAiRepository {
         protocol: protocol ?? AskAiProtocol.chatCompletions,
       ),
     ]);
+  }
+}
+
+class _HangingProposalRepository extends AskAiRepository {
+  _HangingProposalRepository(this.proposal);
+
+  final AskAiCommand proposal;
+  final _controller = StreamController<AskAiEvent>();
+
+  Future<void> close() => _controller.close();
+
+  @override
+  Stream<AskAiEvent> ask({
+    required String terminalContext,
+    required String serverName,
+    String? localeHint,
+    List<AskAiConversationItem> conversation = const [],
+    AskAiProtocol? protocol,
+    String? customInstructions,
+    List<AskAiToolDefinition> tools = const [
+      AskAiToolDefinition.runShellCommand,
+    ],
+  }) {
+    scheduleMicrotask(() {
+      _controller
+        ..add(const AskAiContentDelta('Let me look.'))
+        ..add(AskAiToolSuggestion(proposal));
+    });
+    return _controller.stream;
   }
 }

--- a/test/agent_scope_test.dart
+++ b/test/agent_scope_test.dart
@@ -300,6 +300,30 @@ void main() {
         reason: 'refusing to insert must not also drop the proposal',
       );
     });
+
+    test('a refused insert leaves an open response running', () async {
+      final repository = _HangingProposalRepository(proposal);
+      final container = ProviderContainer(
+        overrides: [askAiRepositoryProvider.overrideWithValue(repository)],
+      );
+      const scope = 'srv-refused-open';
+      final provider = agentSessionProvider(scope);
+      final notifier = container.read(provider.notifier);
+      addTearDown(() async {
+        await notifier.stopWork();
+        await repository.close();
+        container.dispose();
+      });
+
+      expect(await notifier.submitPrompt('check uptime'), isTrue);
+      await settle();
+
+      expect(await notifier.insertPendingTool(), isFalse);
+      final state = container.read(provider);
+      expect(state.isStreaming, isTrue);
+      expect(state.pendingTool, proposal);
+      expect(state.history.whereType<AskAiFunctionCallItem>(), isEmpty);
+    });
   });
 
   test(

--- a/test/ask_ai_layout_test.dart
+++ b/test/ask_ai_layout_test.dart
@@ -2,6 +2,18 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:server_box/view/page/ssh/ask_ai_layout.dart';
 
 void main() {
+  group('askAiCommandPreviewMaxHeightFor', () {
+    test('uses thirty percent of compact viewport heights', () {
+      expect(askAiCommandPreviewMaxHeightFor(400), 120);
+      expect(askAiCommandPreviewMaxHeightFor(600), 180);
+    });
+
+    test('caps tall viewport previews so review actions stay nearby', () {
+      expect(askAiCommandPreviewMaxHeightFor(800), 240);
+      expect(askAiCommandPreviewMaxHeightFor(1200), 240);
+    });
+  });
+
   group('askAiPanelPlacementForWidth', () {
     test('uses bottom sheet on phone and narrow tablet widths', () {
       expect(askAiPanelPlacementForWidth(390), AskAiPanelPlacement.bottomSheet);

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -2,6 +2,8 @@
 #include <flutter/flutter_view_controller.h>
 #include <windows.h>
 
+#include <string>
+
 #include "flutter_window.h"
 #include "utils.h"
 
@@ -11,14 +13,23 @@ constexpr wchar_t kSingleInstanceMutex[] =
     L"Local\\tech.lolli.toolbox.ServerBox.SingleInstance";
 constexpr wchar_t kWindowClassName[] = L"FLUTTER_RUNNER_WIN32_WINDOW";
 constexpr wchar_t kWindowTitle[] = L"ServerBox";
+constexpr DWORD kExistingWindowWaitTimeoutMs = 5000;
+constexpr DWORD kExistingWindowPollIntervalMs = 50;
 
-void ActivateExistingWindow() {
-  const HWND window = FindWindowW(kWindowClassName, kWindowTitle);
-  if (window == nullptr) {
-    return;
+bool ActivateExistingWindow() {
+  const ULONGLONG deadline = GetTickCount64() + kExistingWindowWaitTimeoutMs;
+  while (true) {
+    const HWND window = FindWindowW(kWindowClassName, kWindowTitle);
+    if (window != nullptr) {
+      ShowWindowAsync(window, IsIconic(window) ? SW_RESTORE : SW_SHOW);
+      SetForegroundWindow(window);
+      return true;
+    }
+    if (GetTickCount64() >= deadline) {
+      return false;
+    }
+    Sleep(kExistingWindowPollIntervalMs);
   }
-  ShowWindowAsync(window, IsIconic(window) ? SW_RESTORE : SW_SHOW);
-  SetForegroundWindow(window);
 }
 
 }  // namespace
@@ -33,10 +44,18 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
 
   const HANDLE single_instance =
       CreateMutexW(nullptr, FALSE, kSingleInstanceMutex);
-  if (single_instance != nullptr && GetLastError() == ERROR_ALREADY_EXISTS) {
-    ActivateExistingWindow();
+  const DWORD mutex_error = GetLastError();
+  if (single_instance == nullptr) {
+    const std::wstring message =
+        L"CreateMutexW failed with Win32 error " +
+        std::to_wstring(mutex_error) + L".\n";
+    OutputDebugStringW(message.c_str());
+    return EXIT_FAILURE;
+  }
+  if (mutex_error == ERROR_ALREADY_EXISTS) {
+    const bool activated = ActivateExistingWindow();
     CloseHandle(single_instance);
-    return EXIT_SUCCESS;
+    return activated ? EXIT_SUCCESS : EXIT_FAILURE;
   }
 
   // Initialize COM, so that it is available for use in the library and/or

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -5,12 +5,38 @@
 #include "flutter_window.h"
 #include "utils.h"
 
+namespace {
+
+constexpr wchar_t kSingleInstanceMutex[] =
+    L"Local\\tech.lolli.toolbox.ServerBox.SingleInstance";
+constexpr wchar_t kWindowClassName[] = L"FLUTTER_RUNNER_WIN32_WINDOW";
+constexpr wchar_t kWindowTitle[] = L"ServerBox";
+
+void ActivateExistingWindow() {
+  const HWND window = FindWindowW(kWindowClassName, kWindowTitle);
+  if (window == nullptr) {
+    return;
+  }
+  ShowWindowAsync(window, IsIconic(window) ? SW_RESTORE : SW_SHOW);
+  SetForegroundWindow(window);
+}
+
+}  // namespace
+
 int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
                       _In_ wchar_t *command_line, _In_ int show_command) {
   // Attach to console when present (e.g., 'flutter run') or create a
   // new console when running with a debugger.
   if (!::AttachConsole(ATTACH_PARENT_PROCESS) && ::IsDebuggerPresent()) {
     CreateAndAttachConsole();
+  }
+
+  const HANDLE single_instance =
+      CreateMutexW(nullptr, FALSE, kSingleInstanceMutex);
+  if (single_instance != nullptr && GetLastError() == ERROR_ALREADY_EXISTS) {
+    ActivateExistingWindow();
+    CloseHandle(single_instance);
+    return EXIT_SUCCESS;
   }
 
   // Initialize COM, so that it is available for use in the library and/or
@@ -27,7 +53,10 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(400, 777);
-  if (!window.CreateAndShow(L"ServerBox", origin, size)) {
+  if (!window.CreateAndShow(kWindowTitle, origin, size)) {
+    if (single_instance != nullptr) {
+      CloseHandle(single_instance);
+    }
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);
@@ -39,5 +68,8 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   }
 
   ::CoUninitialize();
+  if (single_instance != nullptr) {
+    CloseHandle(single_instance);
+  }
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Summary

- avoid PowerShell CLIXML progress output when reading the Windows system name
- keep terminal Agent command reviews reachable in compact layouts
- allow complete tool proposals to be reviewed before an SSE stream closes
- reuse and restore the existing Windows app instance on a second launch
- constrain long command previews to a scrollable area

## Testing

- `flutter analyze --no-pub lib test`
- `flutter test --no-pub test/windows_test.dart test/script_version_test.dart test/ask_ai_layout_test.dart test/agent_scope_test.dart test/agent_session_test.dart test/agent_view_test.dart`
- `cargo test -p sbm_parser windows_system_name_does_not_emit_get_computer_info_progress`
- `flutter build windows --debug --no-pub`

Closes #1419
Closes #1421
Closes #1423
Closes #1442
Closes #1443

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - AI tool proposals can be reviewed, approved, declined, or inserted while responses are still streaming.
  - Ask AI proposals appear in the conversation timeline, with scrollable command previews that adapt to screen size.
  - Windows prevents multiple app instances and brings the existing window forward.

- **Bug Fixes**
  - Improved Windows system-information detection to avoid unwanted output in generated scripts.
  - Preserved pending proposals and active responses when insertion is unavailable.
  - Updated generated script versions for compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->