### PR TITLE
fix(bio-auth): let a device that cannot authenticate out of its own lock

### DIFF
--- a/lib/view/page/home.dart
+++ b/lib/view/page/home.dart
@@ -901,9 +901,37 @@ class _HomePageState extends ConsumerState<HomePage>
     // this branch exists for. The future completes once the pop has.
     await LocalAuthPage.route.go(
       context,
-      args: LocalAuthPageArgs(onAuthSuccess: () => _shouldAuth = false),
+      args: LocalAuthPageArgs(
+        onAuthSuccess: () => _shouldAuth = false,
+        onUnavailable: _onAuthUnavailable,
+      ),
     );
     if (showGuide) await _maybeShowNavGuide();
+  }
+
+  /// This device cannot answer the lock, so stop asking it.
+  ///
+  /// The setting is only ever true here because it arrived from somewhere else:
+  /// a backup taken on a phone, restored onto a machine with no sensor. The
+  /// lock screen has no way to open on such a machine, and the settings page
+  /// hides the switch when `LocalAuth.isAvail` is false — so the one control
+  /// that would turn it off is missing on exactly the devices that need it,
+  /// and the app was unusable (#1406).
+  ///
+  /// Written without a sync timestamp. This is a fact about *this* machine, and
+  /// stamping it would let the next sync carry it to the phone the backup came
+  /// from and silently unlock that too.
+  void _onAuthUnavailable() {
+    _shouldAuth = false;
+    final prop = Stores.setting.useBioAuth;
+    final saved = prop.store.set(prop.key, false, updateLastUpdateTsOnSet: false);
+    // `set` answers false rather than throwing. Worth a line and nothing more:
+    // the app is already past the lock either way, and the cost of a failed
+    // write is being asked once more on the next launch.
+    if (saved != true) {
+      Loggers.app.warning('Could not turn ${prop.key} off on a device '
+          'that cannot authenticate');
+    }
   }
 
   /// Let the native privacy cover come off, now that either the lock screen is

--- a/lib/view/page/setting/platform/platform_pub.dart
+++ b/lib/view/page/setting/platform/platform_pub.dart
@@ -73,30 +73,52 @@ abstract final class PlatformPublicSettings {
         title: Text(libL10n.switch_),
         subtitle: Text('${libL10n.fail}: $e', style: UIs.textGrey),
       ),
-      success: (can) {
-        can ??= false;
-        return ListTile(
-          title: Text(libL10n.switch_),
-          subtitle: can
-              ? null
-              : Text(libL10n.notExistFmt(libL10n.bioAuth), style: UIs.textGrey),
-          trailing: can
-              ? StoreSwitch(
-                  prop: Stores.setting.useBioAuth,
-                  callback: (val) async {
-                    if (val) {
-                      Stores.setting.useBioAuth.put(false);
-                      return;
-                    }
-                    // Only auth when turn off (val == false)
-                    final result = await LocalAuth.goWithResult();
-                    // If failed, turn on again
-                    if (result != AuthResult.success) {
-                      Stores.setting.useBioAuth.put(true);
-                    }
-                  },
-                )
-              : null,
+      success: (canAuth) {
+        // A `final` rather than `can ??= false`: both closures below capture
+        // it, and a captured variable is not promoted.
+        final can = canAuth ?? false;
+        final unavailable = can
+            ? null
+            : Text(libL10n.notExistFmt(libL10n.bioAuth), style: UIs.textGrey);
+        return ValBuilder(
+          listenable: Stores.setting.useBioAuth.listenable(),
+          builder: (on) {
+            // The switch used to be absent whenever the device could not
+            // authenticate, which is right until the setting is on anyway —
+            // and a backup restored from a phone puts it there. Then the one
+            // control that would turn it off was missing on exactly the
+            // devices that needed it, and the lock screen had nothing behind
+            // it to open (#1406). `home.dart` turns it off by itself now; this
+            // is what is left if that write ever fails.
+            if (!can && !on) {
+              return ListTile(
+                title: Text(libL10n.switch_),
+                subtitle: unavailable,
+              );
+            }
+            return ListTile(
+              title: Text(libL10n.switch_),
+              subtitle: unavailable,
+              trailing: StoreSwitch(
+                prop: Stores.setting.useBioAuth,
+                // A `validator` and not a `callback`, for the reason spelled
+                // out above `buildPrivacyBlur`: `StoreSwitch` writes the new
+                // value after the callback regardless, so the old code's
+                // "authenticate, and put the old value back if it failed" was
+                // overwritten a line later. Turning the lock *off* took no
+                // authentication at all — anyone holding an unlocked device
+                // could remove it, which is the one thing this check is for.
+                validator: (val) async {
+                  if (val) return can;
+                  // Except where nothing can be proven. Asking a machine with
+                  // no sensor to authenticate before it may stop asking for
+                  // authentication is the deadlock again, one screen along.
+                  if (!can) return true;
+                  return await LocalAuth.goWithResult() == AuthResult.success;
+                },
+              ),
+            );
+          },
         );
       },
     );

--- a/test/bio_auth_unavailable_test.dart
+++ b/test/bio_auth_unavailable_test.dart
@@ -1,0 +1,153 @@
+/// A lock nothing on this device can open (#1406).
+///
+/// `useBioAuth` is stored, synced and restored, so it arrives on machines that
+/// were never asked whether they could satisfy it — the reported case is a
+/// phone's backup restored onto a Linux desktop. The lock screen then has no
+/// way to open, and `PopScope(canPop: false)` there turns the back gesture into
+/// "quit the app", so the app is unusable until the setting goes away.
+///
+/// `LocalAuth` is stubbed to the reported device: nothing available, so every
+/// prompt answers `notAvail`. Stubbed rather than left to the plugin, because a
+/// plugin call's future does not complete inside a `testWidgets` fake-async
+/// zone — the settings tile then renders its loading state for ever, and the
+/// test reads as "the switch is missing" whatever the code does.
+library;
+
+import 'package:fl_lib/fl_lib.dart';
+import 'package:fl_lib/generated/l10n/lib_l10n.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:server_box/data/res/store.dart';
+import 'package:server_box/data/store/setting.dart';
+import 'package:server_box/generated/l10n/l10n.dart';
+import 'package:server_box/view/page/setting/platform/platform_pub.dart';
+
+import 'helpers/test_db.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await openTestDb();
+    getIt.registerSingleton<SettingStore>(SettingStore('setting_test'));
+    LocalAuth.isAvailForTest = () async => false;
+    LocalAuth.goWithResultForTest = ({bool onlyBio = false}) async =>
+        AuthResult.notAvail;
+  });
+
+  tearDown(() async {
+    LocalAuth.isAvailForTest = null;
+    LocalAuth.goWithResultForTest = null;
+    await getIt.reset();
+    await SqliteDb.close();
+  });
+
+  test('turning the lock off is not a user edit', () async {
+    // What `home.dart` does when the lock screen reports it cannot open. It is
+    // a fact about *this* machine: stamped, the next sync would carry it to the
+    // phone the backup came from and silently unlock that too.
+    final prop = Stores.setting.useBioAuth;
+    prop.store.set(prop.key, true, updateLastUpdateTsOnSet: false);
+    final before = Stores.setting.lastUpdateTs;
+
+    final saved = prop.store.set(
+      prop.key,
+      false,
+      updateLastUpdateTsOnSet: false,
+    );
+
+    expect(saved, isTrue);
+    expect(prop.fetch(), isFalse);
+    expect(Stores.setting.lastUpdateTs, before);
+  });
+
+  Future<void> pumpSetting(WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: const [
+          LibLocalizations.delegate,
+          ...AppLocalizations.localizationsDelegates,
+        ],
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(
+          body: ListView(children: [PlatformPublicSettings.buildBioAuth]),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+    // The tile is inside an `ExpandTile`, closed by default.
+    await tester.tap(find.text(libL10n.bioAuth));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+  }
+
+  testWidgets('a device that cannot authenticate can still turn the lock off', (
+    tester,
+  ) async {
+    // The switch used to be absent whenever `isAvail` was false, so the setting
+    // could arrive on such a device and there was no control to remove it with.
+    Stores.setting.useBioAuth.put(true);
+
+    await pumpSetting(tester);
+    expect(
+      find.byType(Switch),
+      findsOneWidget,
+      reason: 'no way to turn off a lock this device can never open',
+    );
+
+    await tester.tap(find.byType(Switch));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(Stores.setting.useBioAuth.fetch(), isFalse);
+  });
+
+  testWidgets('on a device that can authenticate, turning it off asks first', (
+    tester,
+  ) async {
+    // The check that was silently doing nothing. `StoreSwitch` writes the new
+    // value after its `callback` regardless of what the callback did, so the
+    // old "authenticate, and put the old value back on failure" was overwritten
+    // a line later: anyone holding an unlocked device could remove the lock,
+    // which is the one thing this asks about.
+    LocalAuth.isAvailForTest = () async => true;
+    LocalAuth.goWithResultForTest = ({bool onlyBio = false}) async =>
+        AuthResult.fail;
+    Stores.setting.useBioAuth.put(true);
+
+    await pumpSetting(tester);
+    await tester.tap(find.byType(Switch));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(
+      Stores.setting.useBioAuth.fetch(),
+      isTrue,
+      reason: 'the lock came off without anyone proving anything',
+    );
+
+    // And it does come off once the prompt is satisfied.
+    LocalAuth.goWithResultForTest = ({bool onlyBio = false}) async =>
+        AuthResult.success;
+    await tester.tap(find.byType(Switch));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+
+    expect(Stores.setting.useBioAuth.fetch(), isFalse);
+  });
+
+  testWidgets('and cannot turn it on', (tester) async {
+    // The other direction is still refused: switching it on here would put the
+    // app straight back behind a lock with nothing to open it.
+    await pumpSetting(tester);
+
+    expect(find.byType(Switch), findsNothing);
+    expect(
+      find.text(libL10n.notExistFmt(libL10n.bioAuth)),
+      findsWidgets,
+      reason: 'the reason the switch is absent should be on screen',
+    );
+    expect(Stores.setting.useBioAuth.fetch(), isFalse);
+  });
+}


### PR DESCRIPTION
Closes #1406.

The fl_lib half is lollipopkit/fl_lib#53, merged; the gitlink here points at it (`95ebeb5`).

## The app could be locked out of itself

`useBioAuth` is stored, synced and restored, so it reaches machines that were never asked whether they could satisfy it. The reported route is a phone's backup restored onto a Linux Mint desktop. On such a machine:

- `LocalAuth.isAvail` is false — no sensor, and no `local_auth` implementation for the platform — so every attempt answers `notAvail`.
- `LocalAuthPage` acted on `success` and discarded everything else, so the screen did nothing when tapped. That is the fl_lib half.
- `PopScope(canPop: false)` there turns the back gesture into `SystemNavigator.pop()`, so the only other option was quitting.
- And the settings page hid the switch entirely whenever `isAvail` was false — **the one control that would remove the setting was missing on exactly the devices that needed it.**

The reporter's own summary — "there should be a check if the machine has any kind of authentication" — is right about the diagnosis. It also asks for a password fallback; I have not added one. This setting is a local convenience lock and guards no key material (the database key lives in the keychain), so on a device that cannot authenticate the correct behaviour is to let go, not to invent a second credential with its own ways to get stuck.

## Three parts

**`home.dart` stops asking.** It passes `onUnavailable` and turns the setting off from it. Written without a sync timestamp — `store.set(..., updateLastUpdateTsOnSet: false)` — because it is a fact about *this* machine. Stamped, the next sync would carry it back to the phone the backup came from and silently unlock that too, which is the wrong direction for a security setting to travel.

**The settings switch is present whenever the setting is on**, available or not, so there is always a way off. Turning it *on* where nothing can authenticate is still refused. Belt and braces to the above: if that write ever fails, the user is not stuck.

**That switch's authenticate-before-turning-off check never worked.** `StoreSwitch._handleChange` awaits `callback`, then writes the new value regardless:

```dart
await widget.callback?.call(newValue);
await widget.prop.set(newValue);        // overwrites whatever the callback stored
```

So the old code's "authenticate, and put the old value back if it failed" was undone one line later, and **turning the lock off took no authentication at all** — anyone holding an unlocked device could remove it, which is the single thing that check exists for. It is a `validator` now. `buildPrivacyBlur`, twenty lines up in the same file, already carries a comment explaining exactly this ("A `validator` and not a `callback`"); this one predates it.

Turning it off on a device that *cannot* authenticate still asks for nothing. Requiring a prompt before you may stop requiring prompts is the same deadlock, one screen along.

## Tests

`test/bio_auth_unavailable_test.dart`. `LocalAuth` is stubbed through the new hooks rather than left to the plugin: a plugin call's future does not complete inside a `testWidgets` fake-async zone, so the settings tile renders its loading state for ever and the test reads as "the switch is missing" whatever the code does — which is how the first draft of these passed against the bug.

- Turning the lock off is not a user edit (`lastUpdateTs` unchanged).
- A device that cannot authenticate can still turn the lock off — and cannot turn it on.
- On a device that *can*, turning it off asks first, and refuses when the prompt fails.

The two behavioural ones fail against the previous `platform_pub.dart` and pass against this one; verified by stashing that file alone.

`flutter analyze` clean, 2546 passing. `windows_install_ssh_e2e_test.dart` fails for want of `SBM_E2E_SSH_KEY_PASSPHRASE`, as it does on `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Users can disable biometric locking when authentication is unavailable.
  - Enabling biometric locking still requires an available device and successful authentication.
  - Disabling an unavailable biometric lock no longer updates synchronization timestamps.
  - Pending authentication state is cleared when biometric authentication is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->