### PR TITLE
fix(diag): stop a disposed provider writing state, and scrub what a report carries

### DIFF
--- a/lib/core/service/crash_report.dart
+++ b/lib/core/service/crash_report.dart
@@ -6,9 +6,9 @@ import 'package:dio/dio.dart';
 import 'package:fl_lib/fl_lib.dart';
 import 'package:flutter/foundation.dart';
 import 'package:server_box/core/service/diagnostics_upload.dart';
+import 'package:server_box/core/service/known_identifiers.dart';
 import 'package:server_box/core/service/native_exit.dart';
 import 'package:server_box/core/utils/ssh_file_backend.dart';
-import 'package:server_box/data/model/server/server_private_info.dart';
 import 'package:server_box/data/res/build_data.dart';
 import 'package:server_box/data/res/store.dart';
 
@@ -93,7 +93,7 @@ abstract final class CrashReport {
     build: BuildData.build,
     os: '${Pfs.type.name} ${Platform.operatingSystemVersion}',
     locale: Platform.localeName,
-    identifiers: knownIdentifiers(Stores.server.fetch()),
+    identifiers: KnownIdentifiers.of(Stores.server.fetch()),
     previousExit: NativeExitReport.lastExit,
     previousExitTrace: NativeExitReport.lastExitTrace,
   );
@@ -202,47 +202,6 @@ abstract final class CrashReport {
     );
   }
 
-  /// Every string this install knows to be the user's, and what replaces it.
-  ///
-  /// Precise rather than pattern-based, which is the whole point. A regex for
-  /// "things that look like a host" both misses — a machine called `nas` is
-  /// not a pattern — and overreaches, since a package name in a stack trace
-  /// looks like a domain. The app holds the actual records, so it can replace
-  /// exactly the strings that came out of them.
-  ///
-  /// This is what makes the log readable in the Logs page and safe in a
-  /// report: the two readers want opposite things, and the split belongs here
-  /// rather than at the point the line was written.
-  ///
-  /// Numbered rather than hashed. A reader following one server through a log
-  /// needs to see the same token twice; they do not need it to mean anything.
-  @visibleForTesting
-  static Map<String, String> knownIdentifiers(List<Spi> servers) {
-    final out = <String, String>{};
-    for (var i = 0; i < servers.length; i++) {
-      final spi = servers[i];
-      final n = i + 1;
-      _addIdentifier(out, spi.name, '<server-$n>');
-      _addIdentifier(out, spi.ssh?.ip, '<host-$n>');
-      _addIdentifier(out, spi.ssh?.user, '<user-$n>');
-      _addIdentifier(out, spi.monitorHttp?.addr, '<agent-$n>');
-    }
-    return out;
-  }
-
-  /// Too short to substitute safely is left alone: a two-character name occurs
-  /// inside ordinary words, and replacing it would corrupt the log rather than
-  /// redact it. Such a name identifies little in any case.
-  static void _addIdentifier(
-    Map<String, String> out,
-    String? value,
-    String replacement,
-  ) {
-    final trimmed = value?.trim();
-    if (trimmed == null || trimmed.length < 3) return;
-    out[trimmed] = replacement;
-  }
-
   @visibleForTesting
   static String compose({
     required String? log,
@@ -281,7 +240,9 @@ abstract final class CrashReport {
       buf.writeln('### Previous exit trace');
       buf.writeln();
       buf.writeln('```');
-      buf.writeln(_substitute(previousExitTrace.trimRight(), identifiers));
+      buf.writeln(
+        KnownIdentifiers.substitute(previousExitTrace.trimRight(), identifiers),
+      );
       buf.writeln('```');
       buf.writeln();
     }
@@ -296,7 +257,7 @@ abstract final class CrashReport {
       return buf.toString();
     }
 
-    var body = _substitute(log, identifiers);
+    var body = KnownIdentifiers.substitute(log, identifiers);
     var truncated = false;
     if (body.length > maxLogChars) {
       body = body.substring(body.length - maxLogChars);
@@ -314,32 +275,6 @@ abstract final class CrashReport {
     buf.writeln(body.trimRight());
     buf.writeln('```');
     return buf.toString();
-  }
-
-  /// Applies [identifiers] in a single pass, longest match first.
-  ///
-  /// One pass, and that is the point rather than an optimisation. Replacing
-  /// key by key means each pass can match inside a placeholder an earlier pass
-  /// wrote: with servers named `prod-server` and `server`, the first becomes
-  /// `<server-1>`, and the second's pass then rewrites the `server` inside it
-  /// into `<<server-2>-1>`. The same happens to anything named `host`, `user`
-  /// or `agent`. A scan over the original text can only match the original
-  /// text.
-  ///
-  /// Longest first is still needed, for a different overlap: a machine called
-  /// `db` and one called `db-prod` both match at the same position, and the
-  /// short one winning would leave `<server-1>-prod` — still disclosing
-  /// `-prod`, and no longer showing that two lines named different machines.
-  /// Alternation in a Dart regex is ordered, so sorting decides it.
-  static String _substitute(String text, Map<String, String> identifiers) {
-    if (identifiers.isEmpty) return text;
-    final keys = identifiers.keys.toList()
-      ..sort((a, b) => b.length.compareTo(a.length));
-    final pattern = RegExp(keys.map(RegExp.escape).join('|'));
-    return text.replaceAllMapped(
-      pattern,
-      (m) => identifiers[m[0]] ?? m[0]!,
-    );
   }
 }
 

--- a/lib/core/service/diagnostics_upload.dart
+++ b/lib/core/service/diagnostics_upload.dart
@@ -144,8 +144,9 @@ abstract final class DiagnosticsUpload {
         // report needs, and are the SDK guessing at context rather than this
         // app supplying it.
         options.attachThreads = false;
-        // The last thing every event passes through — see [scrub].
-        options.beforeSend = (event, hint) => _scrubWithStoredIdentifiers(event);
+        // The last thing every event passes through, and what decides whether
+        // it goes at all — see [scrubWithStoredIdentifiers].
+        options.beforeSend = (event, hint) => scrubWithStoredIdentifiers(event);
       });
       // Before the sink is installed, so the first error to arrive already
       // says what it arrived from. The pure-Dart SDK cannot work this out for
@@ -213,23 +214,33 @@ abstract final class DiagnosticsUpload {
     }
   }
 
-  /// [scrub], with what this install currently knows to be the user's.
+  /// [scrub], with what this install currently knows to be the user's — or
+  /// null, which drops the event.
   ///
   /// Read per event rather than kept: a server added since launch is one whose
   /// name would otherwise still go out. It is a store read on the way to the
   /// network, which is not a hot path — an event is a crash.
-  static sentry.SentryEvent _scrubWithStoredIdentifiers(
+  ///
+  /// **An event this cannot promise to have scrubbed does not go.** The
+  /// records are the whole of what separates a report from a disclosure, so
+  /// sending one without them would upload an unaudited string on the single
+  /// path where nothing was able to check it. The failure is narrow — an error
+  /// raised from an isolate that never opened a store, or while the app is
+  /// coming down — and what is given up is one report, while the error is
+  /// still written to the on-device log by the sink beside this one.
+  ///
+  /// An install with *no servers* is not this case. It has nothing to
+  /// substitute, and its events go as they are.
+  @visibleForTesting
+  static sentry.SentryEvent? scrubWithStoredIdentifiers(
     sentry.SentryEvent event,
   ) {
-    var identifiers = const <String, String>{};
+    final Map<String, String> identifiers;
     try {
       identifiers = KnownIdentifiers.of(Stores.server.fetch());
     } catch (e, s) {
-      // An error reported from an isolate with no store, or from before one is
-      // open. The SDK treats a throw in `beforeSend` as "send it unchanged",
-      // so catching here is what makes [scrub] still run for the parts that
-      // need no records at all.
       Loggers.app.warning('Could not read what to scrub from a report', e, s);
+      return null;
     }
     return scrub(event, identifiers);
   }

--- a/lib/core/service/diagnostics_upload.dart
+++ b/lib/core/service/diagnostics_upload.dart
@@ -146,6 +146,14 @@ abstract final class DiagnosticsUpload {
         options.attachThreads = false;
         // The last thing every event passes through, and what decides whether
         // it goes at all — see [scrubWithStoredIdentifiers].
+        //
+        // A transaction comes here too, and only because `beforeSendTransaction`
+        // is left unset: `SentryClient._runBeforeSend` tries that callback
+        // first and falls through to this one when it is null. Setting it would
+        // be a second entry point for a kind of event nothing in this app
+        // produces — no `startTransaction` call exists here or in fl_lib, and
+        // the pure-Dart SDK auto-instruments nothing. If one is ever started,
+        // its spans need covering as well, which is a different function.
         options.beforeSend = (event, hint) => scrubWithStoredIdentifiers(event);
       });
       // Before the sink is installed, so the first error to arrive already
@@ -260,6 +268,19 @@ abstract final class DiagnosticsUpload {
   /// removes what this install *knows* is the user's and never guesses. Text
   /// nothing here can attribute goes out as written; the class of errors that
   /// quote a hostname is what the levels and the opt-in are for.
+  ///
+  /// **Three fields of a `SentryEvent` are deliberately not touched**, each
+  /// because reaching it would be writing against something that does not
+  /// happen here rather than covering a path:
+  ///
+  /// - `extra` is deprecated in this SDK and nothing in this app writes one.
+  /// - `contexts` is filled by [DiagnosticsPlatform], whose entire purpose is
+  ///   deciding what may go in it — hardware and OS release, no name, no
+  ///   identifier — and by the SDK's own `app`, `runtime` and `culture`. It
+  ///   holds typed objects rather than free text.
+  /// - `request` is set by an HTTP integration, and the pure-Dart SDK has
+  ///   none. Adding `sentry_dio` would change that, and a monitor agent's URL
+  ///   is exactly what such an event would carry: cover it then.
   @visibleForTesting
   static sentry.SentryEvent scrub(
     sentry.SentryEvent event,
@@ -280,7 +301,18 @@ abstract final class DiagnosticsUpload {
     if (identifiers.isEmpty) return event;
 
     String sub(String text) => KnownIdentifiers.substitute(text, identifiers);
-    Object? subValue(Object? value) => value is String ? sub(value) : value;
+
+    // Through nested collections, not just the top level. A crumb's `data` is
+    // one level of `String` today — `Diag.crumb` takes a `Map<String, String>`
+    // — but the field is `Map<String, dynamic>`, and a value put a level down
+    // would be a hole nothing would notice. Non-strings are returned as they
+    // are, so numbers and booleans keep their type through the round trip.
+    Object? subValue(Object? value) => switch (value) {
+      String() => sub(value),
+      Map() => {for (final e in value.entries) e.key: subValue(e.value)},
+      Iterable() => value.map(subValue).toList(),
+      _ => value,
+    };
 
     final message = event.message;
     if (message != null) {

--- a/lib/core/service/diagnostics_upload.dart
+++ b/lib/core/service/diagnostics_upload.dart
@@ -302,17 +302,51 @@ abstract final class DiagnosticsUpload {
 
     String sub(String text) => KnownIdentifiers.substitute(text, identifiers);
 
+    /// [key], substituted, under a name no entry of [out] has taken.
+    ///
+    /// **Keys are text too.** Every call site writes a literal one today —
+    /// `Diag.crumb` names its fields in code — but nothing about
+    /// `Map<String, dynamic>` stops the next one keying by server name, and a
+    /// key discloses exactly what a value does.
+    ///
+    /// Numbered on collision rather than overwritten, which is the reason this
+    /// is a function at all: two spellings of one address reduce to the same
+    /// token, and a map literal would keep the last of them and silently come
+    /// out shorter than it went in.
+    String subKey(Map<Object?, Object?> out, String key) {
+      final replaced = sub(key);
+      if (!out.containsKey(replaced)) return replaced;
+      var n = 2;
+      while (out.containsKey('$replaced #$n')) {
+        n++;
+      }
+      return '$replaced #$n';
+    }
+
     // Through nested collections, not just the top level. A crumb's `data` is
     // one level of `String` today — `Diag.crumb` takes a `Map<String, String>`
     // — but the field is `Map<String, dynamic>`, and a value put a level down
     // would be a hole nothing would notice. Non-strings are returned as they
-    // are, so numbers and booleans keep their type through the round trip.
-    Object? subValue(Object? value) => switch (value) {
-      String() => sub(value),
-      Map() => {for (final e in value.entries) e.key: subValue(e.value)},
-      Iterable() => value.map(subValue).toList(),
-      _ => value,
-    };
+    // are, so numbers and booleans keep their type through the round trip, and
+    // a key that is not text is left alone: there is nothing in it to match,
+    // and rewriting it would change a shape this cannot read.
+    Object? subValue(Object? value) {
+      switch (value) {
+        case String():
+          return sub(value);
+        case Map():
+          final out = <Object?, Object?>{};
+          for (final e in value.entries) {
+            final key = e.key;
+            out[key is String ? subKey(out, key) : key] = subValue(e.value);
+          }
+          return out;
+        case Iterable():
+          return value.map(subValue).toList();
+        default:
+          return value;
+      }
+    }
 
     final message = event.message;
     if (message != null) {
@@ -335,13 +369,20 @@ abstract final class DiagnosticsUpload {
       if (message != null) crumb.message = sub(message);
       final data = crumb.data;
       if (data != null) {
-        crumb.data = {for (final e in data.entries) e.key: subValue(e.value)};
+        // Through the same walk as any nested map, then retyped: the field is
+        // declared tighter than what that answers, and every key at this level
+        // is already a `String`.
+        crumb.data = Map<String, dynamic>.from(subValue(data)! as Map);
       }
     }
 
     final tags = event.tags;
     if (tags != null) {
-      event.tags = {for (final e in tags.entries) e.key: sub(e.value)};
+      final out = <String, String>{};
+      for (final e in tags.entries) {
+        out[subKey(out, e.key)] = sub(e.value);
+      }
+      event.tags = out;
     }
 
     final culprit = event.culprit;

--- a/lib/core/service/diagnostics_upload.dart
+++ b/lib/core/service/diagnostics_upload.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
 
 import 'package:fl_lib/fl_lib.dart';
+import 'package:flutter/foundation.dart';
 import 'package:sentry/sentry.dart' as sentry;
 import 'package:server_box/core/service/aptabase.dart';
 import 'package:server_box/core/service/diagnostics_platform.dart';
+import 'package:server_box/core/service/known_identifiers.dart';
 import 'package:server_box/core/service/native_exit.dart';
 import 'package:server_box/core/service/openpanel.dart';
 import 'package:server_box/data/model/app/diagnostics_level.dart';
@@ -142,6 +144,8 @@ abstract final class DiagnosticsUpload {
         // report needs, and are the SDK guessing at context rather than this
         // app supplying it.
         options.attachThreads = false;
+        // The last thing every event passes through — see [scrub].
+        options.beforeSend = (event, hint) => _scrubWithStoredIdentifiers(event);
       });
       // Before the sink is installed, so the first error to arrive already
       // says what it arrived from. The pure-Dart SDK cannot work this out for
@@ -207,6 +211,102 @@ abstract final class DiagnosticsUpload {
     } catch (e, s) {
       Loggers.app.warning('Crash upload failed to stop', e, s);
     }
+  }
+
+  /// [scrub], with what this install currently knows to be the user's.
+  ///
+  /// Read per event rather than kept: a server added since launch is one whose
+  /// name would otherwise still go out. It is a store read on the way to the
+  /// network, which is not a hot path — an event is a crash.
+  static sentry.SentryEvent _scrubWithStoredIdentifiers(
+    sentry.SentryEvent event,
+  ) {
+    var identifiers = const <String, String>{};
+    try {
+      identifiers = KnownIdentifiers.of(Stores.server.fetch());
+    } catch (e, s) {
+      // An error reported from an isolate with no store, or from before one is
+      // open. The SDK treats a throw in `beforeSend` as "send it unchanged",
+      // so catching here is what makes [scrub] still run for the parts that
+      // need no records at all.
+      Loggers.app.warning('Could not read what to scrub from a report', e, s);
+    }
+    return scrub(event, identifiers);
+  }
+
+  /// Takes the user's own infrastructure back out of an outgoing event.
+  ///
+  /// **A crumb is written to be published; an exception's message is not.**
+  /// Everything this app records by hand goes through [Redact] where it is
+  /// made, and `SentrySink.log` drops the log stream for exactly that reason —
+  /// but an error's text is written by whoever threw it, which includes
+  /// packages and Riverpod. `Spi.toString` used to be `Spi<user@host:port>`,
+  /// and Riverpod names a family provider after its argument: one
+  /// `UnmountedRefException` uploaded a server's address and login. That
+  /// `toString` is fixed, and this is the net under the next one.
+  ///
+  /// Precise rather than pattern-based — see [KnownIdentifiers] — so it
+  /// removes what this install *knows* is the user's and never guesses. Text
+  /// nothing here can attribute goes out as written; the class of errors that
+  /// quote a hostname is what the levels and the opt-in are for.
+  @visibleForTesting
+  static sentry.SentryEvent scrub(
+    sentry.SentryEvent event,
+    Map<String, String> identifiers,
+  ) {
+    // Nothing sets either: `sendDefaultPii` is false, and the SDK fills
+    // `ip_address` and `server_name` only when it is true. Cleared anyway, for
+    // the same reason that option is set explicitly rather than left to the
+    // default — a later SDK changing its mind would be silent, and a hostname
+    // is a name the machine answers to on every network it joins.
+    //
+    // The address the *receiving* server records from the connection is not
+    // reachable from here. That is a setting on the instance (GlitchTip:
+    // Organization → Scrub IP Addresses).
+    event.user = null;
+    event.serverName = null;
+
+    if (identifiers.isEmpty) return event;
+
+    String sub(String text) => KnownIdentifiers.substitute(text, identifiers);
+    Object? subValue(Object? value) => value is String ? sub(value) : value;
+
+    final message = event.message;
+    if (message != null) {
+      message.formatted = sub(message.formatted);
+      final template = message.template;
+      if (template != null) message.template = sub(template);
+      final params = message.params;
+      // Replaced rather than written through, here and below: a list or map
+      // handed to the SDK may be const, and assigning the field is not.
+      if (params != null) message.params = params.map(subValue).toList();
+    }
+
+    for (final e in event.exceptions ?? const <sentry.SentryException>[]) {
+      final value = e.value;
+      if (value != null) e.value = sub(value);
+    }
+
+    for (final crumb in event.breadcrumbs ?? const <sentry.Breadcrumb>[]) {
+      final message = crumb.message;
+      if (message != null) crumb.message = sub(message);
+      final data = crumb.data;
+      if (data != null) {
+        crumb.data = {for (final e in data.entries) e.key: subValue(e.value)};
+      }
+    }
+
+    final tags = event.tags;
+    if (tags != null) {
+      event.tags = {for (final e in tags.entries) e.key: sub(e.value)};
+    }
+
+    final culprit = event.culprit;
+    if (culprit != null) event.culprit = sub(culprit);
+    final transaction = event.transaction;
+    if (transaction != null) event.transaction = sub(transaction);
+
+    return event;
   }
 }
 

--- a/lib/core/service/known_identifiers.dart
+++ b/lib/core/service/known_identifiers.dart
@@ -1,0 +1,88 @@
+import 'package:server_box/data/model/server/server_private_info.dart';
+
+/// Every string this install knows to be the user's, and what replaces it.
+///
+/// Precise rather than pattern-based, which is the whole point. A regex for
+/// "things that look like a host" both misses — a machine called `nas` is not
+/// a pattern — and overreaches, since a package name in a stack trace looks
+/// like a domain. The app holds the actual records, so it can replace exactly
+/// the strings that came out of them.
+///
+/// **Two readers want opposite things from the same text.** In the Logs page
+/// the user needs to see which machine a line is about; in an issue, or in an
+/// uploaded crash report, nobody may. Substitution is what separates them, and
+/// it belongs here rather than at the point the line was written.
+///
+/// Numbered rather than hashed. A reader following one server through a log
+/// needs to see the same token twice; they do not need it to mean anything.
+abstract final class KnownIdentifiers {
+  /// The identifiers of [servers], in the order they are stored.
+  static Map<String, String> of(List<Spi> servers) {
+    final out = <String, String>{};
+    for (var i = 0; i < servers.length; i++) {
+      final spi = servers[i];
+      final n = i + 1;
+      _add(out, spi.name, '<server-$n>');
+      _add(out, spi.ssh?.ip, '<host-$n>');
+      _add(out, spi.ssh?.user, '<user-$n>');
+      // Both the address as configured and the host inside it: a message may
+      // quote the whole URL, and a dio or socket error names the host alone.
+      // Longest-first ordering in [substitute] keeps the two from colliding.
+      _add(out, spi.monitorHttp?.addr, '<agent-$n>');
+      _add(out, _hostOf(spi.monitorHttp?.addr), '<agent-$n>');
+      _add(out, spi.bmc?.addr, '<bmc-$n>');
+      _add(out, _hostOf(spi.bmc?.addr), '<bmc-$n>');
+    }
+    return out;
+  }
+
+  /// Applies [identifiers] to [text] in a single pass, longest match first.
+  ///
+  /// One pass, and that is the point rather than an optimisation. Replacing
+  /// key by key means each pass can match inside a placeholder an earlier pass
+  /// wrote: with servers named `prod-server` and `server`, the first becomes
+  /// `<server-1>`, and the second's pass then rewrites the `server` inside it
+  /// into `<<server-2>-1>`. The same happens to anything named `host`, `user`
+  /// or `agent`. A scan over the original text can only match the original
+  /// text.
+  ///
+  /// Longest first is still needed, for a different overlap: a machine called
+  /// `db` and one called `db-prod` both match at the same position, and the
+  /// short one winning would leave `<server-1>-prod` — still disclosing
+  /// `-prod`, and no longer showing that two lines named different machines.
+  /// Alternation in a Dart regex is ordered, so sorting decides it.
+  static String substitute(String text, Map<String, String> identifiers) {
+    if (identifiers.isEmpty || text.isEmpty) return text;
+    final keys = identifiers.keys.toList()
+      ..sort((a, b) => b.length.compareTo(a.length));
+    final pattern = RegExp(keys.map(RegExp.escape).join('|'));
+    return text.replaceAllMapped(
+      pattern,
+      (m) => identifiers[m[0]] ?? m[0]!,
+    );
+  }
+
+  /// Too short to substitute safely is left alone: a two-character name occurs
+  /// inside ordinary words, and replacing it would corrupt the log rather than
+  /// redact it. Such a name identifies little in any case.
+  static void _add(Map<String, String> out, String? value, String replacement) {
+    final trimmed = value?.trim();
+    if (trimmed == null || trimmed.length < 3) return;
+    // First writer wins: the same string configured on two servers is one
+    // machine as far as a reader is concerned, and renumbering it per record
+    // would say it was two.
+    out.putIfAbsent(trimmed, () => replacement);
+  }
+
+  /// The host inside a configured address, or null when there is not one.
+  ///
+  /// An address is stored as the user typed it — with a scheme for the agent
+  /// and the BMC, sometimes with a port, sometimes neither. Anything that does
+  /// not parse as a URL with a host contributes nothing here and is dropped;
+  /// the address itself is already a key.
+  static String? _hostOf(String? addr) {
+    if (addr == null || addr.isEmpty) return null;
+    final host = Uri.tryParse(addr.trim())?.host;
+    return host == null || host.isEmpty ? null : host;
+  }
+}

--- a/lib/data/model/server/server_private_info.dart
+++ b/lib/data/model/server/server_private_info.dart
@@ -154,8 +154,20 @@ abstract class Spi with _$Spi {
     return lifted;
   }
 
+  /// Says *which* server without saying where it is or who logs into it.
+  ///
+  /// **This string ends up in places nobody chose.** Riverpod names a family
+  /// provider by its argument's `toString`, and four providers are keyed by a
+  /// whole [Spi] — so `Spi<user@host:port>` was quoted verbatim into an
+  /// `UnmountedRefException` and uploaded with it, address, account and all.
+  /// A `toString` is not a display string; [displayAddr] is, and the pages
+  /// that want an address call it directly.
+  ///
+  /// [Redact.id] rather than the raw [id] so this reads as the same token the
+  /// crumbs carry under `server` — a report can still be followed through one
+  /// machine, which is all an identifier here is for.
   @override
-  String toString() => 'Spi<$displayAddr>';
+  String toString() => 'Spi<${Redact.id(id)}>';
 
   /// Parse the [id], if it's null or empty, generate a new one.
   static String parseId(Object? id) {

--- a/lib/data/provider/benchmark.dart
+++ b/lib/data/provider/benchmark.dart
@@ -208,10 +208,14 @@ class BenchmarkNotifier extends _$BenchmarkNotifier {
       _schedule(noted);
       return;
     }
-    // The one guard for everything below: from here down nothing awaits, so
-    // the provider cannot go away between this line and the end.
-    if (!ref.mounted) return;
-
+    // No blanket guard from here down, on purpose. What follows decides
+    // whether the run is *over*, and that answer belongs in the store whether
+    // or not this page is still open — a fifteen-minute benchmark whose last
+    // poll landed as the user closed the tab would otherwise leave a row that
+    // still says `running`, with the result it had already fetched thrown
+    // away. Only the `state` writes below are guarded; `_schedule` and
+    // `_cleanup` guard themselves, and `_finish` writes its row before its own
+    // guard.
     if (!poll.answered) {
       // The command produced nothing this app recognises: a monitor agent hit
       // its own timeout, a shell was killed, a proxy answered instead. None of
@@ -221,7 +225,7 @@ class BenchmarkNotifier extends _$BenchmarkNotifier {
       final noted = active.copyWith(
         pollError: 'The server did not answer the poll',
       );
-      state = state.copyWith(active: noted);
+      if (ref.mounted) state = state.copyWith(active: noted);
       _schedule(noted);
       return;
     }
@@ -286,7 +290,7 @@ class BenchmarkNotifier extends _$BenchmarkNotifier {
 
     if (!poll.finished) {
       _store.put(updated);
-      state = state.copyWith(active: updated);
+      if (ref.mounted) state = state.copyWith(active: updated);
       _schedule(updated);
       return;
     }

--- a/lib/data/provider/benchmark.dart
+++ b/lib/data/provider/benchmark.dart
@@ -92,6 +92,13 @@ class BenchmarkNotifier extends _$BenchmarkNotifier {
     _timer?.cancel();
     _timer = null;
     if (active == null) return;
+    // `ref.onDispose` cancels the timer, so a timer armed *after* dispose is
+    // one nothing will ever cancel — it would fire on a dead notifier and
+    // throw `UnmountedRefException` out of a callback nobody awaits. Every
+    // caller below is past an `await`, which is where the provider can have
+    // gone: this is keyed by the whole [Spi], so saving a server edit disposes
+    // it while a poll is in flight.
+    if (!ref.mounted) return;
     _timer = Timer(
       immediate ? Duration.zero : _interval(active.elapsed),
       _poll,
@@ -134,7 +141,12 @@ class BenchmarkNotifier extends _$BenchmarkNotifier {
       // Written only once the far side has confirmed. A row claiming a run that
       // was never started would be picked back up on every later open of this
       // page and polled forever.
+      //
+      // Written even when this provider is gone, and before the guard for that
+      // reason: the run is going on the server either way, and the row is the
+      // only thing that lets the next open of this page find it.
       _store.put(run);
+      if (!ref.mounted) return;
       state = state.copyWith(
         active: run,
         history: _store.forServer(_spi.id),
@@ -143,6 +155,7 @@ class BenchmarkNotifier extends _$BenchmarkNotifier {
       _schedule(run, immediate: true);
     } catch (e, s) {
       Loggers.app.warning('Benchmark start failed', e, s);
+      if (!ref.mounted) return;
       state = state.copyWith(isBusy: false, error: '$e');
     }
   }
@@ -170,6 +183,9 @@ class BenchmarkNotifier extends _$BenchmarkNotifier {
   }
 
   Future<void> _poll() async {
+    // Reached from a timer and from [cancel]'s far side, both of which can
+    // outlive the provider. Reading `state` on a disposed one throws.
+    if (!ref.mounted) return;
     final active = state.active;
     if (active == null) return;
 
@@ -187,10 +203,14 @@ class BenchmarkNotifier extends _$BenchmarkNotifier {
       // benchmark is not this device's connection — but a page that shows a
       // spinner while every poll fails is telling the user the run is fine.
       final noted = active.copyWith(pollError: '$e');
+      if (!ref.mounted) return;
       state = state.copyWith(active: noted);
       _schedule(noted);
       return;
     }
+    // The one guard for everything below: from here down nothing awaits, so
+    // the provider cannot go away between this line and the end.
+    if (!ref.mounted) return;
 
     if (!poll.answered) {
       // The command produced nothing this app recognises: a monitor agent hit
@@ -292,7 +312,10 @@ class BenchmarkNotifier extends _$BenchmarkNotifier {
   void _finish(BenchmarkRun run) {
     _timer?.cancel();
     _timer = null;
+    // Before the guard: the result is the thing the user waited for, and it
+    // belongs in the store whether or not this page is still open.
     _store.put(run);
+    if (!ref.mounted) return;
     state = state.copyWith(
       active: null,
       history: _store.forServer(_spi.id),
@@ -302,6 +325,11 @@ class BenchmarkNotifier extends _$BenchmarkNotifier {
   }
 
   Future<void> _cleanup(BenchmarkRun run) async {
+    // It needs a `ref` to reach the server, so a provider disposed as the run
+    // ended cannot do it. The cost is a run directory left on the machine,
+    // which is what this method is best effort about anyway; the alternative
+    // is an `UnmountedRefException` out of an unawaited future.
+    if (!ref.mounted) return;
     try {
       final exec = await ref.read(serverProvider(_spi.id).notifier).ensureExec();
       await exec.run(YabsScript.cleanupCommand(run.runDir, run.id));
@@ -325,10 +353,12 @@ class BenchmarkNotifier extends _$BenchmarkNotifier {
       await exec.run(YabsScript.cancelCommand(active.runDir));
     } catch (e, s) {
       Loggers.app.warning('Benchmark cancel failed', e, s);
+      if (!ref.mounted) return;
       state = state.copyWith(isBusy: false, error: '$e');
       _schedule(active);
       return;
     }
+    if (!ref.mounted) return;
 
     // The exit file the cancel command wrote is what turns the record
     // terminal, so the state comes from a poll like any other rather than

--- a/lib/data/provider/services.dart
+++ b/lib/data/provider/services.dart
@@ -106,6 +106,13 @@ class ServicesNotifier extends _$ServicesNotifier {
     return _manager?.commandFor(unit, action, isRoot: _spi.isRoot);
   }
 
+  /// Lists the units, and writes nothing once this provider is gone.
+  ///
+  /// **Every write below an `await` is guarded.** This is keyed by the whole
+  /// [Spi], so saving an edit makes a *different* provider and disposes this
+  /// one — while a listing started before the edit is still in flight. Writing
+  /// `state` then throws `UnmountedRefException` out of a `Future` nobody is
+  /// awaiting, which reaches the zone handler and is reported as a crash.
   Future<void> getServices() async {
     state = state.copyWith(isBusy: true);
 
@@ -114,12 +121,14 @@ class ServicesNotifier extends _$ServicesNotifier {
       exec = await ref.read(serverProvider(_spi.id).notifier).ensureExec();
     } catch (e, s) {
       dprint('Services exec', e, s);
+      if (!ref.mounted) return;
       state = state.copyWith(
         isBusy: false,
         failure: ServiceFailure(ServiceIssue.unreachable, detail: '$e'),
       );
       return;
     }
+    if (!ref.mounted) return;
 
     try {
       final probe = await ServiceManagerDetector.probe(exec);
@@ -130,6 +139,7 @@ class ServicesNotifier extends _$ServicesNotifier {
       // rather than a systemd client. `none` is a real answer too — it is what
       // a container or a busybox appliance reports.
       Diag.crumb(SbDiag.service, 'list', data: {'via': type?.name ?? 'none'});
+      if (!ref.mounted) return;
       if (type == null) {
         _manager = null;
         state = state.copyWith(
@@ -149,6 +159,7 @@ class ServicesNotifier extends _$ServicesNotifier {
 
       final manager = _managerFor(type);
       final listing = await manager.list(exec);
+      if (!ref.mounted) return;
       _manager = manager;
       state = state.copyWith(
         units: listing.units,
@@ -162,6 +173,7 @@ class ServicesNotifier extends _$ServicesNotifier {
       );
     } catch (e, s) {
       dprint('Services refresh', e, s);
+      if (!ref.mounted) return;
       state = state.copyWith(
         units: const [],
         notice: null,
@@ -169,7 +181,8 @@ class ServicesNotifier extends _$ServicesNotifier {
         failure: ServiceFailure(ServiceIssue.listFailed, detail: '$e'),
       );
     } finally {
-      state = state.copyWith(isBusy: false);
+      // Also reached by every `return` above, which is why it is guarded too.
+      if (ref.mounted) state = state.copyWith(isBusy: false);
     }
   }
 

--- a/test/benchmark_dispose_test.dart
+++ b/test/benchmark_dispose_test.dart
@@ -1,0 +1,184 @@
+/// A poll that lands after the page has gone.
+///
+/// `benchmarkProvider` is keyed by the whole `Spi`, like `servicesProvider`, so
+/// saving a server edit disposes it mid-poll — and so does closing the tab. Two
+/// different things must happen in that window, which is why the guards here
+/// are per-write rather than one at the top:
+///
+/// - Nothing may write `state`, which throws on a disposed provider.
+/// - The *record* must still be written. A benchmark takes fifteen minutes, and
+///   its last poll is the one carrying the exit code and the result JSON. A
+///   blanket guard threw that away and left a row still saying `running`.
+library;
+
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:server_box/data/model/server/benchmark/benchmark_run.dart';
+import 'package:server_box/data/model/server/benchmark/yabs_options.dart';
+import 'package:server_box/data/model/server/benchmark/yabs_script.dart';
+import 'package:server_box/data/model/server/server_exec.dart';
+import 'package:server_box/data/provider/benchmark.dart';
+import 'package:server_box/data/provider/server/single.dart';
+import 'package:server_box/data/res/store.dart';
+import 'package:server_box/data/store/benchmark.dart';
+import 'package:server_box/data/store/private_key.dart';
+import 'package:server_box/data/store/server.dart';
+import 'package:server_box/data/store/setting.dart';
+
+import 'helpers/spi_fixture.dart';
+import 'helpers/test_db.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const sid = 'srv-bench-dispose';
+  final spi = spiFixture(
+    id: sid,
+    name: 'web',
+    ip: 'h',
+    user: 'u',
+    autoConnect: false,
+  );
+
+  setUp(() async {
+    await openTestDb();
+    getIt.registerSingleton<SettingStore>(SettingStore('setting_test'));
+    getIt.registerSingleton<ServerStore>(ServerStore());
+    getIt.registerSingleton<PrivateKeyStore>(PrivateKeyStore());
+    Stores.server.put(spi);
+  });
+
+  tearDown(() async {
+    await getIt.reset();
+    await closeTestDb();
+  });
+
+  BenchmarkRun seedRunning() {
+    final run = BenchmarkRun(
+      id: 'bench_dispose',
+      serverId: sid,
+      startedAt: DateTime.now(),
+      status: BenchmarkStatus.running,
+      options: const YabsOptions(),
+      runDir: '/tmp/x/.server_box_bench',
+    );
+    BenchmarkStore.instance.put(run);
+    return run;
+  }
+
+  /// What the far side prints for a run that has just exited cleanly.
+  const finished =
+      '${YabsScript.stateMarker} exit=0 alive=0 started=1 pid=4321\n'
+      '${YabsScript.jsonMarker}\n'
+      '{"version":"v1"}\n'
+      '${YabsScript.psMarker}\n'
+      '${YabsScript.logMarker}\n'
+      'YABS completed';
+
+  /// Opens the provider, which finds the seeded run and polls it at once.
+  ProviderContainer pollWith(ServerExec exec) {
+    final container = ProviderContainer(
+      overrides: [
+        serverProvider(sid).overrideWith(() => _FakeServerNotifier(exec)),
+      ],
+    );
+    container.read(benchmarkProvider(spi).notifier);
+    return container;
+  }
+
+  test('a run that ends as the page closes is still recorded', () async {
+    seedRunning();
+    final gate = Completer<void>();
+    final container = pollWith(_GatedExec(gate.future, finished));
+
+    // Far enough in for the poll to be waiting on the server.
+    await pumpEventQueue();
+    container.dispose();
+    gate.complete();
+    await pumpEventQueue();
+
+    final stored = BenchmarkStore.instance.forServer(sid).single;
+    expect(stored.status, BenchmarkStatus.completed);
+    expect(stored.exitCode, 0);
+    expect(stored.resultJson, contains('"version"'));
+    expect(
+      BenchmarkStore.instance.activeFor(sid),
+      isNull,
+      reason: 'a row left `running` is polled forever by every later open',
+    );
+  });
+
+  test('and it throws nothing on the way', () async {
+    // The other half of the same window: the record is written, and the state
+    // write that would have followed it does not happen.
+    seedRunning();
+    final gate = Completer<void>();
+    final container = pollWith(_GatedExec(gate.future, finished));
+
+    await pumpEventQueue();
+    container.dispose();
+    gate.complete();
+
+    await expectLater(pumpEventQueue(), completes);
+  });
+
+  test('an unfinished poll still records the log it fetched', () async {
+    // Not terminal, but the log has grown, and the next open of the page reads
+    // it from the store rather than from a server it has yet to reach.
+    seedRunning();
+    final gate = Completer<void>();
+    final container = pollWith(
+      _GatedExec(
+        gate.future,
+        '${YabsScript.stateMarker} exit= alive=1 started=1 pid=4321\n'
+        '${YabsScript.logMarker}\n'
+        'fio Disk Speed Tests',
+      ),
+    );
+
+    await pumpEventQueue();
+    container.dispose();
+    gate.complete();
+    await pumpEventQueue();
+
+    final stored = BenchmarkStore.instance.forServer(sid).single;
+    expect(stored.status, BenchmarkStatus.running);
+    expect(stored.log, contains('fio Disk Speed Tests'));
+  });
+}
+
+/// Hands out one prepared [ServerExec].
+class _FakeServerNotifier extends ServerNotifier {
+  _FakeServerNotifier(this.exec);
+
+  final ServerExec exec;
+
+  @override
+  Future<ServerExec> ensureExec() async => exec;
+}
+
+/// Answers [output], and only once [gate] has completed.
+///
+/// The gate is what puts the dispose *between* the poll and its answer.
+class _GatedExec implements ServerExec {
+  const _GatedExec(this.gate, this.output);
+
+  final Future<void> gate;
+  final String output;
+
+  @override
+  Future<ExecResult> run(
+    String script, {
+    String? entry,
+    Map<String, String>? env,
+    String? stdin,
+    OnExecOutput? onStdout,
+    OnExecOutput? onStderr,
+    Future<void>? cancel,
+  }) async {
+    await gate;
+    return ExecResult(exitCode: 0, stdout: output, stderr: '');
+  }
+}

--- a/test/crash_report_test.dart
+++ b/test/crash_report_test.dart
@@ -5,6 +5,7 @@ import 'package:dartssh2/dartssh2.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:server_box/core/service/crash_report.dart';
+import 'package:server_box/core/service/known_identifiers.dart';
 import 'package:server_box/core/utils/ssh_file_backend.dart';
 
 import 'helpers/spi_fixture.dart';
@@ -84,7 +85,7 @@ void main() {
   });
 
   test('the trace is redacted like the log is', () {
-    final ids = CrashReport.knownIdentifiers([
+    final ids = KnownIdentifiers.of([
       spiFixture(name: 'prod-box', id: 'a'),
     ]);
 
@@ -158,7 +159,7 @@ void main() {
   /// because the app holds the actual records.
   group('identifiers', () {
     test('a server name, host and user are all replaced', () {
-      final ids = CrashReport.knownIdentifiers([
+      final ids = KnownIdentifiers.of([
         spiFixture(name: 'prod-db', id: 'a', ip: '10.1.2.3', user: 'deploy'),
       ]);
 
@@ -179,7 +180,7 @@ void main() {
     test('the same server reads as the same token throughout', () {
       // A reader following one machine through a log needs to see the token
       // twice. It does not need to mean anything beyond that.
-      final ids = CrashReport.knownIdentifiers([
+      final ids = KnownIdentifiers.of([
         spiFixture(name: 'alpha', id: 'a', ip: '10.0.0.1'),
         spiFixture(name: 'beta', id: 'b', ip: '10.0.0.2'),
       ]);
@@ -197,7 +198,7 @@ void main() {
       // `db` inside `db-prod`: replacing the short one first would leave
       // `<server-1>-prod`, which still discloses `-prod` and has lost the fact
       // that the two lines named different machines.
-      final ids = CrashReport.knownIdentifiers([
+      final ids = KnownIdentifiers.of([
         spiFixture(name: 'db', id: 'a'),
         spiFixture(name: 'db-prod', id: 'b'),
       ]);
@@ -214,7 +215,7 @@ void main() {
       // `<<server-2>-1>`, which garbles the report and makes two machines
       // read as one. The same trap exists for anything named host, user or
       // agent.
-      final ids = CrashReport.knownIdentifiers([
+      final ids = KnownIdentifiers.of([
         spiFixture(name: 'prod-server', id: 'a'),
         spiFixture(name: 'server', id: 'b'),
       ]);
@@ -226,7 +227,7 @@ void main() {
     });
 
     test('a name colliding with a placeholder word is still safe', () {
-      final ids = CrashReport.knownIdentifiers([
+      final ids = KnownIdentifiers.of([
         spiFixture(name: 'host', id: 'a', user: 'user'),
       ]);
 
@@ -240,7 +241,7 @@ void main() {
       // Two characters occur inside ordinary words, so replacing them would
       // corrupt the log rather than redact it — and such a name discloses
       // little in any case.
-      final ids = CrashReport.knownIdentifiers([spiFixture(name: 'a', id: 'x')]);
+      final ids = KnownIdentifiers.of([spiFixture(name: 'a', id: 'x')]);
 
       expect(ids.values, isNot(contains('<server-1>')));
       expect(
@@ -252,7 +253,7 @@ void main() {
     test('substitution happens before truncation, not after', () {
       // Otherwise the tail kept is measured against unredacted text, and which
       // lines survive depends on the length of names being removed.
-      final ids = CrashReport.knownIdentifiers([
+      final ids = KnownIdentifiers.of([
         spiFixture(name: 'secret-host', id: 'a'),
       ]);
       final log = [for (var i = 0; i < 200; i++) 'secret-host line $i'].join('\n');

--- a/test/diagnostics_scrub_test.dart
+++ b/test/diagnostics_scrub_test.dart
@@ -134,6 +134,56 @@ void main() {
     );
   });
 
+  test('a map key is text as much as a value is', () {
+    final event = scrubbed(
+      sentry.SentryEvent(
+        breadcrumbs: [
+          sentry.Breadcrumb(
+            message: 'x',
+            data: {
+              'prod-db': 'reachable',
+              'nested': {'10.0.0.9': 'refused', 7: 'left alone'},
+            },
+          ),
+        ],
+        tags: {'prod-db': 'agent-box'},
+      ),
+    );
+
+    final data = event.breadcrumbs!.single.data!;
+    expect(data.keys, contains('<server-1>'));
+    expect(data['<server-1>'], 'reachable');
+    final nested = data['nested'] as Map;
+    expect(nested['<bmc-2>'], 'refused');
+    expect(nested[7], 'left alone', reason: 'a key that is not text is kept');
+    expect(event.tags, {'<server-1>': '<server-2>'});
+  });
+
+  test('two keys reducing to one token keep both entries', () {
+    // The agent's address and the host inside it are two keys and one
+    // replacement. Overwriting would have made the map come out shorter than
+    // it went in, which is a diagnostic silently rewritten rather than
+    // redacted.
+    final event = scrubbed(
+      sentry.SentryEvent(
+        breadcrumbs: [
+          sentry.Breadcrumb(
+            message: 'x',
+            data: {
+              'https://10.0.0.7:3770': 'first',
+              '10.0.0.7': 'second',
+            },
+          ),
+        ],
+      ),
+    );
+
+    final data = event.breadcrumbs!.single.data!;
+    expect(data, hasLength(2));
+    expect(data['<agent-2>'], 'first');
+    expect(data['<agent-2> #2'], 'second');
+  });
+
   test('a const map handed to the SDK is replaced, not written through', () {
     // The failure mode is an `Unsupported operation` thrown out of `beforeSend`,
     // which the SDK catches by sending the event unscrubbed.

--- a/test/diagnostics_scrub_test.dart
+++ b/test/diagnostics_scrub_test.dart
@@ -1,0 +1,206 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sentry/sentry.dart' as sentry;
+import 'package:server_box/core/service/diagnostics_upload.dart';
+import 'package:server_box/core/service/known_identifiers.dart';
+import 'package:server_box/data/model/server/bmc_cfg.dart';
+import 'package:server_box/data/model/server/monitor_http_credential.dart';
+import 'package:server_box/data/model/server/server_private_info.dart';
+
+import 'helpers/spi_fixture.dart';
+
+/// The last thing an event passes through before it leaves the device.
+///
+/// This is the half of diagnostics nobody audits by reading it: a crumb is
+/// written to be published and goes through `Redact` where it is made, while an
+/// error's text is written by whoever threw it. `Spi.toString` used to be
+/// `Spi<user@host:port>`, Riverpod names a family provider after its argument,
+/// and one `UnmountedRefException` uploaded a server's address and login as its
+/// title. Both halves are covered here: what the event carries, and what it
+/// must no longer carry about the device itself.
+void main() {
+  final servers = [
+    spiFixture(name: 'prod-db', id: 'a', ip: '198.51.100.24', user: 'deploy'),
+    Spi(
+      name: 'agent-box',
+      id: 'b',
+      monitorHttp: const MonitorHttpCredential(addr: 'https://10.0.0.7:3770'),
+      bmc: const BmcCfg(addr: 'https://10.0.0.9'),
+    ),
+  ];
+  final identifiers = KnownIdentifiers.of(servers);
+
+  sentry.SentryEvent scrubbed(sentry.SentryEvent event) =>
+      DiagnosticsUpload.scrub(event, identifiers);
+
+  test('an exception message does not carry an address or an account', () {
+    // The shape of the event this exists for, with the reporter's own address
+    // swapped for a documentation one (RFC 5737). Nothing in this repository
+    // gets to hold a real user's host, which is the same rule the code under
+    // test is about.
+    final event = scrubbed(
+      sentry.SentryEvent(
+        exceptions: [
+          sentry.SentryException(
+            type: 'UnmountedRefException',
+            value:
+                'Cannot use the Ref of servicesProvider('
+                'Spi<deploy@198.51.100.24:22>) after it has been disposed.',
+          ),
+        ],
+      ),
+    );
+
+    final value = event.exceptions!.single.value!;
+    expect(value, isNot(contains('198.51.100.24')));
+    expect(value, isNot(contains('deploy')));
+    expect(value, contains('<host-1>'));
+    expect(value, contains('<user-1>'));
+    expect(
+      value,
+      contains('servicesProvider'),
+      reason: 'what is left has to still say where the failure was',
+    );
+  });
+
+  test('the message, its template and its params are all covered', () {
+    final event = scrubbed(
+      sentry.SentryEvent(
+        message: sentry.SentryMessage(
+          'could not reach prod-db',
+          template: 'could not reach %s',
+          params: ['prod-db', 22],
+        ),
+      ),
+    );
+
+    final message = event.message!;
+    expect(message.formatted, 'could not reach <server-1>');
+    expect(message.template, 'could not reach %s');
+    expect(message.params, ['<server-1>', 22]);
+  });
+
+  test('a breadcrumb is covered too, message and data alike', () {
+    // Crumbs are already redacted where they are made. This is about the ones
+    // a package places, and about a `data` value someone adds later without
+    // thinking of this file.
+    final event = scrubbed(
+      sentry.SentryEvent(
+        breadcrumbs: [
+          sentry.Breadcrumb(
+            message: 'GET https://10.0.0.7:3770/api/v1/status',
+            data: {'host': '10.0.0.7', 'attempt': 2},
+          ),
+        ],
+      ),
+    );
+
+    final crumb = event.breadcrumbs!.single;
+    expect(crumb.message, isNot(contains('10.0.0.7')));
+    expect(crumb.data!['host'], '<agent-2>');
+    expect(crumb.data!['attempt'], 2, reason: 'a non-string is left alone');
+  });
+
+  test('a const map handed to the SDK is replaced, not written through', () {
+    // The failure mode is an `Unsupported operation` thrown out of `beforeSend`,
+    // which the SDK catches by sending the event unscrubbed.
+    final event = sentry.SentryEvent(
+      breadcrumbs: [
+        sentry.Breadcrumb(message: 'x', data: const {'host': '10.0.0.7'}),
+      ],
+      message: sentry.SentryMessage('x', params: const ['prod-db']),
+    );
+
+    expect(() => scrubbed(event), returnsNormally);
+    expect(event.breadcrumbs!.single.data!['host'], '<agent-2>');
+    expect(event.message!.params, ['<server-1>']);
+  });
+
+  test('the BMC and the agent are the user\'s infrastructure as well', () {
+    final event = scrubbed(
+      sentry.SentryEvent(
+        message: sentry.SentryMessage(
+          'https://10.0.0.9 refused, so did https://10.0.0.7:3770',
+        ),
+      ),
+    );
+
+    expect(event.message!.formatted, contains('<bmc-2>'));
+    expect(event.message!.formatted, contains('<agent-2>'));
+    expect(event.message!.formatted, isNot(contains('10.0.0.')));
+  });
+
+  test('nothing describes the device it came from', () {
+    // Neither is set while `sendDefaultPii` is false. Cleared regardless, for
+    // the same reason that option is set explicitly: a later SDK changing its
+    // mind about the default would be silent.
+    final event = scrubbed(
+      sentry.SentryEvent(
+        user: sentry.SentryUser(id: 'someone', ipAddress: '2001:db8::1'),
+        serverName: 'someones-macbook.local',
+      ),
+    );
+
+    expect(event.user, isNull);
+    expect(event.serverName, isNull);
+  });
+
+  test('an install with no servers still has its device fields cleared', () {
+    // The path taken when the store cannot be read at all — an error reported
+    // from an isolate that never opened one.
+    final event = DiagnosticsUpload.scrub(
+      sentry.SentryEvent(
+        user: sentry.SentryUser(ipAddress: '2001:db8::1'),
+        message: sentry.SentryMessage('prod-db is gone'),
+      ),
+      const {},
+    );
+
+    expect(event.user, isNull);
+    expect(
+      event.message!.formatted,
+      'prod-db is gone',
+      reason: 'with no records to match, text goes out as written',
+    );
+  });
+
+  /// Here rather than beside the model because this is what the `toString` is
+  /// *for*: it is not a display string — `Spi.displayAddr` is, and the pages
+  /// wanting an address call it — it is what Riverpod, an assertion and a
+  /// package's error message quote when they name a server.
+  group('a Spi describes itself without disclosing anything', () {
+    test('no address, no account, no name', () {
+      final text = servers.first.toString();
+
+      expect(text, isNot(contains('198.51.100.24')));
+      expect(text, isNot(contains('deploy')));
+      expect(text, isNot(contains('prod-db')));
+    });
+
+    test('one machine still reads as one machine', () {
+      // The point of an identifier here: a report has to be followable through
+      // a single server, and two of them have to be tellable apart.
+      expect(servers.first.toString(), servers.first.toString());
+      expect(
+        servers.first.toString(),
+        isNot(servers.last.toString()),
+      );
+      expect(
+        servers.first.copyWith(name: 'renamed').toString(),
+        servers.first.toString(),
+        reason: 'the id is what it is about, not anything the user typed',
+      );
+    });
+  });
+
+  test('text this install cannot attribute is left as it is', () {
+    // Precise, not pattern-based: a package name in a stack trace looks like a
+    // domain, and a machine called `nas` looks like nothing at all.
+    final event = scrubbed(
+      sentry.SentryEvent(
+        message: sentry.SentryMessage('package:server_box/main.dart 1.2.3.4'),
+      ),
+    );
+
+    expect(event.message!.formatted, 'package:server_box/main.dart 1.2.3.4');
+  });
+}

--- a/test/diagnostics_scrub_test.dart
+++ b/test/diagnostics_scrub_test.dart
@@ -103,6 +103,37 @@ void main() {
     expect(crumb.data!['attempt'], 2, reason: 'a non-string is left alone');
   });
 
+  test('a value nested inside a crumb is reached too', () {
+    // `Diag.crumb` takes a `Map<String, String>`, so one level is all there is
+    // today — but the field the SDK exposes is `Map<String, dynamic>`, and a
+    // value put a level down would be a hole nothing would notice.
+    final event = scrubbed(
+      sentry.SentryEvent(
+        breadcrumbs: [
+          sentry.Breadcrumb(
+            message: 'x',
+            data: {
+              'tried': ['10.0.0.7', 'prod-db'],
+              'via': {
+                'jump': {'host': '198.51.100.24'},
+                'attempts': 3,
+              },
+            },
+          ),
+        ],
+      ),
+    );
+
+    final data = event.breadcrumbs!.single.data!;
+    expect(data['tried'], ['<agent-2>', '<server-1>']);
+    expect((data['via'] as Map)['jump'], {'host': '<host-1>'});
+    expect(
+      (data['via'] as Map)['attempts'],
+      3,
+      reason: 'a number keeps its type through the round trip',
+    );
+  });
+
   test('a const map handed to the SDK is replaced, not written through', () {
     // The failure mode is an `Unsupported operation` thrown out of `beforeSend`,
     // which the SDK catches by sending the event unscrubbed.

--- a/test/diagnostics_scrub_test.dart
+++ b/test/diagnostics_scrub_test.dart
@@ -5,8 +5,11 @@ import 'package:server_box/core/service/known_identifiers.dart';
 import 'package:server_box/data/model/server/bmc_cfg.dart';
 import 'package:server_box/data/model/server/monitor_http_credential.dart';
 import 'package:server_box/data/model/server/server_private_info.dart';
+import 'package:server_box/data/res/store.dart';
+import 'package:server_box/data/store/server.dart';
 
 import 'helpers/spi_fixture.dart';
+import 'helpers/test_db.dart';
 
 /// The last thing an event passes through before it leaves the device.
 ///
@@ -145,8 +148,8 @@ void main() {
   });
 
   test('an install with no servers still has its device fields cleared', () {
-    // The path taken when the store cannot be read at all — an error reported
-    // from an isolate that never opened one.
+    // Nothing to substitute is not the same as nothing to do: what the event
+    // says about the *device* is removed whether or not there are records.
     final event = DiagnosticsUpload.scrub(
       sentry.SentryEvent(
         user: sentry.SentryUser(ipAddress: '2001:db8::1'),
@@ -189,6 +192,45 @@ void main() {
         servers.first.toString(),
         reason: 'the id is what it is about, not anything the user typed',
       );
+    });
+  });
+
+  /// The wrapper `beforeSend` is actually given, where the decision to send at
+  /// all is made.
+  group('reading the records to scrub against', () {
+    test('an event nothing could be checked against is dropped', () {
+      // No store registered, which is an error raised from an isolate that
+      // never opened one, or while the app is coming down. The records are the
+      // whole of what separates a report from a disclosure, so an event that
+      // could not be checked against them is not sent unscrubbed instead.
+      expect(
+        DiagnosticsUpload.scrubWithStoredIdentifiers(
+          sentry.SentryEvent(
+            message: sentry.SentryMessage('could not reach prod-db'),
+          ),
+        ),
+        isNull,
+      );
+    });
+
+    test('an install with no servers is not that case', () async {
+      // It has nothing to substitute, which is an answer rather than a
+      // failure — otherwise a fresh install would report nothing at all.
+      await openTestDb();
+      getIt.registerSingleton<ServerStore>(ServerStore());
+      addTearDown(closeTestDb);
+      addTearDown(getIt.reset);
+
+      final event = DiagnosticsUpload.scrubWithStoredIdentifiers(
+        sentry.SentryEvent(
+          user: sentry.SentryUser(ipAddress: '2001:db8::1'),
+          message: sentry.SentryMessage('nothing here to match'),
+        ),
+      );
+
+      expect(event, isNotNull);
+      expect(event!.user, isNull);
+      expect(event.message!.formatted, 'nothing here to match');
     });
   });
 

--- a/test/services_dispose_test.dart
+++ b/test/services_dispose_test.dart
@@ -1,0 +1,142 @@
+/// Listing units for a page that has already gone.
+///
+/// `servicesProvider` is keyed by the whole `Spi`, so saving a server edit
+/// makes a *different* provider and disposes this one — while the listing
+/// started before the edit is still in flight. Writing `state` then throws
+/// `UnmountedRefException` out of a future nobody awaits, which reaches the
+/// zone handler and is reported as a crash: it was, from a device that had
+/// saved the same server's editor twice in ten seconds.
+///
+/// Nothing in the page can see this. The listing is correct, the failure is in
+/// what happens to it afterwards, and the exception names Riverpod rather than
+/// anything in this repository.
+library;
+
+import 'dart:async';
+
+import 'package:fl_lib/fl_lib.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:server_box/data/model/server/server_exec.dart';
+import 'package:server_box/data/provider/server/single.dart';
+import 'package:server_box/data/provider/services.dart';
+import 'package:server_box/data/res/store.dart';
+import 'package:server_box/data/store/private_key.dart';
+import 'package:server_box/data/store/server.dart';
+import 'package:server_box/data/store/setting.dart';
+
+import 'helpers/spi_fixture.dart';
+import 'helpers/test_db.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const sid = 'srv-services-1';
+  final spi = spiFixture(
+    id: sid,
+    name: 'web',
+    ip: 'h',
+    user: 'u',
+    autoConnect: false,
+  );
+
+  setUp(() async {
+    await openTestDb();
+    getIt.registerSingleton<SettingStore>(SettingStore('setting_test'));
+    getIt.registerSingleton<ServerStore>(ServerStore());
+    getIt.registerSingleton<PrivateKeyStore>(PrivateKeyStore());
+    Stores.server.put(spi);
+  });
+
+  tearDown(() async {
+    await getIt.reset();
+    await SqliteDb.close();
+  });
+
+  /// A container whose servers hand out [exec], or refuse if it is null.
+  ProviderContainer containerWith(ServerExec? exec) => ProviderContainer(
+    overrides: [
+      serverProvider(sid).overrideWith(() => _FakeServerNotifier(exec)),
+    ],
+  );
+
+  test('a server that answers after the page closed', () async {
+    // The listing succeeds — this is the ordinary path, arriving late.
+    final gate = Completer<void>();
+    final container = containerWith(_GatedExec(gate.future));
+    final pending = container.read(servicesProvider(spi).notifier).getServices();
+
+    // Far enough in to be waiting on the probe.
+    await Future<void>.delayed(Duration.zero);
+    container.dispose();
+    gate.complete();
+
+    await expectLater(pending, completes);
+  });
+
+  test('a server that fails after the page closed', () async {
+    // The other half: `ensureExec` throwing is the common case — the machine is
+    // off, or the credentials were what the user was editing — and its handler
+    // writes `state` as well.
+    final container = containerWith(null);
+    final pending = container.read(servicesProvider(spi).notifier).getServices();
+
+    container.dispose();
+
+    await expectLater(pending, completes);
+  });
+
+  test('a listing that arrives in time is still kept', () async {
+    // The guards must not have turned the ordinary path into a no-op.
+    final container = containerWith(_GatedExec(Future.value()));
+    addTearDown(container.dispose);
+    final notifier = container.read(servicesProvider(spi).notifier);
+
+    await notifier.getServices();
+
+    final state = container.read(servicesProvider(spi));
+    expect(state.isBusy, isFalse);
+    // Nothing on the far side answers the probe, so this is the "no init system
+    // found" answer rather than a list of units — what matters here is that an
+    // answer was written at all.
+    expect(state.failure?.issue, ServiceIssue.unsupported);
+  });
+}
+
+/// Hands out a prepared [ServerExec], or refuses like an unreachable machine.
+class _FakeServerNotifier extends ServerNotifier {
+  _FakeServerNotifier(this.exec);
+
+  final ServerExec? exec;
+
+  @override
+  Future<ServerExec> ensureExec() async {
+    final exec = this.exec;
+    if (exec == null) throw StateError('offline: this test does not connect');
+    return exec;
+  }
+}
+
+/// Answers nothing, and only once [gate] has completed.
+///
+/// The gate is what puts the dispose *between* the request and its answer,
+/// which is the window the whole file is about.
+class _GatedExec implements ServerExec {
+  const _GatedExec(this.gate);
+
+  final Future<void> gate;
+
+  @override
+  Future<ExecResult> run(
+    String script, {
+    String? entry,
+    Map<String, String>? env,
+    String? stdin,
+    OnExecOutput? onStdout,
+    OnExecOutput? onStderr,
+    Future<void>? cancel,
+  }) async {
+    await gate;
+    return const ExecResult(exitCode: 0, stdout: '', stderr: '');
+  }
+}


### PR DESCRIPTION
Two halves of GlitchTip issue 83. That one event was both a crash and a disclosure, so both are here.

## The crash

`servicesProvider` is keyed by the whole `Spi`. Saving a server edit makes a *different* provider and disposes this one — while the listing started before the edit is still in flight. The `state` write that comes back then throws `UnmountedRefException` out of a future nobody awaits, which reaches the zone handler and is reported as a crash. The reporter's breadcrumbs show exactly that: two `edit saved` in ten seconds, then a `service list`, then the event.

Every write below an `await` is guarded now, `finally` included — each early `return` passes through it.

`benchmark.dart` is keyed the same way and had the same defect, so it is fixed here too. Two details worth reading:

- `_store.put` stays **before** the guard. The run is going on the server either way, and that row is the only thing that lets the next open of the page find it.
- `_schedule` refuses to arm a timer once unmounted. `ref.onDispose` cancels the timer, so one armed after dispose is one nothing would ever cancel.

`pve.dart` already guards with `ref.mounted`, and `bmc.dart` bumps a generation in `onDispose`. Neither needed anything.

## The disclosure

`Spi.toString` was `Spi<user@host:port>`, and Riverpod names a family provider after its argument — so a server's address and login were quoted verbatim into the exception's text and uploaded as the issue title. Four providers are keyed by a `Spi`.

It now reads as the same token the crumbs already carry under `server`, so a report can still be followed through one machine. `displayAddr` is untouched and is what the pages call.

Under that, a `beforeSend` that takes what this install knows to be the user's back out of an outgoing event — exception values, message (formatted, template, params), breadcrumb messages and data, tags, culprit — and clears `user` and `serverName`. The reasoning is the one `SentrySink.log` already gives for dropping the log stream: a crumb is written to be published and goes through `Redact` where it is made, while an error's text is written by whoever threw it, which includes packages and Riverpod.

Still precise rather than pattern-based, for the reason `KnownIdentifiers` documents. The identifier table moves out of `CrashReport` so the report and the upload share one implementation, and gains the BMC address plus the host inside a configured URL — a dio or socket error names the host alone, not the whole address.

Const collections are replaced rather than written through: an `Unsupported operation` thrown out of `beforeSend` is caught by the SDK, which then sends the event **unscrubbed**.

## Not in this PR

The `user.ip_address` on that event is not from the SDK — `sendDefaultPii` is false, and `user` is now cleared as well. GlitchTip records it from the connection. That needs **Organization → Scrub IP Addresses** on the instance; no code change can reach it.

## Tests

- `test/services_dispose_test.dart` — answer arriving late, `ensureExec` failing late, and the ordinary path still writing. Verified against the bug: with the guards removed, the first two fail with `UnmountedRefException`.
- `test/diagnostics_scrub_test.dart` — the reported event's shape (address swapped for RFC 5737), each field the scrub covers, the const-collection trap, and that `Spi.toString` discloses nothing while still telling two machines apart.
- `test/crash_report_test.dart` follows the identifier table to its new home.

`flutter analyze` clean. Full `flutter test` green apart from `windows_install_ssh_e2e_test.dart`, which is opt-in and wants `SBM_E2E_SSH_KEY_PASSPHRASE`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Privacy**
  - Crash reports and diagnostic events now redact server names, addresses, usernames, credentials, and related metadata before submission.
  - Diagnostic details are sanitized across messages, errors, breadcrumbs, tags, transaction data, and nested fields, including map keys.
  - Server information in diagnostic output is represented by privacy-safe identifiers.
  - Events are omitted when stored identifiers cannot be loaded.

- **Bug Fixes**
  - Improved reliability when benchmark or service operations finish after leaving the screen.
  - Prevented delayed background operations from updating disposed screens or causing errors.

- **Tests**
  - Added coverage for diagnostic redaction and disposed asynchronous operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->