### PR TITLE
fix(ui): cap the Agent's command previews, and put the settings tabs back

### DIFF
--- a/lib/view/page/agent/view.dart
+++ b/lib/view/page/agent/view.dart
@@ -300,10 +300,7 @@ class _AgentConversationViewState extends ConsumerState<AgentConversationView> {
           children: [
             Text(context.l10n.askAiHighRiskConfirmBody),
             const SizedBox(height: 12),
-            SelectableText(
-              proposal.displayValue,
-              style: const TextStyle(fontFamily: 'monospace'),
-            ),
+            AgentCommandPreview(text: proposal.displayValue),
           ],
         ),
         actionsBuilder: (dialogContext) => [
@@ -908,8 +905,8 @@ class _AgentConversationViewState extends ConsumerState<AgentConversationView> {
                   color: theme.colorScheme.surfaceContainerHighest,
                   borderRadius: BorderRadius.circular(10),
                 ),
-                child: SelectableText(
-                  detail,
+                child: AgentCommandPreview(
+                  text: detail,
                   style: theme.textTheme.bodyMedium?.copyWith(
                     fontFamily: proposal.toolName == 'run_shell_command'
                         ? 'monospace'
@@ -922,18 +919,15 @@ class _AgentConversationViewState extends ConsumerState<AgentConversationView> {
               const SizedBox(height: 10),
               Container(
                 width: double.infinity,
-                constraints: const BoxConstraints(maxHeight: 240),
                 padding: const EdgeInsets.all(12),
                 decoration: BoxDecoration(
                   color: theme.colorScheme.surfaceContainerHighest,
                   borderRadius: BorderRadius.circular(10),
                 ),
-                child: SingleChildScrollView(
-                  child: SelectableText(
-                    content,
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      fontFamily: 'monospace',
-                    ),
+                child: AgentCommandPreview(
+                  text: content,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    fontFamily: 'monospace',
                   ),
                 ),
               ),

--- a/lib/view/page/agent/view.dart
+++ b/lib/view/page/agent/view.dart
@@ -300,7 +300,12 @@ class _AgentConversationViewState extends ConsumerState<AgentConversationView> {
           children: [
             Text(context.l10n.askAiHighRiskConfirmBody),
             const SizedBox(height: 12),
-            AgentCommandPreview(text: proposal.displayValue),
+            AgentCommandPreview(
+              text: proposal.displayValue,
+              language: proposal.toolName == 'run_shell_command'
+                  ? 'shell'
+                  : 'text',
+            ),
           ],
         ),
         actionsBuilder: (dialogContext) => [
@@ -907,6 +912,12 @@ class _AgentConversationViewState extends ConsumerState<AgentConversationView> {
                 ),
                 child: AgentCommandPreview(
                   text: detail,
+                  // Only one of these tools takes a command. The rest put a
+                  // path or an action here, and tagging those as shell would
+                  // be a claim about them that is not true.
+                  language: proposal.toolName == 'run_shell_command'
+                      ? 'shell'
+                      : 'text',
                   style: theme.textTheme.bodyMedium?.copyWith(
                     fontFamily: proposal.toolName == 'run_shell_command'
                         ? 'monospace'
@@ -926,6 +937,9 @@ class _AgentConversationViewState extends ConsumerState<AgentConversationView> {
                 ),
                 child: AgentCommandPreview(
                   text: content,
+                  // What a `write_file` would write. Whatever it is, it is not
+                  // a command.
+                  language: 'text',
                   style: theme.textTheme.bodySmall?.copyWith(
                     fontFamily: 'monospace',
                   ),

--- a/lib/view/page/setting/entries/app.dart
+++ b/lib/view/page/setting/entries/app.dart
@@ -8,26 +8,22 @@ extension _App on _AppSettingsPageState {
   Widget _buildApp() {
     final androidSettings = isAndroid ? _buildAndroidSettings() : null;
     final specific = _buildPlatformSetting();
-    final children = <Widget>[
-      _buildLocale().cardx,
-      _buildThemeMode().cardx,
-      _buildAppColor().cardx,
-      _buildCheckUpdate().cardx,
+    final children = [
+      _buildLocale(),
+      _buildThemeMode(),
+      _buildAppColor(),
+      _buildCheckUpdate(),
       PlatformPublicSettings.buildBioAuth,
       // `buildPrivacyBlur` was here. Covering the app in the switcher is about
       // who can read what is on screen, which is what the privacy page is —
       // and a setting is easier to find under the subject it belongs to than
       // in the list of everything.
-      if (androidSettings != null) androidSettings.cardx,
-      if (specific != null) specific.cardx,
-      _buildBeta().cardx,
-      if (isMobile) _buildWakeLock().cardx,
-      _buildCollapseUI().cardx,
-      if (isDesktop) _buildHideTitleBar().cardx,
-      if (kDebugMode) _buildEditRawSettings().cardx,
+      ?androidSettings,
+      ?specific,
+      _buildAppMore(),
     ];
 
-    return Column(children: children);
+    return Column(children: children.map((e) => e.cardx).toList());
   }
 
   Widget _buildAndroidSettings() {
@@ -325,6 +321,23 @@ extension _App on _AppSettingsPageState {
         listenable: _setting.locale.listenable(),
         builder: () => Text(context.localeNativeName, style: UIs.text15),
       ),
+    );
+  }
+
+  Widget _buildAppMore() {
+    return ExpandTile(
+      leading: const Icon(MingCute.more_3_fill),
+      title: Text(libL10n.more),
+      initiallyExpanded: false,
+      children: [
+        _buildBeta(),
+        if (isMobile) _buildWakeLock(),
+        _buildCollapseUI(),
+        if (isDesktop) _buildHideTitleBar(),
+        // Debug only, which is where it was moved to while these rows were
+        // flat. Folding them back does not put it back in a release build.
+        if (kDebugMode) _buildEditRawSettings(),
+      ],
     );
   }
 

--- a/lib/view/page/setting/entries/app.dart
+++ b/lib/view/page/setting/entries/app.dart
@@ -8,22 +8,27 @@ extension _App on _AppSettingsPageState {
   Widget _buildApp() {
     final androidSettings = isAndroid ? _buildAndroidSettings() : null;
     final specific = _buildPlatformSetting();
-    final children = [
-      _buildLocale(),
-      _buildThemeMode(),
-      _buildAppColor(),
-      _buildCheckUpdate(),
+    // Carded one by one rather than by mapping the list. `buildBioAuth` owns
+    // its own card and answers with an empty widget where there is no
+    // biometric hardware, where it is still loading, and where the check
+    // failed — so a card applied from out here is a card around nothing three
+    // times over, and a card around a card in the one case it has something.
+    final children = <Widget>[
+      _buildLocale().cardx,
+      _buildThemeMode().cardx,
+      _buildAppColor().cardx,
+      _buildCheckUpdate().cardx,
       PlatformPublicSettings.buildBioAuth,
       // `buildPrivacyBlur` was here. Covering the app in the switcher is about
       // who can read what is on screen, which is what the privacy page is —
       // and a setting is easier to find under the subject it belongs to than
       // in the list of everything.
-      ?androidSettings,
-      ?specific,
-      _buildAppMore(),
+      if (androidSettings != null) androidSettings.cardx,
+      if (specific != null) specific.cardx,
+      _buildAppMore().cardx,
     ];
 
-    return Column(children: children.map((e) => e.cardx).toList());
+    return Column(children: children);
   }
 
   Widget _buildAndroidSettings() {

--- a/lib/view/page/setting/entry.dart
+++ b/lib/view/page/setting/entry.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:math' as math;
+import 'dart:ui' show ImageFilter;
 
 import 'package:dynamic_color/dynamic_color.dart';
 import 'package:file_picker/file_picker.dart';
@@ -544,7 +546,16 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
             collapseTooltip: libL10n.fold,
             expandTooltip: libL10n.open,
             listBuilder: (_, _) => menu,
-            surfaceBuilder: (_, _) => content,
+            // A `Builder` so the insets read below are the ones this body
+            // actually has: the state's own context is above the `Scaffold`,
+            // where `padding` is still the whole window's — the status bar the
+            // app bar already covers, and the home indicator the `SafeArea`
+            // just above here already cleared.
+            surfaceBuilder: (ctx, split) => split
+                ? content
+                : Builder(
+                    builder: (ctx) => _buildNarrow(ctx, nodes, content),
+                  ),
           ),
         ),
       ),
@@ -603,7 +614,6 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
       return _SettingsPages(
         key: ValueKey('pages_${leaves.firstOrNull?.id ?? 'none'}'),
         leaves: leaves,
-        showTabBar: !wide && leaves.length > 1,
         selectedId: selected.id,
         onChanged: _onSelect,
       );
@@ -648,6 +658,83 @@ class _SettingsPageState extends ConsumerState<SettingsPage> {
     return NavigatorPopHandler(
       onPopWithResult: (_) => _contentNav.currentState?.pop(),
       child: navigator,
+    );
+  }
+
+  /// The content with the tabs floating over its foot.
+  ///
+  /// The content fills the body and the bar sits over it, so what is on the page
+  /// carries on under the bar instead of stopping at a bare strip above it. The
+  /// room a list needs to bring its last row into the clear arrives as
+  /// [MediaQuery] padding, which `context.padBottom` puts on the scrollable —
+  /// padding a list can scroll through, rather than a strip taken out of the
+  /// page's box.
+  ///
+  /// [context] has to be one from inside the body — see where this is called.
+  Widget _buildNarrow(
+    BuildContext context,
+    List<SettingsNode> nodes,
+    Widget content,
+  ) {
+    final mediaQuery = MediaQuery.of(context);
+    // Nothing over the list — a bar of tabs there would be the same names
+    // twice — and nothing over a leaf, which has no level under it to show.
+    final entered = _path.lastOrNull;
+    final level = entered == null || entered.isLeaf ? null : entered;
+    final space = level == null ? 0.0 : _kTabsHeight + _kTabsMargin * 2;
+
+    return Stack(
+      // Nothing here should reach past the floor of this box — the page is
+      // pushed into the home tab's navigator, and the `Scaffold` paints its
+      // bottom bar after the body, so anything that does is covered rather than
+      // shown. `none` only keeps the clip from being what cuts it: the bar
+      // carries its own margin, so it stops short of the floor on its own.
+      clipBehavior: Clip.none,
+      children: [
+        MediaQuery(
+          data: mediaQuery.copyWith(
+            padding: mediaQuery.padding.copyWith(
+              bottom: mediaQuery.padding.bottom + space,
+            ),
+          ),
+          child: content,
+        ),
+        // Edge to edge, and the bar centres itself within that: it is as wide
+        // as the level it is showing, and only scrolls when that is too wide.
+        //
+        // Flush with the floor, because the gap the bar stands in is padding
+        // inside it now. Lifting it from here as well would move it up by that
+        // much again, and put the shadow back outside the clip it just left.
+        Positioned(
+          left: 0,
+          right: 0,
+          bottom: 0,
+          child: AnimatedSwitcher(
+            duration: Durations.medium2,
+            // Springs up past its place and settles, as displacement does
+            // elsewhere. No fade with it: the curve overshoots, and an opacity
+            // past 1 asserts.
+            switchInCurve: _kTabsCurve,
+            switchOutCurve: Curves.easeIn,
+            transitionBuilder: (child, animation) => SlideTransition(
+              position: Tween(
+                // Far enough to take the shadow with it.
+                begin: const Offset(0, 1.4),
+                end: Offset.zero,
+              ).animate(animation),
+              child: child,
+            ),
+            child: level == null
+                ? const SizedBox(key: ValueKey('no_tabs'), width: double.infinity)
+                : _SettingsTabs(
+                    key: ValueKey(level.id),
+                    nodes: _levelOf(level),
+                    selectedId: _selectedId,
+                    onTap: _onTab,
+                  ),
+          ),
+        ),
+      ],
     );
   }
 }
@@ -859,3 +946,4 @@ final class _AppSettingsPageState extends ConsumerState<AppSettingsPage> {
     );
   }
 }
+

--- a/lib/view/page/setting/entry.dart
+++ b/lib/view/page/setting/entry.dart
@@ -57,6 +57,7 @@ import 'package:server_box/view/widget/crash_report_dialog.dart';
 import 'package:server_box/view/widget/diagnostics_level_picker.dart';
 import 'package:server_box/view/widget/dist_icon.dart';
 import 'package:server_box/view/widget/dmg_notice.dart';
+import 'package:server_box/view/widget/edge_fade_scroll.dart';
 import 'package:server_box/view/widget/geo_data_install.dart';
 import 'package:server_box/view/widget/pane_settings.dart';
 import 'package:server_box/view/widget/rootfs_install.dart';

--- a/lib/view/page/setting/menu.dart
+++ b/lib/view/page/setting/menu.dart
@@ -50,13 +50,215 @@ final class SettingsNode {
   }
 }
 
+/// Height of the floating tab bar, and the gap around it.
+///
+/// The gap is carried by the bar's own padding rather than by where it is
+/// placed, so that its shadow falls inside the scroll view that clips it. The
+/// two shadows are written to stay within this much — see where they are built.
+const _kTabsHeight = 56.0;
+const _kTabsMargin = 12.0;
+
+/// Displacement springs past its mark and settles, as it does elsewhere.
+/// Only the bar's own width: a size factor past 1 would be a gap.
+const _kTabsCurve = Curves.easeOutBack;
+
 /// Names the menu — the column beside the content, or the list a narrow
 /// window starts on. Only ever one of them is in the tree.
 const settingsMenuKey = ValueKey('settings_menu');
 
-/// Names the native tab bar. Several of its labels are also words in the
+/// Names the floating tab bar. Several of its labels are also words in the
 /// settings behind it, so finding one means saying which of the two is meant.
 const settingsTabsKey = ValueKey('settings_tabs');
+
+/// The same tree as [_SettingsMenu], one level at a time.
+///
+/// A narrow window has no room for a column beside the content, and a drawer
+/// hides where you are the moment you have gone there. This shows the level you
+/// are on, floating over the foot of the content.
+///
+/// Only the level: the way back out is the title bar's own button, which is
+/// where every other page in the app puts it. A second one here was the same
+/// move twice on one screen.
+final class _SettingsTabs extends StatelessWidget {
+  /// The level being shown, which is the root or one branch's children.
+  final List<SettingsNode> nodes;
+
+  final String? selectedId;
+  final void Function(SettingsNode node) onTap;
+
+  const _SettingsTabs({
+    super.key,
+    required this.nodes,
+    required this.selectedId,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final radius = BorderRadius.circular(_kTabsHeight / 2);
+
+    final row = SizedBox(
+      height: _kTabsHeight,
+      child: Row(
+        // As wide as what is on it. A level of two tabs is a short bar.
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const SizedBox(width: 4),
+          for (final node in nodes)
+            _TabButton(
+              icon: node.icon,
+              label: node.title,
+              // A branch counts as on while what is showing is inside it.
+              selected: node.flattened.any((e) => e.id == selectedId),
+              onTap: () => onTap(node),
+            ),
+          const SizedBox(width: 4),
+        ],
+      ),
+    );
+
+    // Translucent and blurring what goes behind it, because the content runs
+    // the full height of the page and passes under here rather than stopping
+    // above it. Opaque, the bar sat in a band of bare background and read as a
+    // second bottom bar instead of as something over the page.
+    //
+    // The shadow is outside the clip: inside, the rounded rect that keeps the
+    // blur in would cut it off.
+    //
+    // An elevation and not a single `BoxShadow`: one soft shadow at 16% is
+    // visible over the content on a full page and invisible over the bare
+    // background of a short one, which is where it was first noticed. What
+    // Flutter draws for an elevation carries far enough to read either way.
+    final bar = Material(
+      color: Colors.transparent,
+      elevation: 8,
+      shadowColor: Colors.black.withValues(alpha: 0.34),
+      borderRadius: radius,
+      child: ClipRRect(
+        borderRadius: radius,
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 18, sigmaY: 18),
+          child: Material(
+            key: settingsTabsKey,
+            color: scheme.surfaceContainerHigh.withValues(alpha: 0.72),
+            // Around the row rather than inside it, so the bar itself is what
+            // springs between one level's width and the next. Inside, the
+            // overshoot would be a gap opening at the end of a bar that had
+            // already stopped growing.
+            child: AnimatedSize(
+              duration: Durations.medium2,
+              curve: _kTabsCurve,
+              alignment: Alignment.centerLeft,
+              child: row,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Centred while it fits and scrolled when it does not: the first level has
+    // more tabs than a phone is wide, and the levels under it have three.
+    //
+    // The vertical padding is the room the shadow needs. A scroll view clips to
+    // its viewport, and this one's viewport is as tall as the bar exactly — so
+    // the shadow was cut off above and below while the sides, which have the
+    // width of the page to spread into, kept theirs. Padding grows the viewport
+    // instead of turning the clip off, which the horizontal axis still needs:
+    // a level too wide for the phone has to scroll out of sight, not spill.
+    //
+    // It is padding here rather than an offset on the `Positioned` that places
+    // this, so the bar sits where it always did — see [_kTabsMargin].
+    return LayoutBuilder(
+      builder: (context, constraints) => SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.all(_kTabsMargin),
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            minWidth: math.max(0, constraints.maxWidth - _kTabsMargin * 2),
+          ),
+          child: Row(mainAxisAlignment: MainAxisAlignment.center, children: [bar]),
+        ),
+      ),
+    );
+  }
+}
+
+final class _TabButton extends StatelessWidget {
+  final IconData icon;
+  final String? label;
+  final bool selected;
+  final VoidCallback? onTap;
+
+  const _TabButton({
+    required this.icon,
+    this.label,
+    this.selected = false,
+    this.onTap,
+  });
+
+  /// The pill behind the icon, at the measurements `NavigationBar` uses.
+  ///
+  /// It sizes the icon's background and nothing else. The label below is left
+  /// to its own width, so a tab is as wide as its name — the pill only sets
+  /// how narrow a short one can get.
+  static const _indicator = Size(56, 30);
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final color = selected ? scheme.onSecondaryContainer : scheme.onSurfaceVariant;
+
+    return InkWell(
+      onTap: onTap,
+      child: Padding(
+        // Wider than it was. The label used to sit in a fixed box and centre
+        // itself in it, which left a gap either side whatever it said; now it
+        // reaches the edges of its tab, and two of them need keeping apart.
+        padding: const EdgeInsets.symmetric(horizontal: 8),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            // Around the icon and not the label, the way the rail on the home
+            // page marks its own destination.
+            AnimatedContainer(
+              duration: Durations.short3,
+              curve: Curves.easeOut,
+              width: _indicator.width,
+              height: _indicator.height,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: selected ? scheme.secondaryContainer : null,
+                borderRadius: BorderRadius.circular(_indicator.height / 2),
+              ),
+              child: Icon(icon, size: 20, color: color),
+            ),
+            if (label != null) ...[
+              const SizedBox(height: 3),
+              // Unconstrained: a tab is as wide as its own name. Held to the
+              // pill's width these ellipsed — they are section names, not the
+              // one or two words a bottom bar carries, and several languages
+              // spell them longer still. The bar already scrolls sideways when
+              // a level does not fit across the window, so the room is there
+              // to be taken.
+              Text(
+                label!,
+                maxLines: 1,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  fontSize: 11,
+                  height: 1.1,
+                  fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
+                  color: color,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
 
 /// One row of the narrow list.
 ///
@@ -116,21 +318,20 @@ final class _SettingsList extends StatelessWidget {
   }
 }
 
-/// One level's leaves, with the native tab bar above them.
+/// One level's leaves, side by side.
 ///
-/// `TabBar` and `TabBarView` share a `TabController`, so tapping or swiping a
-/// setting uses the same Material tab behavior and keeps the selected setting
-/// in sync with the settings navigator.
+/// A [PageView] rather than one page swapped for another: the tabs under it are
+/// siblings, so moving between them is moving along a row, and it should look
+/// like it. Dragging the content does the same thing as tapping a tab, which is
+/// what having them side by side promises.
 final class _SettingsPages extends StatefulWidget {
   final List<SettingsNode> leaves;
-  final bool showTabBar;
   final String selectedId;
   final void Function(SettingsNode node) onChanged;
 
   const _SettingsPages({
     super.key,
     required this.leaves,
-    required this.showTabBar,
     required this.selectedId,
     required this.onChanged,
   });
@@ -139,22 +340,8 @@ final class _SettingsPages extends StatefulWidget {
   State<_SettingsPages> createState() => _SettingsPagesState();
 }
 
-class _SettingsPagesState extends State<_SettingsPages>
-    with SingleTickerProviderStateMixin {
-  late final TabController _controller;
-  late int _lastNotifiedIndex;
-
-  @override
-  void initState() {
-    super.initState();
-    final initial = _indexOf(widget.selectedId);
-    _lastNotifiedIndex = initial;
-    _controller = TabController(
-      length: widget.leaves.length,
-      initialIndex: initial,
-      vsync: this,
-    )..addListener(_onControllerChanged);
-  }
+class _SettingsPagesState extends State<_SettingsPages> {
+  late final PageController _controller = PageController(initialPage: _indexOf(widget.selectedId));
 
   int _indexOf(String id) {
     final index = widget.leaves.indexWhere((e) => e.id == id);
@@ -166,52 +353,33 @@ class _SettingsPagesState extends State<_SettingsPages>
     super.didUpdateWidget(oldWidget);
     if (widget.selectedId == oldWidget.selectedId) return;
     final target = _indexOf(widget.selectedId);
-    if (_controller.index != target) {
-      _lastNotifiedIndex = target;
-      _controller.animateTo(target);
-    }
+    if (!_controller.hasClients || _controller.page?.round() == target) return;
+    _controller.animateToPage(
+      target,
+      duration: Durations.medium2,
+      curve: Curves.easeOutCubic,
+    );
   }
 
   @override
   void dispose() {
-    _controller.removeListener(_onControllerChanged);
     _controller.dispose();
     super.dispose();
   }
 
-  void _onControllerChanged() {
-    if (_controller.indexIsChanging) return;
-    final index = _controller.index;
-    if (index == _lastNotifiedIndex || index >= widget.leaves.length) return;
-    _lastNotifiedIndex = index;
-    widget.onChanged(widget.leaves[index]);
-  }
-
   @override
   Widget build(BuildContext context) {
-    return Column(
-      children: [
-        if (widget.showTabBar)
-          Material(
-            color: Theme.of(context).scaffoldBackgroundColor,
-            child: TabBar(
-              key: settingsTabsKey,
-              controller: _controller,
-              isScrollable: true,
-              tabAlignment: TabAlignment.center,
-              tabs: [
-                for (final node in widget.leaves)
-                  Tab(icon: Icon(node.icon, size: 20), text: node.title),
-              ],
-            ),
-          ),
-        Expanded(
-          child: TabBarView(
-            controller: _controller,
-            children: [for (final leaf in widget.leaves) leaf.builder!()],
-          ),
-        ),
-      ],
+    return PageView.builder(
+      controller: _controller,
+      // Told rather than inferred: a drag that lands on another page has picked
+      // it, and the tabs have to say so.
+      onPageChanged: (index) => widget.onChanged(widget.leaves[index]),
+      itemCount: widget.leaves.length,
+      // Built as it is reached. Every page change rebuilds this widget — that
+      // is how the tabs hear about a swipe — and a `children` list builds all
+      // of a group's pages again each time, including the ones no drag can
+      // reach without passing through the neighbour first.
+      itemBuilder: (_, index) => widget.leaves[index].builder!(),
     );
   }
 }

--- a/lib/view/page/setting/menu.dart
+++ b/lib/view/page/setting/menu.dart
@@ -58,6 +58,12 @@ final class SettingsNode {
 const _kTabsHeight = 56.0;
 const _kTabsMargin = 12.0;
 
+/// How much of an end the fade covers when a level runs off it.
+///
+/// Wider than a tab's padding and narrower than a tab, so what is fading is
+/// legible as a tab rather than as a smudge or as half the bar.
+const _kTabsFade = 32.0;
+
 /// Displacement springs past its mark and settles, as it does elsewhere.
 /// Only the bar's own width: a size factor past 1 would be a gap.
 const _kTabsCurve = Curves.easeOutBack;
@@ -79,7 +85,7 @@ const settingsTabsKey = ValueKey('settings_tabs');
 /// Only the level: the way back out is the title bar's own button, which is
 /// where every other page in the app puts it. A second one here was the same
 /// move twice on one screen.
-final class _SettingsTabs extends StatelessWidget {
+final class _SettingsTabs extends StatefulWidget {
   /// The level being shown, which is the root or one branch's children.
   final List<SettingsNode> nodes;
 
@@ -94,8 +100,63 @@ final class _SettingsTabs extends StatelessWidget {
   });
 
   @override
+  State<_SettingsTabs> createState() => _SettingsTabsState();
+}
+
+final class _SettingsTabsState extends State<_SettingsTabs> {
+  /// Read for how much is off each end, not to scroll anything.
+  final _controller = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+    // There is no position to measure until the first layout, and nothing
+    // notifies when one arrives. Without this the right edge of a level too
+    // wide for the window is cut off square until the first drag.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  /// Fades whichever end has tabs behind it, and neither when none has.
+  ///
+  /// The fade is as wide as what is hidden, up to [_kTabsFade]: a bar one
+  /// pixel from its end is a bar at its end, and a mask that ignored that
+  /// would leave the last tab permanently half faded.
+  Shader _edgeFade(Rect rect, double before, double after) {
+    final leading = (math.min(before, _kTabsFade) / rect.width).clamp(0.0, 1.0);
+    final trailing = math.max(
+      leading,
+      1 - (math.min(after, _kTabsFade) / rect.width).clamp(0.0, 1.0),
+    );
+    return LinearGradient(
+      begin: Alignment.centerLeft,
+      end: Alignment.centerRight,
+      // Alpha only: the bar floats over the page, so an end covered by a
+      // colour would hide the content it is floating over rather than the
+      // tabs running off the edge.
+      colors: const [
+        Colors.transparent,
+        Colors.black,
+        Colors.black,
+        Colors.transparent,
+      ],
+      stops: [0, leading, trailing, 1],
+    ).createShader(rect);
+  }
+
+  @override
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
+    final nodes = widget.nodes;
+    final selectedId = widget.selectedId;
+    final onTap = widget.onTap;
     final radius = BorderRadius.circular(_kTabsHeight / 2);
 
     final row = SizedBox(
@@ -130,10 +191,14 @@ final class _SettingsTabs extends StatelessWidget {
     // visible over the content on a full page and invisible over the bare
     // background of a short one, which is where it was first noticed. What
     // Flutter draws for an elevation carries far enough to read either way.
+    //
+    // Low, because the bar only has to read as being over the page. At 8 and
+    // a third of black it was a dark band under the bar, which on a light
+    // theme is the most prominent thing on the screen.
     final bar = Material(
       color: Colors.transparent,
-      elevation: 8,
-      shadowColor: Colors.black.withValues(alpha: 0.34),
+      elevation: 3,
+      shadowColor: Colors.black.withValues(alpha: 0.18),
       borderRadius: radius,
       child: ClipRRect(
         borderRadius: radius,
@@ -169,8 +234,9 @@ final class _SettingsTabs extends StatelessWidget {
     //
     // It is padding here rather than an offset on the `Positioned` that places
     // this, so the bar sits where it always did — see [_kTabsMargin].
-    return LayoutBuilder(
+    final scroller = LayoutBuilder(
       builder: (context, constraints) => SingleChildScrollView(
+        controller: _controller,
         scrollDirection: Axis.horizontal,
         padding: const EdgeInsets.all(_kTabsMargin),
         child: ConstrainedBox(
@@ -179,6 +245,42 @@ final class _SettingsTabs extends StatelessWidget {
           ),
           child: Row(mainAxisAlignment: MainAxisAlignment.center, children: [bar]),
         ),
+      ),
+    );
+
+    // A level wider than the window ends at the window's edge, and a tab cut
+    // off square there reads as the last one rather than as one of several
+    // more. Fading it says the bar carries on.
+    //
+    // Rebuilt on scroll through the controller, and on a change of metrics
+    // that no scroll caused — the bar grows and shrinks between levels, which
+    // is what decides whether there is anything off the end at all.
+    return NotificationListener<ScrollMetricsNotification>(
+      onNotification: (_) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) setState(() {});
+        });
+        return false;
+      },
+      child: AnimatedBuilder(
+        animation: _controller,
+        child: scroller,
+        builder: (context, child) {
+          final position = _controller.positions.length == 1
+              ? _controller.position
+              : null;
+          final before = position?.extentBefore ?? 0;
+          final after = position?.extentAfter ?? 0;
+          // Nothing off either end: no mask at all rather than one that does
+          // nothing, because the mask is a `saveLayer` and the bar under it
+          // is blurring what it stands over.
+          if (before < 0.5 && after < 0.5) return child!;
+          return ShaderMask(
+            blendMode: BlendMode.dstIn,
+            shaderCallback: (rect) => _edgeFade(rect, before, after),
+            child: child,
+          );
+        },
       ),
     );
   }

--- a/lib/view/page/setting/menu.dart
+++ b/lib/view/page/setting/menu.dart
@@ -58,12 +58,6 @@ final class SettingsNode {
 const _kTabsHeight = 56.0;
 const _kTabsMargin = 12.0;
 
-/// How much of an end the fade covers when a level runs off it.
-///
-/// Wider than a tab's padding and narrower than a tab, so what is fading is
-/// legible as a tab rather than as a smudge or as half the bar.
-const _kTabsFade = 32.0;
-
 /// Displacement springs past its mark and settles, as it does elsewhere.
 /// Only the bar's own width: a size factor past 1 would be a gap.
 const _kTabsCurve = Curves.easeOutBack;
@@ -85,7 +79,7 @@ const settingsTabsKey = ValueKey('settings_tabs');
 /// Only the level: the way back out is the title bar's own button, which is
 /// where every other page in the app puts it. A second one here was the same
 /// move twice on one screen.
-final class _SettingsTabs extends StatefulWidget {
+final class _SettingsTabs extends StatelessWidget {
   /// The level being shown, which is the root or one branch's children.
   final List<SettingsNode> nodes;
 
@@ -100,63 +94,8 @@ final class _SettingsTabs extends StatefulWidget {
   });
 
   @override
-  State<_SettingsTabs> createState() => _SettingsTabsState();
-}
-
-final class _SettingsTabsState extends State<_SettingsTabs> {
-  /// Read for how much is off each end, not to scroll anything.
-  final _controller = ScrollController();
-
-  @override
-  void initState() {
-    super.initState();
-    // There is no position to measure until the first layout, and nothing
-    // notifies when one arrives. Without this the right edge of a level too
-    // wide for the window is cut off square until the first drag.
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) setState(() {});
-    });
-  }
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
-  /// Fades whichever end has tabs behind it, and neither when none has.
-  ///
-  /// The fade is as wide as what is hidden, up to [_kTabsFade]: a bar one
-  /// pixel from its end is a bar at its end, and a mask that ignored that
-  /// would leave the last tab permanently half faded.
-  Shader _edgeFade(Rect rect, double before, double after) {
-    final leading = (math.min(before, _kTabsFade) / rect.width).clamp(0.0, 1.0);
-    final trailing = math.max(
-      leading,
-      1 - (math.min(after, _kTabsFade) / rect.width).clamp(0.0, 1.0),
-    );
-    return LinearGradient(
-      begin: Alignment.centerLeft,
-      end: Alignment.centerRight,
-      // Alpha only: the bar floats over the page, so an end covered by a
-      // colour would hide the content it is floating over rather than the
-      // tabs running off the edge.
-      colors: const [
-        Colors.transparent,
-        Colors.black,
-        Colors.black,
-        Colors.transparent,
-      ],
-      stops: [0, leading, trailing, 1],
-    ).createShader(rect);
-  }
-
-  @override
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
-    final nodes = widget.nodes;
-    final selectedId = widget.selectedId;
-    final onTap = widget.onTap;
     final radius = BorderRadius.circular(_kTabsHeight / 2);
 
     final row = SizedBox(
@@ -234,53 +173,26 @@ final class _SettingsTabsState extends State<_SettingsTabs> {
     //
     // It is padding here rather than an offset on the `Positioned` that places
     // this, so the bar sits where it always did — see [_kTabsMargin].
-    final scroller = LayoutBuilder(
-      builder: (context, constraints) => SingleChildScrollView(
-        controller: _controller,
-        scrollDirection: Axis.horizontal,
-        padding: const EdgeInsets.all(_kTabsMargin),
-        child: ConstrainedBox(
-          constraints: BoxConstraints(
-            minWidth: math.max(0, constraints.maxWidth - _kTabsMargin * 2),
-          ),
-          child: Row(mainAxisAlignment: MainAxisAlignment.center, children: [bar]),
-        ),
-      ),
-    );
-
+    //
     // A level wider than the window ends at the window's edge, and a tab cut
     // off square there reads as the last one rather than as one of several
-    // more. Fading it says the bar carries on.
-    //
-    // Rebuilt on scroll through the controller, and on a change of metrics
-    // that no scroll caused — the bar grows and shrinks between levels, which
-    // is what decides whether there is anything off the end at all.
-    return NotificationListener<ScrollMetricsNotification>(
-      onNotification: (_) {
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          if (mounted) setState(() {});
-        });
-        return false;
-      },
-      child: AnimatedBuilder(
-        animation: _controller,
-        child: scroller,
-        builder: (context, child) {
-          final position = _controller.positions.length == 1
-              ? _controller.position
-              : null;
-          final before = position?.extentBefore ?? 0;
-          final after = position?.extentAfter ?? 0;
-          // Nothing off either end: no mask at all rather than one that does
-          // nothing, because the mask is a `saveLayer` and the bar under it
-          // is blurring what it stands over.
-          if (before < 0.5 && after < 0.5) return child!;
-          return ShaderMask(
-            blendMode: BlendMode.dstIn,
-            shaderCallback: (rect) => _edgeFade(rect, before, after),
-            child: child,
-          );
-        },
+    // more — hence [EdgeFadeScroll] around it, which says the bar carries on.
+    return EdgeFadeScroll(
+      builder: (context, controller) => LayoutBuilder(
+        builder: (context, constraints) => SingleChildScrollView(
+          controller: controller,
+          scrollDirection: Axis.horizontal,
+          padding: const EdgeInsets.all(_kTabsMargin),
+          child: ConstrainedBox(
+            constraints: BoxConstraints(
+              minWidth: math.max(0, constraints.maxWidth - _kTabsMargin * 2),
+            ),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [bar],
+            ),
+          ),
+        ),
       ),
     );
   }

--- a/lib/view/page/setting/menu.dart
+++ b/lib/view/page/setting/menu.dart
@@ -311,51 +311,57 @@ final class _TabButton extends StatelessWidget {
     final scheme = Theme.of(context).colorScheme;
     final color = selected ? scheme.onSecondaryContainer : scheme.onSurfaceVariant;
 
-    return InkWell(
-      onTap: onTap,
-      child: Padding(
-        // Wider than it was. The label used to sit in a fixed box and centre
-        // itself in it, which left a gap either side whatever it said; now it
-        // reaches the edges of its tab, and two of them need keeping apart.
-        padding: const EdgeInsets.symmetric(horizontal: 8),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            // Around the icon and not the label, the way the rail on the home
-            // page marks its own destination.
-            AnimatedContainer(
-              duration: Durations.short3,
-              curve: Curves.easeOut,
-              width: _indicator.width,
-              height: _indicator.height,
-              alignment: Alignment.center,
-              decoration: BoxDecoration(
-                color: selected ? scheme.secondaryContainer : null,
-                borderRadius: BorderRadius.circular(_indicator.height / 2),
-              ),
-              child: Icon(icon, size: 20, color: color),
-            ),
-            if (label != null) ...[
-              const SizedBox(height: 3),
-              // Unconstrained: a tab is as wide as its own name. Held to the
-              // pill's width these ellipsed — they are section names, not the
-              // one or two words a bottom bar carries, and several languages
-              // spell them longer still. The bar already scrolls sideways when
-              // a level does not fit across the window, so the room is there
-              // to be taken.
-              Text(
-                label!,
-                maxLines: 1,
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  fontSize: 11,
-                  height: 1.1,
-                  fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
-                  color: color,
+    // Which tab is on is a colour and a pill, neither of which a screen reader
+    // has any way to read. `TabBar` says it for its own tabs; this bar is not
+    // one, so it says it here.
+    return Semantics(
+      selected: selected,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          // Wider than it was. The label used to sit in a fixed box and centre
+          // itself in it, which left a gap either side whatever it said; now it
+          // reaches the edges of its tab, and two of them need keeping apart.
+          padding: const EdgeInsets.symmetric(horizontal: 8),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              // Around the icon and not the label, the way the rail on the home
+              // page marks its own destination.
+              AnimatedContainer(
+                duration: Durations.short3,
+                curve: Curves.easeOut,
+                width: _indicator.width,
+                height: _indicator.height,
+                alignment: Alignment.center,
+                decoration: BoxDecoration(
+                  color: selected ? scheme.secondaryContainer : null,
+                  borderRadius: BorderRadius.circular(_indicator.height / 2),
                 ),
+                child: Icon(icon, size: 20, color: color),
               ),
+              if (label != null) ...[
+                const SizedBox(height: 3),
+                // Unconstrained: a tab is as wide as its own name. Held to the
+                // pill's width these ellipsed — they are section names, not the
+                // one or two words a bottom bar carries, and several languages
+                // spell them longer still. The bar already scrolls sideways
+                // when a level does not fit across the window, so the room is
+                // there to be taken.
+                Text(
+                  label!,
+                  maxLines: 1,
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontSize: 11,
+                    height: 1.1,
+                    fontWeight: selected ? FontWeight.w600 : FontWeight.w500,
+                    color: color,
+                  ),
+                ),
+              ],
             ],
-          ],
+          ),
         ),
       ),
     );
@@ -445,6 +451,21 @@ final class _SettingsPages extends StatefulWidget {
 class _SettingsPagesState extends State<_SettingsPages> {
   late final PageController _controller = PageController(initialPage: _indexOf(widget.selectedId));
 
+  /// Where a tap is currently being animated to, and null the rest of the time.
+  ///
+  /// `animateToPage` scrolls through every page between here and there, and
+  /// `PageView` reports each one it passes. Without this, tapping the fourth
+  /// tab announced the second and the third on the way, which named them in
+  /// the title bar and wrote each to the settings navigator.
+  int? _animatingTo;
+
+  /// Which animation [_animatingTo] belongs to.
+  ///
+  /// A second tap mid-flight starts a second animation, and the first one's
+  /// completion still arrives. Without a generation it would clear the guard
+  /// that the animation still running had just set.
+  int _animation = 0;
+
   int _indexOf(String id) {
     final index = widget.leaves.indexWhere((e) => e.id == id);
     return index < 0 ? 0 : index;
@@ -456,11 +477,26 @@ class _SettingsPagesState extends State<_SettingsPages> {
     if (widget.selectedId == oldWidget.selectedId) return;
     final target = _indexOf(widget.selectedId);
     if (!_controller.hasClients || _controller.page?.round() == target) return;
-    _controller.animateToPage(
-      target,
-      duration: Durations.medium2,
-      curve: Curves.easeOutCubic,
-    );
+
+    final animation = ++_animation;
+    _animatingTo = target;
+    _controller
+        .animateToPage(
+          target,
+          duration: Durations.medium2,
+          curve: Curves.easeOutCubic,
+        )
+        .whenComplete(() {
+          if (!mounted || animation != _animation) return;
+          _animatingTo = null;
+          // A drag can interrupt the animation, and where it came to rest is a
+          // choice like any other — reported now rather than dropped, or the
+          // tabs would keep pointing at a page nobody is on.
+          final landed = _controller.page?.round();
+          if (landed != null && landed != target && landed < widget.leaves.length) {
+            widget.onChanged(widget.leaves[landed]);
+          }
+        });
   }
 
   @override
@@ -474,8 +510,12 @@ class _SettingsPagesState extends State<_SettingsPages> {
     return PageView.builder(
       controller: _controller,
       // Told rather than inferred: a drag that lands on another page has picked
-      // it, and the tabs have to say so.
-      onPageChanged: (index) => widget.onChanged(widget.leaves[index]),
+      // it, and the tabs have to say so. Pages passed through on the way to a
+      // tapped one are not landings — see [_animatingTo].
+      onPageChanged: (index) {
+        if (_animatingTo != null && index != _animatingTo) return;
+        widget.onChanged(widget.leaves[index]);
+      },
       itemCount: widget.leaves.length,
       // Built as it is reached. Every page change rebuilds this widget — that
       // is how the tabs hear about a swipe — and a `children` list builds all

--- a/lib/view/page/ssh/ask_ai_layout.dart
+++ b/lib/view/page/ssh/ask_ai_layout.dart
@@ -4,10 +4,6 @@ enum AskAiHistoryPresentation { bottomSheet, dialog }
 
 const askAiSidePanelBreakpoint = 800.0;
 
-double askAiCommandPreviewMaxHeightFor(double viewportHeight) {
-  return (viewportHeight * 0.3).clamp(120.0, 240.0);
-}
-
 AskAiPanelPlacement askAiPanelPlacementForWidth(double width) {
   return width >= askAiSidePanelBreakpoint
       ? AskAiPanelPlacement.sidePanel

--- a/lib/view/page/ssh/page/ask_ai.dart
+++ b/lib/view/page/ssh/page/ask_ai.dart
@@ -279,7 +279,6 @@ class _AskAiPanel extends ConsumerStatefulWidget {
 
 class _AskAiPanelState extends ConsumerState<_AskAiPanel> {
   final _scrollController = ScrollController();
-  final _commandPreviewScrollController = ScrollController();
   final _inputController = TextEditingController();
   bool _autoStarted = false;
 
@@ -308,7 +307,6 @@ class _AskAiPanelState extends ConsumerState<_AskAiPanel> {
     // session, which outlives this panel on purpose: closing it used to cancel
     // whatever was streaming, which is not what closing a window means.
     _scrollController.dispose();
-    _commandPreviewScrollController.dispose();
     _inputController
       ..removeListener(_handleInputChanged)
       ..dispose();
@@ -344,10 +342,7 @@ class _AskAiPanelState extends ConsumerState<_AskAiPanel> {
           children: [
             Text(context.l10n.askAiHighRiskConfirmBody),
             const SizedBox(height: 12),
-            SelectableText(
-              command.command,
-              style: const TextStyle(fontFamily: 'monospace'),
-            ),
+            AgentCommandPreview(text: command.command),
           ],
         ),
         actions: [
@@ -727,9 +722,6 @@ class _AskAiPanelState extends ConsumerState<_AskAiPanel> {
   ) {
     final command = session.pendingTool!;
     final canReview = session.canReviewPendingTool;
-    final commandPreviewMaxHeight = askAiCommandPreviewMaxHeightFor(
-      MediaQuery.sizeOf(context).height,
-    );
     final (label, color, icon) = switch (command.risk) {
       AskAiCommandRisk.readOnly => (
         context.l10n.askAiRiskReadOnly,
@@ -798,24 +790,14 @@ class _AskAiPanelState extends ConsumerState<_AskAiPanel> {
           const SizedBox(height: 10),
           Container(
             width: double.infinity,
-            constraints: BoxConstraints(maxHeight: commandPreviewMaxHeight),
             padding: const EdgeInsets.all(10),
             decoration: BoxDecoration(
               color: theme.colorScheme.surface,
               borderRadius: BorderRadius.circular(9),
             ),
-            child: Scrollbar(
-              controller: _commandPreviewScrollController,
-              child: SingleChildScrollView(
-                controller: _commandPreviewScrollController,
-                child: SelectableText(
-                  command.command,
-                  style: const TextStyle(
-                    fontFamily: 'monospace',
-                    fontSize: 12.5,
-                  ),
-                ),
-              ),
+            child: AgentCommandPreview(
+              text: command.command,
+              style: const TextStyle(fontFamily: 'monospace', fontSize: 12.5),
             ),
           ),
           if (command.description.isNotEmpty) ...[

--- a/lib/view/widget/agent_common.dart
+++ b/lib/view/widget/agent_common.dart
@@ -132,6 +132,67 @@ bool composerKeySends(
   return true;
 }
 
+/// How tall a command preview may be, given the height it is shown in.
+///
+/// A share of the viewport rather than a constant, so a long command does not
+/// push the buttons that approve it off a phone screen, and does not waste a
+/// desktop window's height either.
+double askAiCommandPreviewMaxHeightFor(double viewportHeight) {
+  return (viewportHeight * 0.3).clamp(120.0, 240.0);
+}
+
+/// A command, shown where it is about to be approved or declined.
+///
+/// The height cap is the point of the widget. [SelectableText] in a [Column]
+/// draws past its constraints rather than clipping, and neither `AlertDialog`
+/// nor a card scrolls its content for you — so a long enough command was drawn
+/// over the labels of the very buttons that decide it (#1462). Every surface
+/// that shows a proposal uses this, because each of them had grown its own
+/// answer to the same question and two of them had no answer at all.
+class AgentCommandPreview extends StatefulWidget {
+  const AgentCommandPreview({super.key, required this.text, this.style});
+
+  final String text;
+
+  /// Null is monospace, which is what a command wants everywhere but the one
+  /// tool call that is not a command.
+  final TextStyle? style;
+
+  @override
+  State<AgentCommandPreview> createState() => _AgentCommandPreviewState();
+}
+
+class _AgentCommandPreviewState extends State<AgentCommandPreview> {
+  final _controller = ScrollController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ConstrainedBox(
+      constraints: BoxConstraints(
+        maxHeight: askAiCommandPreviewMaxHeightFor(
+          MediaQuery.sizeOf(context).height,
+        ),
+      ),
+      child: Scrollbar(
+        controller: _controller,
+        child: SingleChildScrollView(
+          controller: _controller,
+          child: SelectableText(
+            widget.text,
+            style: widget.style ?? const TextStyle(fontFamily: 'monospace'),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 /// The failure of the last turn, with the offer to try it again.
 ///
 /// Takes the sentence rather than the error: one surface keeps the raw object

--- a/lib/view/widget/agent_common.dart
+++ b/lib/view/widget/agent_common.dart
@@ -10,6 +10,7 @@ library;
 import 'package:fl_lib/fl_lib.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:server_box/core/extension/context/locale.dart';
 import 'package:server_box/data/provider/ai/agent_session.dart';
 import 'package:server_box/data/provider/ai/ask_ai.dart';
@@ -141,18 +142,57 @@ double askAiCommandPreviewMaxHeightFor(double viewportHeight) {
   return (viewportHeight * 0.3).clamp(120.0, 240.0);
 }
 
+/// Wraps [command] in a fenced code block tagged [language].
+///
+/// The fence is as long as the command makes it need to be. A backtick is
+/// ordinary shell — `` `date` `` substitutes — and a three-tick fence would
+/// close inside one, spilling the rest of the command out of the block and
+/// through the inline parser.
+@visibleForTesting
+String fenceAgentCommand(String command, {required String language}) {
+  var longestRun = 0;
+  var run = 0;
+  for (var index = 0; index < command.length; index++) {
+    if (command.codeUnitAt(index) == 0x60) {
+      run++;
+      if (run > longestRun) longestRun = run;
+    } else {
+      run = 0;
+    }
+  }
+  final fence = '`' * (longestRun >= 3 ? longestRun + 1 : 3);
+  return '$fence$language\n$command\n$fence';
+}
+
 /// A command, shown where it is about to be approved or declined.
 ///
-/// The height cap is the point of the widget. [SelectableText] in a [Column]
-/// draws past its constraints rather than clipping, and neither `AlertDialog`
-/// nor a card scrolls its content for you — so a long enough command was drawn
-/// over the labels of the very buttons that decide it (#1462). Every surface
-/// that shows a proposal uses this, because each of them had grown its own
-/// answer to the same question and two of them had no answer at all.
+/// The height cap is the point of the widget. A text block in a [Column] draws
+/// past its constraints rather than clipping, and neither `AlertDialog` nor a
+/// card scrolls its content for you — so a long enough command was drawn over
+/// the labels of the very buttons that decide it (#1462). Every surface that
+/// shows a proposal uses this, because each of them had grown its own answer
+/// to the same question and two of them had no answer at all.
+///
+/// The command is rendered as a fenced code block, which is also what the
+/// assistant's own messages go through, so a command reads the same wherever
+/// it appears. The block carries no surface of its own: the caller draws one
+/// where there is a card, and a dialog has none.
 class AgentCommandPreview extends StatefulWidget {
-  const AgentCommandPreview({super.key, required this.text, this.style});
+  const AgentCommandPreview({
+    super.key,
+    required this.text,
+    this.language = 'shell',
+    this.style,
+  });
 
   final String text;
+
+  /// What the block is tagged as.
+  ///
+  /// `shell` wherever the text is a command, which is most of them. The two
+  /// that are not — a path, and the contents a `write_file` would write — say
+  /// so rather than claiming a syntax they do not have.
+  final String language;
 
   /// Null is monospace, which is what a command wants everywhere but the one
   /// tool call that is not a command.
@@ -173,6 +213,7 @@ class _AgentCommandPreviewState extends State<AgentCommandPreview> {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return ConstrainedBox(
       constraints: BoxConstraints(
         maxHeight: askAiCommandPreviewMaxHeightFor(
@@ -181,11 +222,21 @@ class _AgentCommandPreviewState extends State<AgentCommandPreview> {
       ),
       child: Scrollbar(
         controller: _controller,
+        // The vertical half. A code block scrolls itself sideways rather than
+        // wrapping, so a long single-line command is reachable without this
+        // one; a command written as a script is not.
         child: SingleChildScrollView(
           controller: _controller,
-          child: SelectableText(
-            widget.text,
-            style: widget.style ?? const TextStyle(fontFamily: 'monospace'),
+          child: SimpleMarkdown(
+            data: fenceAgentCommand(widget.text, language: widget.language),
+            // A command is read to be checked, and checking it includes
+            // copying it somewhere else. The default here is not selectable.
+            selectable: true,
+            styleSheet: MarkdownStyleSheet.fromTheme(theme).copyWith(
+              code: widget.style ?? const TextStyle(fontFamily: 'monospace'),
+              codeblockDecoration: const BoxDecoration(),
+              codeblockPadding: EdgeInsets.zero,
+            ),
           ),
         ),
       ),

--- a/lib/view/widget/edge_fade_scroll.dart
+++ b/lib/view/widget/edge_fade_scroll.dart
@@ -1,0 +1,113 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+/// A horizontal scroll view that fades whichever end still has content behind
+/// it.
+///
+/// A row that ends at its viewport's edge reads as a row that ends. Both bars
+/// that float over a page — the settings tabs and a server's function buttons —
+/// are as wide as what is on them until they are not, and the moment they are
+/// not is exactly when nothing says so.
+///
+/// The mask is alpha rather than a colour. Where these are used the thing
+/// behind the fade is either the page itself or the bar's own surface, and a
+/// colour picked for one is wrong over the other.
+///
+/// The scroll view is built rather than passed, because it has to take the
+/// controller this reads its position from, and a controller owned out here
+/// would be one more thing for every caller to dispose.
+class EdgeFadeScroll extends StatefulWidget {
+  const EdgeFadeScroll({super.key, required this.builder, this.fade = 32});
+
+  final Widget Function(BuildContext context, ScrollController controller)
+  builder;
+
+  /// How much of an end the fade covers when a row runs off it.
+  ///
+  /// Wide enough that what is fading reads as something continuing, narrow
+  /// enough that it is not mistaken for the row being dim.
+  final double fade;
+
+  @override
+  State<EdgeFadeScroll> createState() => _EdgeFadeScrollState();
+}
+
+class _EdgeFadeScrollState extends State<EdgeFadeScroll> {
+  /// Read for how much is off each end, not to scroll anything.
+  final _controller = ScrollController();
+
+  @override
+  void initState() {
+    super.initState();
+    // There is no position to measure until the first layout, and nothing
+    // notifies when one arrives. Without this the far end of a row too wide
+    // for its window is cut off square until the first drag.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  /// The fade is as wide as what is hidden, up to [EdgeFadeScroll.fade]: a row
+  /// one pixel from its end is a row at its end, and a mask that ignored that
+  /// would leave the last item permanently half faded.
+  Shader _edgeFade(Rect rect, double before, double after) {
+    final fade = widget.fade;
+    final leading = (math.min(before, fade) / rect.width).clamp(0.0, 1.0);
+    final trailing = math.max(
+      leading,
+      1 - (math.min(after, fade) / rect.width).clamp(0.0, 1.0),
+    );
+    return LinearGradient(
+      begin: Alignment.centerLeft,
+      end: Alignment.centerRight,
+      colors: const [
+        Colors.transparent,
+        Colors.black,
+        Colors.black,
+        Colors.transparent,
+      ],
+      stops: [0, leading, trailing, 1],
+    ).createShader(rect);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Rebuilt on scroll through the controller, and on a change of metrics
+    // that no scroll caused — these rows grow and shrink with what is on
+    // them, which is what decides whether there is anything off the end.
+    return NotificationListener<ScrollMetricsNotification>(
+      onNotification: (_) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (mounted) setState(() {});
+        });
+        return false;
+      },
+      child: AnimatedBuilder(
+        animation: _controller,
+        child: widget.builder(context, _controller),
+        builder: (context, child) {
+          final position = _controller.positions.length == 1
+              ? _controller.position
+              : null;
+          final before = position?.extentBefore ?? 0;
+          final after = position?.extentAfter ?? 0;
+          // Nothing off either end: no mask at all rather than one that does
+          // nothing, because the mask is a `saveLayer`.
+          if (before < 0.5 && after < 0.5) return child!;
+          return ShaderMask(
+            blendMode: BlendMode.dstIn,
+            shaderCallback: (rect) => _edgeFade(rect, before, after),
+            child: child,
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/view/widget/server_func_btns.dart
+++ b/lib/view/widget/server_func_btns.dart
@@ -29,6 +29,7 @@ import 'package:server_box/view/page/scheduled_tasks.dart';
 import 'package:server_box/view/page/services.dart';
 import 'package:server_box/view/page/ssh/snippet_run.dart';
 import 'package:server_box/view/page/users.dart';
+import 'package:server_box/view/widget/edge_fade_scroll.dart';
 import 'package:server_box/view/widget/server_power.dart';
 
 class ServerFuncBtns extends StatelessWidget {
@@ -54,13 +55,25 @@ class ServerFuncBtns extends StatelessWidget {
     // takes the width of what is in it and no more — and, once whatever holds
     // it runs out of room to give, scrolls instead of overflowing. One line
     // either way.
-    return ListView.separated(
-      scrollDirection: Axis.horizontal,
-      shrinkWrap: true,
-      padding: const EdgeInsets.fromLTRB(_kPad, _kVPadTop, _kPad, _kVPadBottom),
-      itemCount: items.length,
-      itemBuilder: (_, i) => items[i],
-      separatorBuilder: (_, _) => const SizedBox(width: _kGap),
+    //
+    // Faded at whichever end it is scrolling past, the way the settings tabs
+    // are: a button cut in half by the bar's edge reads as the last one, and
+    // this row is the only way to reach half of what a server can do.
+    return EdgeFadeScroll(
+      builder: (context, controller) => ListView.separated(
+        controller: controller,
+        scrollDirection: Axis.horizontal,
+        shrinkWrap: true,
+        padding: const EdgeInsets.fromLTRB(
+          _kPad,
+          _kVPadTop,
+          _kPad,
+          _kVPadBottom,
+        ),
+        itemCount: items.length,
+        itemBuilder: (_, i) => items[i],
+        separatorBuilder: (_, _) => const SizedBox(width: _kGap),
+      ),
     );
   }
 }

--- a/test/agent_command_preview_test.dart
+++ b/test/agent_command_preview_test.dart
@@ -1,3 +1,4 @@
+import 'package:fl_lib/fl_lib.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:server_box/view/widget/agent_common.dart';
@@ -19,6 +20,36 @@ void main() {
     test('caps tall viewport previews so review actions stay nearby', () {
       expect(askAiCommandPreviewMaxHeightFor(800), 240);
       expect(askAiCommandPreviewMaxHeightFor(1200), 240);
+    });
+  });
+
+  group('fenceAgentCommand', () {
+    test('tags the block with the language it was given', () {
+      expect(
+        fenceAgentCommand('ls -la', language: 'shell'),
+        '```shell\nls -la\n```',
+      );
+      expect(
+        fenceAgentCommand('/etc/hosts', language: 'text'),
+        '```text\n/etc/hosts\n```',
+      );
+    });
+
+    test('outgrows a command that contains a fence of its own', () {
+      // Command substitution is ordinary shell, and a run of three or more
+      // backticks reaches a three-tick fence's length.
+      expect(
+        fenceAgentCommand('echo `date`', language: 'shell'),
+        '```shell\necho `date`\n```',
+      );
+      expect(
+        fenceAgentCommand('cat <<EOF\n```\nEOF', language: 'shell'),
+        '````shell\ncat <<EOF\n```\nEOF\n````',
+      );
+      expect(
+        fenceAgentCommand('echo "`````"', language: 'shell'),
+        '``````shell\necho "`````"\n``````',
+      );
     });
   });
 
@@ -64,6 +95,7 @@ void main() {
       await tester.pump();
 
       expect(tester.takeException(), isNull);
+      expect(find.byType(SimpleMarkdown), findsOneWidget);
 
       final preview = tester.getRect(find.byType(AgentCommandPreview));
       expect(
@@ -91,14 +123,14 @@ void main() {
       await tester.pumpWidget(dialogWith(AgentCommandPreview(text: _longCommand)));
       await tester.pump();
 
-      final scrollView = find.descendant(
-        of: find.byType(AgentCommandPreview),
-        matching: find.byType(SingleChildScrollView),
-      );
-      expect(scrollView, findsOneWidget);
-
-      // `.first` is the outer one: a `SelectableText` carries a `Scrollable`
-      // of its own, and that is the one that must not answer here.
+      // `.first` is the outer one. A code block carries a horizontal scroll
+      // view of its own, and that is not the one being asked about here.
+      final scrollView = find
+          .descendant(
+            of: find.byType(AgentCommandPreview),
+            matching: find.byType(SingleChildScrollView),
+          )
+          .first;
       final scrollable = find
           .descendant(of: scrollView, matching: find.byType(Scrollable))
           .first;
@@ -109,6 +141,47 @@ void main() {
       await tester.drag(scrollable, const Offset(0, -120));
       await tester.pump();
       expect(position.pixels, greaterThan(0));
+    });
+
+    testWidgets('renders the command as a block, fence and all kept out', (
+      tester,
+    ) async {
+      useReportedPhone(tester);
+
+      await tester.pumpWidget(
+        dialogWith(const AgentCommandPreview(text: 'echo `date`')),
+      );
+      await tester.pump();
+
+      Finder shows(String text) => find.descendant(
+        of: find.byType(AgentCommandPreview),
+        matching: find.textContaining(text),
+      );
+
+      // The command reaches the screen; the fence that carried it there and
+      // the language it was tagged with do not.
+      expect(shows('echo `date`'), findsOneWidget);
+      expect(shows('```'), findsNothing);
+      expect(shows('shell'), findsNothing);
+    });
+
+    testWidgets('scrolls one long line sideways instead of growing', (
+      tester,
+    ) async {
+      useReportedPhone(tester);
+
+      await tester.pumpWidget(
+        dialogWith(AgentCommandPreview(text: 'echo ${'x' * 4000}')),
+      );
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+      // One line stays one line: the block scrolls sideways rather than
+      // wrapping, so the cap is not what is holding it in.
+      expect(
+        tester.getRect(find.byType(AgentCommandPreview)).height,
+        lessThan(askAiCommandPreviewMaxHeightFor(800)),
+      );
     });
 
     testWidgets('takes only the height a short command needs', (tester) async {

--- a/test/agent_command_preview_test.dart
+++ b/test/agent_command_preview_test.dart
@@ -1,0 +1,126 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:server_box/view/widget/agent_common.dart';
+
+/// What a model proposes when it writes a script rather than a command: long
+/// enough that an uncapped preview reaches the buttons that decide it (#1462).
+final _longCommand = List.generate(
+  60,
+  (index) => "echo '>>> step $index' && sleep 1",
+).join('\n');
+
+void main() {
+  group('askAiCommandPreviewMaxHeightFor', () {
+    test('uses thirty percent of compact viewport heights', () {
+      expect(askAiCommandPreviewMaxHeightFor(400), 120);
+      expect(askAiCommandPreviewMaxHeightFor(600), 180);
+    });
+
+    test('caps tall viewport previews so review actions stay nearby', () {
+      expect(askAiCommandPreviewMaxHeightFor(800), 240);
+      expect(askAiCommandPreviewMaxHeightFor(1200), 240);
+    });
+  });
+
+  group('AgentCommandPreview', () {
+    /// The phone the report came from, sized the way `MediaQuery` reads it.
+    void useReportedPhone(WidgetTester tester) {
+      tester.view.physicalSize = const Size(1080, 2400);
+      tester.view.devicePixelRatio = 3;
+      addTearDown(tester.view.reset);
+    }
+
+    Widget dialogWith(Widget preview) {
+      return MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: AlertDialog(
+              title: const Text('Run a high-risk command?'),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Text('This may make changes that are hard to undo.'),
+                  const SizedBox(height: 12),
+                  preview,
+                ],
+              ),
+              actions: [
+                TextButton(onPressed: () {}, child: const Text('Cancel')),
+                FilledButton(onPressed: () {}, child: const Text('Run')),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('keeps a long command clear of the dialog buttons', (
+      tester,
+    ) async {
+      useReportedPhone(tester);
+
+      await tester.pumpWidget(dialogWith(AgentCommandPreview(text: _longCommand)));
+      await tester.pump();
+
+      expect(tester.takeException(), isNull);
+
+      final preview = tester.getRect(find.byType(AgentCommandPreview));
+      expect(
+        preview.height,
+        lessThanOrEqualTo(askAiCommandPreviewMaxHeightFor(800)),
+      );
+
+      // The buttons are what the overflow landed on: text drawn past the
+      // preview's box does not clip, so "below it" is the assertion that says
+      // the labels are readable.
+      for (final label in const ['Cancel', 'Run']) {
+        expect(
+          tester.getRect(find.text(label)).top,
+          greaterThanOrEqualTo(preview.bottom),
+          reason: '$label is drawn over by the command',
+        );
+      }
+    });
+
+    testWidgets('scrolls the part of the command it cannot show', (
+      tester,
+    ) async {
+      useReportedPhone(tester);
+
+      await tester.pumpWidget(dialogWith(AgentCommandPreview(text: _longCommand)));
+      await tester.pump();
+
+      final scrollView = find.descendant(
+        of: find.byType(AgentCommandPreview),
+        matching: find.byType(SingleChildScrollView),
+      );
+      expect(scrollView, findsOneWidget);
+
+      // `.first` is the outer one: a `SelectableText` carries a `Scrollable`
+      // of its own, and that is the one that must not answer here.
+      final scrollable = find
+          .descendant(of: scrollView, matching: find.byType(Scrollable))
+          .first;
+
+      final position = tester.state<ScrollableState>(scrollable).position;
+      expect(position.maxScrollExtent, greaterThan(0));
+
+      await tester.drag(scrollable, const Offset(0, -120));
+      await tester.pump();
+      expect(position.pixels, greaterThan(0));
+    });
+
+    testWidgets('takes only the height a short command needs', (tester) async {
+      useReportedPhone(tester);
+
+      await tester.pumpWidget(dialogWith(const AgentCommandPreview(text: 'ls')));
+      await tester.pump();
+
+      expect(
+        tester.getRect(find.byType(AgentCommandPreview)).height,
+        lessThan(askAiCommandPreviewMaxHeightFor(800)),
+      );
+    });
+  });
+}

--- a/test/ask_ai_layout_test.dart
+++ b/test/ask_ai_layout_test.dart
@@ -2,18 +2,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:server_box/view/page/ssh/ask_ai_layout.dart';
 
 void main() {
-  group('askAiCommandPreviewMaxHeightFor', () {
-    test('uses thirty percent of compact viewport heights', () {
-      expect(askAiCommandPreviewMaxHeightFor(400), 120);
-      expect(askAiCommandPreviewMaxHeightFor(600), 180);
-    });
-
-    test('caps tall viewport previews so review actions stay nearby', () {
-      expect(askAiCommandPreviewMaxHeightFor(800), 240);
-      expect(askAiCommandPreviewMaxHeightFor(1200), 240);
-    });
-  });
-
   group('askAiPanelPlacementForWidth', () {
     test('uses bottom sheet on phone and narrow tablet widths', () {
       expect(askAiPanelPlacementForWidth(390), AskAiPanelPlacement.bottomSheet);

--- a/test/bio_auth_unavailable_test.dart
+++ b/test/bio_auth_unavailable_test.dart
@@ -85,6 +85,10 @@ void main() {
     expect(find.text(libL10n.bioAuth), findsNothing);
     expect(find.text(libL10n.notExistFmt(libL10n.bioAuth)), findsNothing);
     expect(find.byType(Switch), findsNothing);
+    // Nothing at all: this one carries its own card in the one case it has
+    // something to put in it, so a caller that cards it as well leaves an
+    // empty card on a device that hid the setting.
+    expect(find.byType(CardX), findsNothing);
   });
 
   testWidgets(

--- a/test/edge_fade_scroll_test.dart
+++ b/test/edge_fade_scroll_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:server_box/view/widget/edge_fade_scroll.dart';
+
+/// The mask over a row that runs off its window, shared by the settings tabs
+/// and a server's function buttons.
+void main() {
+  Finder mask() => find.descendant(
+    of: find.byType(EdgeFadeScroll),
+    matching: find.byType(ShaderMask),
+  );
+
+  Future<void> pumpRow(WidgetTester tester, {required double itemWidth}) async {
+    tester.view.devicePixelRatio = 1;
+    tester.view.physicalSize = const Size(400, 200);
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: SizedBox(
+              height: 60,
+              child: EdgeFadeScroll(
+                builder: (context, controller) => ListView.builder(
+                  controller: controller,
+                  scrollDirection: Axis.horizontal,
+                  itemCount: 4,
+                  itemBuilder: (_, index) =>
+                      SizedBox(width: itemWidth, child: Text('item $index')),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    // One for the layout, one for the frame that reads the position it
+    // produced — there is nothing to measure before the first.
+    await tester.pump();
+    await tester.pump();
+  }
+
+  testWidgets('a row that fits is not masked at all', (tester) async {
+    await pumpRow(tester, itemWidth: 60);
+
+    // Not a mask that happens to be transparent: the mask is a `saveLayer`,
+    // and a row with nothing off either end should not pay for one.
+    expect(mask(), findsNothing);
+  });
+
+  testWidgets('a row wider than its window is masked', (tester) async {
+    await pumpRow(tester, itemWidth: 300);
+
+    expect(mask(), findsOneWidget);
+  });
+
+  testWidgets('the mask stays at the far end, where the other side is hidden', (
+    tester,
+  ) async {
+    await pumpRow(tester, itemWidth: 300);
+
+    await tester.drag(find.byType(ListView), const Offset(-2000, 0));
+    await tester.pump();
+    await tester.pump();
+
+    expect(mask(), findsOneWidget);
+  });
+
+  testWidgets('a row that grows past its window picks the mask up', (
+    tester,
+  ) async {
+    // Metrics can change without anyone scrolling — a settings level is as
+    // wide as the tabs on it, and moving between levels resizes the bar.
+    await pumpRow(tester, itemWidth: 60);
+    expect(mask(), findsNothing);
+
+    await pumpRow(tester, itemWidth: 300);
+    expect(mask(), findsOneWidget);
+  });
+}

--- a/test/settings_menu_test.dart
+++ b/test/settings_menu_test.dart
@@ -313,6 +313,31 @@ void main() {
     expect(edgeFade(), findsOneWidget);
   });
 
+  testWidgets('a tab several along does not announce the ones passed through', (
+    tester,
+  ) async {
+    await pump(tester, width: 500);
+
+    await tester.tap(menuRow(libL10n.app));
+    await settle(tester, 20);
+
+    // The fourth tab of the app group, so the animation crosses two others.
+    final target = AppLocalizations.of(
+      tester.element(find.byKey(settingsTabsKey)),
+    )!.homeTabs;
+    final titles = <String>[barTitle(tester)];
+
+    await tester.tap(tabRow(target));
+    for (var i = 0; i < 20; i++) {
+      await tester.pump(const Duration(milliseconds: 20));
+      final title = barTitle(tester);
+      if (title != titles.last) titles.add(title);
+    }
+
+    // Where it started and where it was sent, and nothing in between.
+    expect(titles, [libL10n.general, target]);
+  });
+
   testWidgets('the tab being shown is filled in', (tester) async {
     await pump(tester, width: 500);
     await tester.tap(menuRow(libL10n.server));

--- a/test/settings_menu_test.dart
+++ b/test/settings_menu_test.dart
@@ -17,7 +17,7 @@ import 'helpers/test_db.dart';
 ///
 /// Above 800 it is a menu beside the content, showing every level and opening
 /// branches in place. Below, it starts as a list of what there is; picking a row
-/// goes in, and the level it landed on becomes a native tab bar above the
+/// goes in, and the level it landed on becomes a bar of tabs floating over the
 /// content. Either way the bar at the top names what is being shown.
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -47,7 +47,7 @@ void main() {
     matching: find.text(title),
   );
 
-  /// A tab of the native bar, told apart from the settings behind it.
+  /// A tab of the floating bar, told apart from the settings behind it.
   Finder tabRow(String title) => find.descendant(
     of: find.byKey(settingsTabsKey),
     matching: find.text(title),
@@ -196,7 +196,7 @@ void main() {
     }
   });
 
-  testWidgets('picking a row goes in and brings up native tabs above it', (
+  testWidgets('picking a row goes in and brings up its level as tabs', (
     tester,
   ) async {
     await pump(tester, width: 500);
@@ -208,8 +208,8 @@ void main() {
     expect(tabRow(libL10n.sequence), findsOneWidget);
     // What is first inside it, rather than a row of tabs with none of them on.
     expect(barTitle(tester), libL10n.general);
-    // One way back, in the app bar. A second at the foot was the same move
-    // twice on one screen.
+    // One way back, in the bar at the top. A second at the foot was the same
+    // move twice on one screen.
     expect(backBtn, findsOneWidget);
     expect(
       find.descendant(
@@ -220,15 +220,19 @@ void main() {
     );
   });
 
-  testWidgets('the native tabs are placed below the app bar', (tester) async {
+  testWidgets('the tabs rise into place rather than appearing', (tester) async {
     await pump(tester, width: 500);
 
     await tester.tap(menuRow(libL10n.server));
-    await settle(tester, 20);
-    final appBarBottom = tester.getBottomLeft(find.byType(AppBar)).dy;
-    final tabsTop = tester.getTopLeft(find.byKey(settingsTabsKey)).dy;
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 80));
+    final midway = tester.getTopLeft(find.byKey(settingsTabsKey)).dy;
 
-    expect(tabsTop, greaterThanOrEqualTo(appBarBottom));
+    await settle(tester, 20);
+    final settled = tester.getTopLeft(find.byKey(settingsTabsKey)).dy;
+
+    // Still on its way up from under the foot of the screen.
+    expect(midway, greaterThan(settled));
   });
 
   testWidgets('a first-level leaf shows on its own, with no tabs', (
@@ -267,37 +271,50 @@ void main() {
     expect(menuRow(libL10n.terminal), findsOneWidget);
   });
 
-  testWidgets('the native tab bar is centered and can scroll across a level', (
-    tester,
-  ) async {
+  testWidgets('the bar is as wide as the level on it', (tester) async {
     await pump(tester, width: 500);
 
-    await tester.tap(menuRow(libL10n.app));
+    await tester.tap(menuRow(libL10n.server));
+    await settle(tester, 20);
+    final four = tester.getSize(find.byKey(settingsTabsKey)).width;
+
+    await tester.tap(backBtn);
+    await settle(tester, 20);
+    await tester.tap(menuRow(libL10n.file));
     await settle(tester, 20);
 
-    expect(
-      tester.widget<TabBar>(find.byKey(settingsTabsKey)).isScrollable,
-      isTrue,
-    );
-    expect(
-      tester.widget<TabBar>(find.byKey(settingsTabsKey)).tabAlignment,
-      TabAlignment.center,
-    );
+    // Two tabs and a way back is a shorter bar than four and a way back.
+    expect(tester.getSize(find.byKey(settingsTabsKey)).width, lessThan(four));
   });
 
-  testWidgets('the selected tab follows the displayed page', (tester) async {
+  testWidgets('the tab being shown is filled in', (tester) async {
     await pump(tester, width: 500);
     await tester.tap(menuRow(libL10n.server));
     await settle(tester, 20);
 
-    final tabBar = tester.widget<TabBar>(find.byKey(settingsTabsKey));
-    expect(tabBar.controller!.index, 0);
+    final scheme = Theme.of(
+      tester.element(find.byKey(settingsTabsKey)),
+    ).colorScheme;
+    Color? fillOf(String title) {
+      // The pill is around the icon, not the label — so it is a sibling of the
+      // text, reached through the button's own column.
+      final button = find
+          .ancestor(of: tabRow(title), matching: find.byType(Column))
+          .first;
+      final pill = find.descendant(
+        of: button,
+        matching: find.byType(AnimatedContainer),
+      );
+      final decoration =
+          tester.widget<AnimatedContainer>(pill.first).decoration
+              as BoxDecoration?;
+      return decoration?.color;
+    }
 
-    await tester.tap(tabRow(libL10n.sequence));
-    await settle(tester, 20);
-
-    expect(tabBar.controller!.index, 1);
-    expect(barTitle(tester), libL10n.sequence);
+    // Filled rather than only recoloured — a shade of grey against another is
+    // not a state at a glance.
+    expect(fillOf(libL10n.general), scheme.secondaryContainer);
+    expect(fillOf(libL10n.sequence), isNull);
   });
 
   testWidgets('the leaves of a level sit side by side, and drag between', (
@@ -311,7 +328,7 @@ void main() {
 
     // Dragging the content is the same move as tapping the next tab, which is
     // what putting them side by side promises.
-    await tester.drag(find.byType(TabBarView), const Offset(-400, 0));
+    await tester.drag(find.byType(PageView), const Offset(-400, 0));
     await settle(tester, 20);
 
     expect(barTitle(tester), libL10n.sequence);

--- a/test/settings_menu_test.dart
+++ b/test/settings_menu_test.dart
@@ -287,6 +287,32 @@ void main() {
     expect(tester.getSize(find.byKey(settingsTabsKey)).width, lessThan(four));
   });
 
+  /// The mask over the bar, which is only there while there is something to
+  /// mask — so this is `findsNothing` as often as it is `findsOneWidget`.
+  Finder edgeFade() => find.ancestor(
+    of: find.byKey(settingsTabsKey),
+    matching: find.byType(ShaderMask),
+  );
+
+  testWidgets('a level that fits its window is not faded', (tester) async {
+    await pump(tester, width: 500);
+
+    await tester.tap(menuRow(libL10n.file));
+    await settle(tester, 20);
+
+    expect(edgeFade(), findsNothing);
+  });
+
+  testWidgets('a level wider than its window fades at the edge', (tester) async {
+    // Narrow enough that the app group's leaves cannot all be on screen.
+    await pump(tester, width: 320);
+
+    await tester.tap(menuRow(libL10n.app));
+    await settle(tester, 20);
+
+    expect(edgeFade(), findsOneWidget);
+  });
+
   testWidgets('the tab being shown is filled in', (tester) async {
     await pump(tester, width: 500);
     await tester.tap(menuRow(libL10n.server));


### PR DESCRIPTION
Two unrelated things asked for together. Squash-merging, so the history is the five commits.

## The Agent's command previews (#1462)

A `SelectableText` inside a `Column` draws past its constraints instead of clipping, and neither `AlertDialog` nor the proposal card scrolls its content. A long enough command is drawn over the labels of the buttons that decide it — "取消" and "运行" in the report's screenshot.

Measured in a test harness at the reporter's 1080×2400: the old layout overflows by 1952 px, with the command's last line at y=2632 and the Run button at y=718.

| Surface | Before |
| --- | --- |
| Agent tab, high-risk confirm dialog | no cap, no scroll |
| Terminal panel, high-risk confirm dialog | no cap, no scroll |
| Agent tab, proposal card | no cap, no scroll |
| Terminal panel, proposal card | capped in #1446, owning its own `ScrollController` |
| Agent tab, tool result content | fixed 240 px, no `Scrollbar` |

#1446 fixed one of the five, and v1.0.1574 — the version in the report — predates even that.

All five now share `AgentCommandPreview` (`view/widget/agent_common.dart`): capped at `askAiCommandPreviewMaxHeightFor` (30% of the viewport, clamped to 120–240), scrolled, controller owned by the widget.

The preview is also a fenced code block now, tagged `shell` — or `text` for the two arguments that are not a command, a path and the contents a `write_file` would write. It goes through `SimpleMarkdown`, which is what the assistant's own messages already use, so a command reads the same wherever it appears. The fence grows past three backticks when the command contains a run of its own: `` `date` `` is ordinary shell, and a fixed fence would close inside it.

Two consequences worth knowing: a code block scrolls sideways rather than wrapping, so a long single line is now dragged rather than folded; and `SimpleMarkdown` does not expose `MarkdownBody.syntaxHighlighter`, so the `shell` tag is currently semantic only — highlighting would be a change in fl_lib.

## The settings tabs

Reverts two changes from #1459 and polishes what comes back.

**The level's tabs go back over the foot of the page.** The native `TabBar` put them under the app bar, where two rows of chrome stack at the top of a phone screen. `_SettingsTabs` is restored — the floating bar, blurred over content that runs on underneath it, as wide as the level it shows — with the `PageView` behind it and the narrow layout that places it.

**The four rows under More fold again.** Flattening them put a pre-release switch, a wake lock, a UI density toggle and a raw-JSON editor among the settings people open the page for. `_buildEditRawSettings` keeps the `kDebugMode` guard it grew while they were flat.

**Polish on the restored bar:** the shadow drops from elevation 8 at 34% black to 3 at 18% — it was a dark band under the bar on a light theme. And a level wider than the window now fades at whichever end has tabs behind it, as wide as what is hidden up to 32 px. The mask is alpha rather than a colour, because the bar floats over the page; it is absent entirely when nothing is off either end, since it is a `saveLayer` over a bar that is already blurring what it stands on.

## Tests

`test/agent_command_preview_test.dart` (9 cases) sizes the view to the reported phone and asserts no overflow, the cap holds, both button labels sit below the preview, the remainder scrolls, the fence never reaches the screen, and a long single line stays one line.

`test/settings_menu_test.dart` is back to the 16 that describe the floating bar, with two added for the edge fade.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent, selectable, scrollable Markdown previews for agent commands and AI-assisted SSH actions.
  * Command previews now use appropriate syntax formatting for shell commands, paths, actions, and file content.
  * Added a floating, translucent settings tab bar with animated selection and responsive navigation.
  * Added edge-fade indicators to horizontally scrollable content.

* **Improvements**
  * Proposal content expands naturally without fixed-height or internal scrolling limits.
  * Additional app settings are grouped under a collapsed section for easier navigation.

* **Tests**
  * Expanded coverage for previews, settings navigation, animations, overflow handling, and responsive behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
## Review fixes, and the same fade on a server's buttons

Three things the restored bar brought back with it:

- `buildBioAuth` owns its own card and answers with an empty widget three ways — no hardware, still loading, check failed. The restored `_buildApp` carded every child by mapping the list, so a device that hides the setting got an empty card and a device that shows it got a card inside a card. Carded one by one now, as the flat version did.
- Pages passed through on the way to a tapped tab are no longer announced. `animateToPage` crosses every page in between and `PageView` reports each, so tapping the fourth tab named the second and the third in the title bar and wrote both to the settings navigator. Guarded by the page the animation is heading for, with a generation so a second tap's guard survives the first animation completing; a drag that interrupts one is still reported.
- `_TabButton` carries `Semantics(selected:)`. `TabBar` announced which tab was on; a colour and a pill do not.

And the fade is now shared. `EdgeFadeScroll` (`view/widget/edge_fade_scroll.dart`) owns the controller — it exists to read a position, not to scroll anything — so both callers stay stateless and build their scroll view through it. `ServerFuncBtns` uses it too: that row is the only way to reach half of what a server can do, and it ended at the bar's edge with a button cut in half.

The two masks land in different places for the same reason either way. The tabs' bar is itself what runs off the window, so the mask takes the bar; a server's bar is a fixed rounded box with a row inside it, so the mask takes the row and the buttons fade into the bar's own surface.

`test/edge_fade_scroll_test.dart` covers the shared widget: no `ShaderMask` at all when nothing is off either end, one when there is, still one at the far end, and picked up when a row grows past its window without anyone scrolling.
