### PR TITLE
chore(audit): remove dead store APIs, dedup helpers, fix benchmark detail state

### DIFF
--- a/lib/data/store/benchmark.dart
+++ b/lib/data/store/benchmark.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:convert';
 
 import 'package:fl_lib/fl_lib.dart';
@@ -20,22 +19,9 @@ class BenchmarkStore {
 
   static final instance = BenchmarkStore();
 
-  /// A separate instance for a test, so the change stream is not shared with
-  /// the singleton across tests in one process.
-  factory BenchmarkStore.forTest() => BenchmarkStore();
-
   final String _table;
 
   Database get _db => SqliteDb.instance;
-
-  final _changes = StreamController<void>.broadcast();
-
-  /// Fires after any write, for the pages showing a run or a history list.
-  Stream<void> get changes => _changes.stream;
-
-  void _invalidate() {
-    if (!_changes.isClosed) _changes.add(null);
-  }
 
   /// How many runs are kept per server.
   ///
@@ -150,7 +136,6 @@ class BenchmarkStore {
       ],
     );
     _prune(run.serverId);
-    _invalidate();
   }
 
   /// Drops this server's oldest runs past [historyLimit].
@@ -170,16 +155,6 @@ class BenchmarkStore {
 
   void remove(String id) {
     _db.execute('DELETE FROM $_table WHERE id = ?;', [id]);
-    _invalidate();
-  }
-
-  /// Forgets one server's history.
-  ///
-  /// The foreign key cascades when the server itself is deleted; this is for
-  /// the user clearing it by hand.
-  void removeForServer(String serverId) {
-    _db.execute('DELETE FROM $_table WHERE server_id = ?;', [serverId]);
-    _invalidate();
   }
 
   /// Every run of every server, newest first.
@@ -190,21 +165,6 @@ class BenchmarkStore {
   List<BenchmarkRun> all() {
     final rows = _db.select(
       'SELECT $_columns FROM $_table ORDER BY started_at DESC;',
-    );
-    return [
-      for (final row in rows) ?_fromRow(row),
-    ];
-  }
-
-  /// Every run of every server, newest first — the cross-server comparison.
-  ///
-  /// Only rows that produced a result: comparing against a run that failed
-  /// halfway would put an empty column beside real ones.
-  List<BenchmarkRun> allCompleted() {
-    final rows = _db.select(
-      'SELECT $_columns FROM $_table WHERE status = ? AND result_json IS NOT NULL '
-      'ORDER BY started_at DESC;',
-      [BenchmarkStatus.completed.name],
     );
     return [
       for (final row in rows) ?_fromRow(row),

--- a/lib/data/store/connection_stats.dart
+++ b/lib/data/store/connection_stats.dart
@@ -60,52 +60,6 @@ class ConnectionStatsStore {
     return rows.map(_fromRow).toList();
   }
 
-  ServerConnectionStats getServerStats(String serverId, String serverName) {
-    final allStats = getConnectionHistory(serverId);
-
-    if (allStats.isEmpty) {
-      return ServerConnectionStats(
-        serverId: serverId,
-        serverName: serverName,
-        totalAttempts: 0,
-        successCount: 0,
-        failureCount: 0,
-        recentConnections: [],
-        successRate: 0.0,
-      );
-    }
-
-    var successCount = 0;
-    DateTime? lastSuccessTime;
-    DateTime? lastFailureTime;
-    final recentConnections = <ConnectionStat>[];
-
-    for (final stat in allStats) {
-      if (stat.result.isSuccess) {
-        successCount += 1;
-        lastSuccessTime ??= stat.timestamp;
-      } else {
-        lastFailureTime ??= stat.timestamp;
-      }
-      if (recentConnections.length < _recentPerServer) {
-        recentConnections.add(stat);
-      }
-    }
-
-    final totalAttempts = allStats.length;
-    return ServerConnectionStats(
-      serverId: serverId,
-      serverName: serverName,
-      totalAttempts: totalAttempts,
-      successCount: successCount,
-      failureCount: totalAttempts - successCount,
-      lastSuccessTime: lastSuccessTime,
-      lastFailureTime: lastFailureTime,
-      recentConnections: recentConnections,
-      successRate: successCount / totalAttempts,
-    );
-  }
-
   /// Every server's summary, in two queries.
   ///
   /// One `GROUP BY` to enumerate servers and then a full history read per

--- a/lib/view/page/benchmark/result.dart
+++ b/lib/view/page/benchmark/result.dart
@@ -8,6 +8,7 @@ import 'package:server_box/core/extension/context/locale.dart';
 import 'package:server_box/data/model/server/benchmark/benchmark_run.dart';
 import 'package:server_box/data/model/server/benchmark/yabs_result.dart';
 import 'package:server_box/data/store/benchmark.dart';
+import 'package:server_box/view/page/benchmark/history_tile.dart';
 import 'package:server_box/view/page/benchmark/log_view.dart';
 
 /// One benchmark's numbers.
@@ -157,7 +158,7 @@ extension _Sections on _BenchmarkResultPageState {
             Icon(icon, color: color, size: 17),
             UIs.width13,
             Expanded(
-              child: Text(_fmtDuration(elapsed), style: UIs.text15),
+              child: Text(fmtDuration(elapsed), style: UIs.text15),
             ),
             if (_run.status == BenchmarkStatus.running)
               const SizedBox(
@@ -173,12 +174,6 @@ extension _Sections on _BenchmarkResultPageState {
         if (_run.exitCode case final code?) _kv('Exit', '$code'),
       ],
     );
-  }
-
-  static String _fmtDuration(Duration d) {
-    final m = d.inMinutes;
-    final s = d.inSeconds % 60;
-    return '${m}m ${s.toString().padLeft(2, '0')}s';
   }
 
   Widget _systemCard(YabsResult r) {

--- a/lib/view/page/benchmark/tab.dart
+++ b/lib/view/page/benchmark/tab.dart
@@ -279,7 +279,6 @@ extension _Widgets on _BenchmarkTabPageState {
     );
   }
 
-
   /// The right column: a result being read, or the selected machine's run.
   ///
   /// Both are pages with their own `ref`. That is what lets this build them
@@ -290,11 +289,22 @@ extension _Widgets on _BenchmarkTabPageState {
       final run = BenchmarkStore.instance.get(id);
       // Deleted from the list beside it. Falls through to the machine's own
       // column rather than rendering a record that is gone.
-      if (run != null) return BenchmarkResultPage(args: run);
+      //
+      // Keyed by run: the state polls by run id, so a reused element would
+      // keep showing and polling the run that was there before.
+      if (run != null) {
+        return BenchmarkResultPage(key: ValueKey(id), args: run);
+      }
     }
     final spi = _selected;
     if (spi == null) return const EmptyPane(icon: Icons.speed_outlined);
-    return BenchmarkRunPage(args: SpiRequiredArgs(spi), inPane: true);
+    // Keyed like the single-column branch: the state holds its server in a
+    // `late final`, so a reused element would keep acting on the old machine.
+    return BenchmarkRunPage(
+      key: ValueKey(spi.id),
+      args: SpiRequiredArgs(spi),
+      inPane: true,
+    );
   }
 
 }

--- a/lib/view/widget/globe/land.dart
+++ b/lib/view/widget/globe/land.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 
 import 'package:fl_lib/fl_lib.dart';
+import 'package:flutter/foundation.dart' show visibleForTesting;
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:server_box/data/model/server/geo.dart';
 
@@ -148,6 +149,7 @@ abstract final class BundledLand {
   }
 
   /// For tests, which need each case to start from nothing.
+  @visibleForTesting
   static void resetForTest([GlobeLand? land]) {
     _loaded = land;
     _tried = land != null;

--- a/test/benchmark_store_test.dart
+++ b/test/benchmark_store_test.dart
@@ -148,7 +148,7 @@ void main() {
       SqliteDb.instance.execute(
         "INSERT INTO server (id, name, ssh_ip) VALUES ('srv2', 'web', '10.0.0.2');",
       );
-      store = BenchmarkStore.forTest();
+      store = BenchmarkStore();
     });
 
     tearDown(closeTestDb);
@@ -283,14 +283,5 @@ void main() {
       );
     });
 
-    test('forgetting one server leaves the other alone', () {
-      store.put(_run('a'));
-      store.put(_run('b', serverId: 'srv2'));
-
-      store.removeForServer('srv');
-
-      expect(store.forServer('srv'), isEmpty);
-      expect(store.forServer('srv2'), hasLength(1));
-    });
   });
 }

--- a/test/connection_stats_store_test.dart
+++ b/test/connection_stats_store_test.dart
@@ -150,7 +150,9 @@ void main() {
       stat('a', at: base.add(const Duration(minutes: 2))),
     );
 
-    final summary = store.getServerStats('a', 'srv');
+    final summary = store.getAllServerStats().single;
+    expect(summary.serverId, 'a');
+    expect(summary.serverName, 'srv');
     expect(summary.totalAttempts, 3);
     expect(summary.successCount, 2);
     expect(summary.failureCount, 1);
@@ -159,11 +161,11 @@ void main() {
     expect(summary.lastFailureTime, base.add(const Duration(minutes: 1)));
   });
 
-  test('a server with no attempts summarises as empty, not as an error', () {
-    final summary = store.getServerStats('nobody', 'srv');
-    expect(summary.totalAttempts, 0);
-    expect(summary.successRate, 0.0);
-    expect(summary.recentConnections, isEmpty);
+  test('a server with no attempts is absent from the list, not an error', () {
+    expect(
+      store.getAllServerStats().where((e) => e.serverId == 'nobody'),
+      isEmpty,
+    );
   });
 
   test('the overall list names each server as it was named last', () async {
@@ -199,7 +201,7 @@ void main() {
   });
 
   group('the overall list, which is two queries regardless of server count', () {
-    test('it agrees with reading each server separately', () async {
+    test('the overall list aggregates each server correctly', () async {
       for (var server = 0; server < 4; server++) {
         for (var i = 0; i < 25; i++) {
           await store.recordConnection(
@@ -220,24 +222,28 @@ void main() {
       };
       expect(all.keys, hasLength(4));
 
-      // The aggregate has to answer exactly what the per-server read does.
+      // Even minutes succeeded and odd ones timed out, so the aggregates are
+      // known up front rather than agreed between two implementations.
       for (var server = 0; server < 4; server++) {
         final id = 's$server';
-        final one = store.getServerStats(id, 'name-$server');
-        final many = all[id]!;
+        final summary = all[id]!;
 
-        expect(many.serverName, one.serverName, reason: id);
-        expect(many.totalAttempts, one.totalAttempts, reason: id);
-        expect(many.successCount, one.successCount, reason: id);
-        expect(many.failureCount, one.failureCount, reason: id);
-        expect(many.successRate, closeTo(one.successRate, 1e-12), reason: id);
-        expect(many.lastSuccessTime, one.lastSuccessTime, reason: id);
-        expect(many.lastFailureTime, one.lastFailureTime, reason: id);
+        expect(summary.serverName, 'name-$server', reason: id);
+        expect(summary.totalAttempts, 25, reason: id);
+        expect(summary.successCount, 13, reason: id);
+        expect(summary.failureCount, 12, reason: id);
+        expect(summary.successRate, closeTo(13 / 25, 1e-12), reason: id);
         expect(
-          many.recentConnections.map((e) => e.timestamp),
-          one.recentConnections.map((e) => e.timestamp),
+          summary.lastSuccessTime,
+          base.add(const Duration(minutes: 24)),
           reason: id,
         );
+        expect(
+          summary.lastFailureTime,
+          base.add(const Duration(minutes: 23)),
+          reason: id,
+        );
+        expect(summary.recentConnections, hasLength(20), reason: id);
       }
     });
 

--- a/test/connection_stats_store_test.dart
+++ b/test/connection_stats_store_test.dart
@@ -163,7 +163,7 @@ void main() {
 
   test('a server with no attempts is absent from the list, not an error', () {
     expect(
-      store.getAllServerStats().where((e) => e.serverId == 'nobody'),
+      store.getAllServerStats().where((e) => e.serverId == 'b'),
       isEmpty,
     );
   });

--- a/test/hive_release_migration_test.dart
+++ b/test/hive_release_migration_test.dart
@@ -320,7 +320,9 @@ void main() {
             .single['n'];
         expect(rows, 120);
 
-        final stats = Stores.connectionStats.getServerStats('srv-pwd', 'x');
+        final stats = Stores.connectionStats.getAllServerStats().firstWhere(
+          (e) => e.serverId == 'srv-pwd',
+        );
         expect(stats.totalAttempts, 60);
         // The generator made one in five a success.
         expect(stats.successCount, 12);


### PR DESCRIPTION
Follow-up to the read-only code audit. Five small, atomic commits; no behavior change except the last fix.

## Commits

1. **refactor(benchmark): remove dead BenchmarkStore APIs** — drops the unsubscribed \_changes\/\changes\/\_invalidate\ stream, the test-only \orTest\ factory, and the unused \emoveForServer\/\llCompleted\ methods. Server deletion already cascades via FK; the tab re-reads the store on build and poll.
2. **refactor(conn-stats): remove test-only getServerStats** — the page reads \getAllServerStats\, which aggregates in SQL. Tests now assert aggregates absolutely; the Hive migration regression test reads the same list via \irstWhere\.
3. **refactor(globe): mark BundledLand.resetForTest as visibleForTesting** — matches \GeoData.resetForTest\ and \NativeExitReport.debugForgetPending\. The helper stays: static caches need a reset for test isolation.
4. **refactor(benchmark): reuse fmtDuration instead of a private duplicate** — the result page carried an identical \_fmtDuration\; \BenchmarkRunningCard\ already used the shared one.
5. **fix(benchmark): key detail pages so switching runs or servers resets state** — without keys, picking another history entry or server reused the state element: the result page kept polling the previous run id and the run page kept its \late final\ server. The single-column branch already keyed by server id; the pane branch did not.

## Verification

- \lutter analyze\: clean for \lib/\ and \	est/\ (only 3 pre-existing infos/warnings in \packages/*/example\, untouched).
- \lutter test\ could not run in this environment (\lutter_tester\ fails to start with a WebSocket upgrade error, same on unmodified \main\); rewritten expectations were verified by hand against the SQL (counts, rates, min/max timestamps, 20-row recent cap).

## Deliberately left out

- Duplicate test names and trivial \xpect\s (cosmetic; separate churn).
- \esetForTest\/\debugForgetPending\ deletion (would break test isolation; annotated instead).
- Snippet password expansion and poll-interval tuning (behavioral; need product decision).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved benchmark and server detail pages so displayed data and polling remain tied to the correct run or server.
  - Standardized duration formatting for benchmark results.

- **Changes**
  - Server connection summaries now use aggregate statistics, with empty servers omitted.
  - Removed benchmark history notifications, completion queries, and server-specific history deletion.

- **Tests**
  - Updated benchmark, connection-statistics, and migration coverage for the revised behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->