### PR TITLE
fix(agent): the API version is the user's to write, not this app's to guess

### DIFF
--- a/lib/data/model/app/ask_ai_config.dart
+++ b/lib/data/model/app/ask_ai_config.dart
@@ -26,7 +26,7 @@ part 'ask_ai_config.g.dart';
 @JsonSerializable()
 class AskAiConfig {
   const AskAiConfig({
-    this.baseUrl = 'https://api.openai.com',
+    this.baseUrl = 'https://api.openai.com/v1',
     this.apiKey = '',
     this.model = 'gpt-5.6-luna',
     this.protocol = 'auto',

--- a/lib/data/provider/ai/ask_ai.dart
+++ b/lib/data/provider/ai/ask_ai.dart
@@ -920,6 +920,14 @@ class AskAiRepository {
     return '[Earlier terminal context omitted]\n${text.substring(text.length - limit)}';
   }
 
+  /// Where a provider's API root ends: `v1`, `v2`, `v4` — any of them.
+  ///
+  /// `v1` alone was the rule, and it is only OpenAI's number. Zhipu serves
+  /// `/api/paas/v4`, so the completion was `/api/paas/v4/v1/chat/completions`
+  /// and every request 404'd — reported as "the app cannot use a custom base
+  /// URL" (#1465), which it could all along, just not that one.
+  static final _apiVersionSegment = RegExp(r'^v\d+$');
+
   static Uri composeEndpointUri(String endpoint, AskAiProtocol protocol) {
     final uri = Uri.parse(endpoint.replaceAll(RegExp(r'/+$'), ''));
     final target = protocol == AskAiProtocol.responses
@@ -932,7 +940,12 @@ class AskAiRepository {
     } else if (_endsWithSegments(segments, const ['responses'])) {
       segments = segments.sublist(0, segments.length - 1);
     }
-    final append = segments.isNotEmpty && segments.last == 'v1'
+    // A path that already names a version is an API root and gets the target
+    // appended. Anything else — a bare host, or a gateway path like
+    // `/openai` — gets `v1` as well, which is what it got before and what
+    // those addresses mean.
+    final last = segments.isEmpty ? null : segments.last;
+    final append = last != null && _apiVersionSegment.hasMatch(last)
         ? target
         : ['v1', ...target];
     return uri.replace(pathSegments: [...segments, ...append]);

--- a/lib/data/provider/ai/ask_ai.dart
+++ b/lib/data/provider/ai/ask_ai.dart
@@ -920,14 +920,20 @@ class AskAiRepository {
     return '[Earlier terminal context omitted]\n${text.substring(text.length - limit)}';
   }
 
-  /// Where a provider's API root ends: `v1`, `v2`, `v4` — any of them.
+  /// The endpoint for [protocol], from the address the user wrote.
   ///
-  /// `v1` alone was the rule, and it is only OpenAI's number. Zhipu serves
-  /// `/api/paas/v4`, so the completion was `/api/paas/v4/v1/chat/completions`
-  /// and every request 404'd — reported as "the app cannot use a custom base
-  /// URL" (#1465), which it could all along, just not that one.
-  static final _apiVersionSegment = RegExp(r'^v\d+$');
-
+  /// Only the protocol's own path is added. The version is the user's to
+  /// write, because it is not this app's to know: `v1` is OpenAI's number and
+  /// Zhipu's is `v4`, so a guess that inserted `v1` made their documented root
+  /// unusable (#1465) — `/api/paas/v4/v1/chat/completions` — while appearing
+  /// to work everywhere else.
+  ///
+  /// Guessing it back for those cases would be the same mistake with a longer
+  /// list. An address that ends in a version is an API root, an address that
+  /// does not is the root its owner says it is, and this appends
+  /// `chat/completions` or `responses` to either. Addresses stored before the
+  /// guess was removed are rewritten once, by `AiEndpointVersionMigration`, so
+  /// they keep meaning what they meant.
   static Uri composeEndpointUri(String endpoint, AskAiProtocol protocol) {
     final uri = Uri.parse(endpoint.replaceAll(RegExp(r'/+$'), ''));
     final target = protocol == AskAiProtocol.responses
@@ -935,20 +941,14 @@ class AskAiRepository {
         : const ['chat', 'completions'];
     var segments = List<String>.from(uri.pathSegments);
     if (_endsWithSegments(segments, target)) return uri;
+    // The other protocol's path, swapped rather than stacked: a user who
+    // changes the protocol without retyping the address means the same root.
     if (_endsWithSegments(segments, const ['chat', 'completions'])) {
       segments = segments.sublist(0, segments.length - 2);
     } else if (_endsWithSegments(segments, const ['responses'])) {
       segments = segments.sublist(0, segments.length - 1);
     }
-    // A path that already names a version is an API root and gets the target
-    // appended. Anything else — a bare host, or a gateway path like
-    // `/openai` — gets `v1` as well, which is what it got before and what
-    // those addresses mean.
-    final last = segments.isEmpty ? null : segments.last;
-    final append = last != null && _apiVersionSegment.hasMatch(last)
-        ? target
-        : ['v1', ...target];
-    return uri.replace(pathSegments: [...segments, ...append]);
+    return uri.replace(pathSegments: [...segments, ...target]);
   }
 
   static AskAiProtocol resolveProtocol({

--- a/lib/data/store/migrations/all.dart
+++ b/lib/data/store/migrations/all.dart
@@ -16,6 +16,7 @@ import 'package:server_box/data/store/migrations/m018_server_geo.dart';
 import 'package:server_box/data/store/migrations/m019_drop_geo_cache.dart';
 import 'package:server_box/data/store/migrations/m020_benchmark_runs.dart';
 import 'package:server_box/data/store/migrations/m021_home_tabs_bar.dart';
+import 'package:server_box/data/store/migrations/m022_ai_endpoint_version.dart';
 import 'package:server_box/data/store/schema.dart';
 
 /// Every migration, ordered, in the one place that names them.
@@ -54,4 +55,5 @@ const kSchemaMigrations = <SchemaMigration>[
   DropGeoCacheMigration(),
   BenchmarkRunsMigration(),
   HomeTabsBarMigration(),
+  AiEndpointVersionMigration(),
 ];

--- a/lib/data/store/migrations/m022_ai_endpoint_version.dart
+++ b/lib/data/store/migrations/m022_ai_endpoint_version.dart
@@ -1,0 +1,76 @@
+import 'package:server_box/data/model/app/ask_ai_config.dart';
+import 'package:server_box/data/store/schema.dart';
+import 'package:server_box/data/store/setting.dart';
+
+/// Writes the API version into an AI endpoint that was relying on it being
+/// guessed.
+///
+/// The path completion used to insert `v1` for any address that did not
+/// already end in it. That is only OpenAI's number — Zhipu's is `v4` — so the
+/// guess made their documented root unusable (#1465) while quietly working for
+/// everyone else.
+///
+/// The guess is gone; a stored address is now sent as the user wrote it. Which
+/// means an address that was working *because* of the guess would stop, with a
+/// 404 and nothing to say why. This puts the guess into the stored value once,
+/// so the request that goes out tomorrow is the one that went out yesterday.
+///
+/// Only an address that has no version and is not already a complete endpoint.
+/// `…/api/paas/v4` and `…/v1/chat/completions` are left exactly as they are.
+class AiEndpointVersionMigration implements SchemaMigration {
+  const AiEndpointVersionMigration({SettingStore? store}) : _store = store;
+
+  final SettingStore? _store;
+
+  static const appliedAt = 22;
+  static const key = 'askAi';
+
+  @override
+  int get from => appliedAt;
+
+  @override
+  Future<void> apply() async => applySync();
+
+  void applySync() {
+    final store = _store ?? SettingStore.instance;
+    final raw = store.get<Object>(key);
+    if (raw is! Map) return;
+
+    final config = AskAiConfig.fromJson(Map<String, dynamic>.from(raw));
+    final migrated = versioned(config.baseUrl);
+    if (migrated == config.baseUrl) return;
+
+    final ok = store.set(
+      key,
+      config.copyWith(baseUrl: migrated).toJson(),
+      // Not a user edit: the address means what it always meant, and syncing
+      // this as a change would carry a rewrite nobody made to every device.
+      updateLastUpdateTsOnSet: false,
+    );
+    if (!ok) throw StateError('m022: writing "$key" failed');
+  }
+
+  /// [baseUrl] with `v1` appended where the old completion would have put it.
+  ///
+  /// Static and named so the test can state the rule directly; the store is
+  /// not involved in deciding it.
+  static String versioned(String baseUrl) {
+    final trimmed = baseUrl.trim();
+    if (trimmed.isEmpty) return baseUrl;
+    final uri = Uri.tryParse(trimmed.replaceAll(RegExp(r'/+$'), ''));
+    if (uri == null || uri.host.isEmpty) return baseUrl;
+
+    final segments = uri.pathSegments.where((s) => s.isNotEmpty).toList();
+    // Already an endpoint. The completion never touched these, so neither does
+    // this.
+    if (segments.isNotEmpty &&
+        (segments.last == 'responses' || segments.last == 'completions')) {
+      return baseUrl;
+    }
+    // Already names its version, whichever it is.
+    if (segments.isNotEmpty && RegExp(r'^v\d+$').hasMatch(segments.last)) {
+      return baseUrl;
+    }
+    return uri.replace(pathSegments: [...segments, 'v1']).toString();
+  }
+}

--- a/lib/data/store/schema.dart
+++ b/lib/data/store/schema.dart
@@ -93,7 +93,7 @@ abstract final class SchemaVersion {
   ///      retired with the per-lookup requests it existed for
   /// v21: the old five-button home arrangement becomes four buttons plus
   ///      the "more" destination
-  static const current = 22;
+  static const current = 23;
 
   /// Persisted locally, never included in a backup: it describes *this
   /// device's* storage, and restoring another device's number would make the

--- a/lib/generated/l10n/l10n.dart
+++ b/lib/generated/l10n/l10n.dart
@@ -248,7 +248,7 @@ abstract class AppLocalizations {
   /// No description provided for @askAiEndpointTip.
   ///
   /// In en, this message translates to:
-  /// **'A domain, an API root such as https://open.bigmodel.cn/api/paas/v4, or the full endpoint. Whatever is missing is completed from the protocol.'**
+  /// **'Include the API version, such as /v1 — Zhipu uses /api/paas/v4. Only /chat/completions or /responses is added, from the protocol you pick.'**
   String get askAiEndpointTip;
 
   /// No description provided for @askAiProtocolTip.

--- a/lib/generated/l10n/l10n.dart
+++ b/lib/generated/l10n/l10n.dart
@@ -248,7 +248,7 @@ abstract class AppLocalizations {
   /// No description provided for @askAiEndpointTip.
   ///
   /// In en, this message translates to:
-  /// **'Enter a domain or a full URL. The path is completed from the protocol you pick.'**
+  /// **'A domain, an API root such as https://open.bigmodel.cn/api/paas/v4, or the full endpoint. Whatever is missing is completed from the protocol.'**
   String get askAiEndpointTip;
 
   /// No description provided for @askAiProtocolTip.

--- a/lib/generated/l10n/l10n_en.dart
+++ b/lib/generated/l10n/l10n_en.dart
@@ -78,7 +78,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get askAiEndpointTip =>
-      'Enter a domain or a full URL. The path is completed from the protocol you pick.';
+      'A domain, an API root such as https://open.bigmodel.cn/api/paas/v4, or the full endpoint. Whatever is missing is completed from the protocol.';
 
   @override
   String get askAiProtocolTip => 'Auto tries Responses, then Chat Completions.';

--- a/lib/generated/l10n/l10n_en.dart
+++ b/lib/generated/l10n/l10n_en.dart
@@ -78,7 +78,7 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get askAiEndpointTip =>
-      'A domain, an API root such as https://open.bigmodel.cn/api/paas/v4, or the full endpoint. Whatever is missing is completed from the protocol.';
+      'Include the API version, such as /v1 — Zhipu uses /api/paas/v4. Only /chat/completions or /responses is added, from the protocol you pick.';
 
   @override
   String get askAiProtocolTip => 'Auto tries Responses, then Chat Completions.';

--- a/lib/generated/l10n/l10n_zh.dart
+++ b/lib/generated/l10n/l10n_zh.dart
@@ -73,7 +73,8 @@ class AppLocalizationsZh extends AppLocalizations {
   String get askAiAwaitingResponse => '等待 AI 响应...';
 
   @override
-  String get askAiEndpointTip => '填写域名或完整地址。会根据所选协议自动补全路径。';
+  String get askAiEndpointTip =>
+      '可填域名、API 根地址（如 https://open.bigmodel.cn/api/paas/v4），或完整端点。缺少的部分会按所选协议补全。';
 
   @override
   String get askAiProtocolTip => '自动模式会尝试 Responses / Chat Completions。';
@@ -2114,7 +2115,8 @@ class AppLocalizationsZhTw extends AppLocalizationsZh {
   String get askAiAwaitingResponse => '等待 AI 回應...';
 
   @override
-  String get askAiEndpointTip => '填寫網域或完整位址。會根據所選協定自動補全路徑。';
+  String get askAiEndpointTip =>
+      '可填網域、API 根位址（如 https://open.bigmodel.cn/api/paas/v4），或完整端點。缺少的部分會依所選協定補全。';
 
   @override
   String get askAiProtocolTip => '自動模式會嘗試 Responses / Chat Completions。';

--- a/lib/generated/l10n/l10n_zh.dart
+++ b/lib/generated/l10n/l10n_zh.dart
@@ -74,7 +74,7 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get askAiEndpointTip =>
-      '可填域名、API 根地址（如 https://open.bigmodel.cn/api/paas/v4），或完整端点。缺少的部分会按所选协议补全。';
+      '需要带上 API 版本号，如 /v1；智谱是 /api/paas/v4。只会按所选协议补上 /chat/completions 或 /responses。';
 
   @override
   String get askAiProtocolTip => '自动模式会尝试 Responses / Chat Completions。';
@@ -2116,7 +2116,7 @@ class AppLocalizationsZhTw extends AppLocalizationsZh {
 
   @override
   String get askAiEndpointTip =>
-      '可填網域、API 根位址（如 https://open.bigmodel.cn/api/paas/v4），或完整端點。缺少的部分會依所選協定補全。';
+      '需要帶上 API 版本號，如 /v1；智譜是 /api/paas/v4。只會依所選協定補上 /chat/completions 或 /responses。';
 
   @override
   String get askAiProtocolTip => '自動模式會嘗試 Responses / Chat Completions。';

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -20,7 +20,7 @@
   "added2List": "Added to task list",
   "askAi": "Ask AI",
   "askAiAwaitingResponse": "Waiting for AI response...",
-  "askAiEndpointTip": "Enter a domain or a full URL. The path is completed from the protocol you pick.",
+  "askAiEndpointTip": "A domain, an API root such as https://open.bigmodel.cn/api/paas/v4, or the full endpoint. Whatever is missing is completed from the protocol.",
   "askAiProtocolTip": "Auto tries Responses, then Chat Completions.",
   "askAiCommandInserted": "Command inserted into terminal",
   "askAiConfigMissing": "Please configure {fields} in Settings.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -20,7 +20,7 @@
   "added2List": "Added to task list",
   "askAi": "Ask AI",
   "askAiAwaitingResponse": "Waiting for AI response...",
-  "askAiEndpointTip": "A domain, an API root such as https://open.bigmodel.cn/api/paas/v4, or the full endpoint. Whatever is missing is completed from the protocol.",
+  "askAiEndpointTip": "Include the API version, such as /v1 — Zhipu uses /api/paas/v4. Only /chat/completions or /responses is added, from the protocol you pick.",
   "askAiProtocolTip": "Auto tries Responses, then Chat Completions.",
   "askAiCommandInserted": "Command inserted into terminal",
   "askAiConfigMissing": "Please configure {fields} in Settings.",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -20,7 +20,7 @@
   "added2List": "已添加至任务列表",
   "askAi": "问 AI",
   "askAiAwaitingResponse": "等待 AI 响应...",
-  "askAiEndpointTip": "填写域名或完整地址。会根据所选协议自动补全路径。",
+  "askAiEndpointTip": "可填域名、API 根地址（如 https://open.bigmodel.cn/api/paas/v4），或完整端点。缺少的部分会按所选协议补全。",
   "askAiProtocolTip": "自动模式会尝试 Responses / Chat Completions。",
   "askAiCommandInserted": "命令已插入终端",
   "askAiConfigMissing": "请前往设置配置 {fields}",

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -20,7 +20,7 @@
   "added2List": "已添加至任务列表",
   "askAi": "问 AI",
   "askAiAwaitingResponse": "等待 AI 响应...",
-  "askAiEndpointTip": "可填域名、API 根地址（如 https://open.bigmodel.cn/api/paas/v4），或完整端点。缺少的部分会按所选协议补全。",
+  "askAiEndpointTip": "需要带上 API 版本号，如 /v1；智谱是 /api/paas/v4。只会按所选协议补上 /chat/completions 或 /responses。",
   "askAiProtocolTip": "自动模式会尝试 Responses / Chat Completions。",
   "askAiCommandInserted": "命令已插入终端",
   "askAiConfigMissing": "请前往设置配置 {fields}",

--- a/lib/l10n/app_zh_tw.arb
+++ b/lib/l10n/app_zh_tw.arb
@@ -20,7 +20,7 @@
   "added2List": "已新增至任務清單",
   "askAi": "詢問 AI",
   "askAiAwaitingResponse": "等待 AI 回應...",
-  "askAiEndpointTip": "可填網域、API 根位址（如 https://open.bigmodel.cn/api/paas/v4），或完整端點。缺少的部分會依所選協定補全。",
+  "askAiEndpointTip": "需要帶上 API 版本號，如 /v1；智譜是 /api/paas/v4。只會依所選協定補上 /chat/completions 或 /responses。",
   "askAiProtocolTip": "自動模式會嘗試 Responses / Chat Completions。",
   "askAiCommandInserted": "指令已插入終端機",
   "askAiConfigMissing": "請前往設定配置 {fields}",

--- a/lib/l10n/app_zh_tw.arb
+++ b/lib/l10n/app_zh_tw.arb
@@ -20,7 +20,7 @@
   "added2List": "已新增至任務清單",
   "askAi": "詢問 AI",
   "askAiAwaitingResponse": "等待 AI 回應...",
-  "askAiEndpointTip": "填寫網域或完整位址。會根據所選協定自動補全路徑。",
+  "askAiEndpointTip": "可填網域、API 根位址（如 https://open.bigmodel.cn/api/paas/v4），或完整端點。缺少的部分會依所選協定補全。",
   "askAiProtocolTip": "自動模式會嘗試 Responses / Chat Completions。",
   "askAiCommandInserted": "指令已插入終端機",
   "askAiConfigMissing": "請前往設定配置 {fields}",

--- a/lib/view/page/setting/entries/ai.dart
+++ b/lib/view/page/setting/entries/ai.dart
@@ -83,7 +83,7 @@ extension _AI on _AppSettingsPageState {
           prop: _setting.askAiBaseUrl,
           leading: const Icon(MingCute.link_2_line, size: _kIconSize),
           title: libL10n.apiEndpoint,
-          hint: 'https://api.openai.com',
+          hint: 'https://api.openai.com/v1',
           description: l10n.askAiEndpointTip,
           displayBuilder: (val) => val.isEmpty ? libL10n.empty : val,
         ),

--- a/test/ask_ai_repository_test.dart
+++ b/test/ask_ai_repository_test.dart
@@ -7,13 +7,24 @@ import 'package:server_box/data/provider/ai/global_agent_tools.dart';
 
 void main() {
   group('AskAiRepository.composeEndpointUri', () {
-    test('appends v1 chat completions to service root', () {
-      final uri = AskAiRepository.composeEndpointUri(
-        'https://api.openai.com',
-        AskAiProtocol.chatCompletions,
+    test('adds the protocol path and nothing else', () {
+      // The version is the user's to write: `v1` is OpenAI's number and
+      // Zhipu's is `v4`, so guessing one made the other unusable (#1465).
+      // Addresses stored before this are rewritten by m022.
+      expect(
+        AskAiRepository.composeEndpointUri(
+          'https://api.openai.com/v1',
+          AskAiProtocol.chatCompletions,
+        ).toString(),
+        'https://api.openai.com/v1/chat/completions',
       );
-
-      expect(uri.toString(), 'https://api.openai.com/v1/chat/completions');
+      expect(
+        AskAiRepository.composeEndpointUri(
+          'https://api.openai.com',
+          AskAiProtocol.chatCompletions,
+        ).toString(),
+        'https://api.openai.com/chat/completions',
+      );
     });
 
     test('appends chat completions to v1 endpoint', () {
@@ -68,22 +79,15 @@ void main() {
       );
     });
 
-    test('a path that names no version still gets v1', () {
-      // Unchanged on purpose: a gateway path means the v1 API under it, and
-      // that is what these addresses have always resolved to.
+    test('a gateway path is sent as written, not as guessed', () {
+      // Guessing `v1` back for these would be the same mistake with a longer
+      // list of exceptions. What the user wrote is the root.
       expect(
         AskAiRepository.composeEndpointUri(
           'https://proxy.example/openai',
           AskAiProtocol.chatCompletions,
         ).toString(),
-        'https://proxy.example/openai/v1/chat/completions',
-      );
-      expect(
-        AskAiRepository.composeEndpointUri(
-          'https://api.openai.com',
-          AskAiProtocol.chatCompletions,
-        ).toString(),
-        'https://api.openai.com/v1/chat/completions',
+        'https://proxy.example/openai/chat/completions',
       );
     });
 
@@ -117,7 +121,7 @@ void main() {
     test('composes and converts full protocol endpoints', () {
       expect(
         AskAiRepository.composeEndpointUri(
-          'https://api.openai.com',
+          'https://api.openai.com/v1',
           AskAiProtocol.responses,
         ),
         Uri.parse('https://api.openai.com/v1/responses'),

--- a/test/ask_ai_repository_test.dart
+++ b/test/ask_ai_repository_test.dart
@@ -40,6 +40,69 @@ void main() {
       );
     });
 
+    test('a version other than v1 is still an API root (#1465)', () {
+      // Zhipu's is v4. `v1` alone was the rule, so the path came out as
+      // `/api/paas/v4/v1/chat/completions` and every request 404'd.
+      expect(
+        AskAiRepository.composeEndpointUri(
+          'https://open.bigmodel.cn/api/paas/v4',
+          AskAiProtocol.chatCompletions,
+        ).toString(),
+        'https://open.bigmodel.cn/api/paas/v4/chat/completions',
+      );
+      // The coding plan's, which has another segment before the version.
+      expect(
+        AskAiRepository.composeEndpointUri(
+          'https://open.bigmodel.cn/api/coding/paas/v4',
+          AskAiProtocol.chatCompletions,
+        ).toString(),
+        'https://open.bigmodel.cn/api/coding/paas/v4/chat/completions',
+      );
+      // And a trailing slash is the same address.
+      expect(
+        AskAiRepository.composeEndpointUri(
+          'https://open.bigmodel.cn/api/paas/v4/',
+          AskAiProtocol.chatCompletions,
+        ).toString(),
+        'https://open.bigmodel.cn/api/paas/v4/chat/completions',
+      );
+    });
+
+    test('a path that names no version still gets v1', () {
+      // Unchanged on purpose: a gateway path means the v1 API under it, and
+      // that is what these addresses have always resolved to.
+      expect(
+        AskAiRepository.composeEndpointUri(
+          'https://proxy.example/openai',
+          AskAiProtocol.chatCompletions,
+        ).toString(),
+        'https://proxy.example/openai/v1/chat/completions',
+      );
+      expect(
+        AskAiRepository.composeEndpointUri(
+          'https://api.openai.com',
+          AskAiProtocol.chatCompletions,
+        ).toString(),
+        'https://api.openai.com/v1/chat/completions',
+      );
+    });
+
+    test('a full endpoint is left exactly as it was typed', () {
+      // The way out for anything this cannot guess: name the whole path.
+      for (final endpoint in const [
+        'https://open.bigmodel.cn/api/paas/v4/chat/completions',
+        'https://gateway.example/weird/path/chat/completions',
+      ]) {
+        expect(
+          AskAiRepository.composeEndpointUri(
+            endpoint,
+            AskAiProtocol.chatCompletions,
+          ).toString(),
+          endpoint,
+        );
+      }
+    });
+
     test('supports OpenRouter-compatible v1 endpoint', () {
       final uri = AskAiRepository.composeEndpointUri(
         'https://openrouter.ai/api/v1',

--- a/test/benchmark_store_test.dart
+++ b/test/benchmark_store_test.dart
@@ -85,7 +85,14 @@ void main() {
     // a user's device.
     test('is registered, and the version was bumped past it', () {
       expect(const BenchmarkRunsMigration().from, 20);
-      expect(SchemaVersion.current, 22);
+      // Relative, not `SchemaVersion.current == 20 + 2`: an absolute number
+      // pins this step as one of the newest and fails the day another is
+      // added, which is information about `all.dart` rather than about this
+      // one. See the same note in `m013_virt_key_names_test.dart`.
+      expect(
+        SchemaVersion.current,
+        greaterThan(const BenchmarkRunsMigration().from),
+      );
       expect(
         kSchemaMigrations.map((m) => m.from),
         contains(20),

--- a/test/m021_home_tabs_bar_test.dart
+++ b/test/m021_home_tabs_bar_test.dart
@@ -20,7 +20,9 @@ void main() {
 
   test('is registered as the step after the current schema', () {
     expect(migration.from, 21);
-    expect(SchemaVersion.current, 22);
+    // Relative, not absolute: pinning this as the newest step fails the day
+    // another is added. See `m013_virt_key_names_test.dart`.
+    expect(SchemaVersion.current, greaterThan(migration.from));
     expect(
       kSchemaMigrations.where((m) => m.from == migration.from),
       hasLength(1),

--- a/test/m022_ai_endpoint_version_test.dart
+++ b/test/m022_ai_endpoint_version_test.dart
@@ -1,0 +1,147 @@
+import 'package:fl_lib/fl_lib.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:server_box/data/model/app/ask_ai_config.dart';
+import 'package:server_box/data/store/migrations/all.dart';
+import 'package:server_box/data/store/migrations/m022_ai_endpoint_version.dart';
+import 'package:server_box/data/store/schema.dart';
+import 'package:server_box/data/store/setting.dart';
+
+/// The path completion used to insert `v1` into any address that did not have
+/// it. Removing the guess is what fixes #1465 — and would break every address
+/// that was working because of it, with a 404 and nothing to say why. This
+/// puts the guess into the stored value once, so tomorrow's request is the one
+/// that went out yesterday.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('the rule', () {
+    test('an address with no version gets the one it was being given', () {
+      expect(
+        AiEndpointVersionMigration.versioned('https://api.openai.com'),
+        'https://api.openai.com/v1',
+      );
+      expect(
+        AiEndpointVersionMigration.versioned('https://proxy.example/openai'),
+        'https://proxy.example/openai/v1',
+      );
+      // A trailing slash is the same address.
+      expect(
+        AiEndpointVersionMigration.versioned('https://api.openai.com/'),
+        'https://api.openai.com/v1',
+      );
+    });
+
+    test('an address that names its version is left alone', () {
+      for (final url in const [
+        'https://api.openai.com/v1',
+        'https://open.bigmodel.cn/api/paas/v4',
+        'https://open.bigmodel.cn/api/coding/paas/v4',
+      ]) {
+        expect(AiEndpointVersionMigration.versioned(url), url, reason: url);
+      }
+    });
+
+    test('a complete endpoint is left alone', () {
+      // The completion never touched these, so neither does this.
+      for (final url in const [
+        'https://api.openai.com/v1/chat/completions',
+        'https://api.openai.com/v1/responses',
+        'https://gateway.example/weird/path/chat/completions',
+      ]) {
+        expect(AiEndpointVersionMigration.versioned(url), url, reason: url);
+      }
+    });
+
+    test('nothing to work with is left as it is', () {
+      expect(AiEndpointVersionMigration.versioned(''), '');
+      expect(AiEndpointVersionMigration.versioned('   '), '   ');
+      // No host: a value like this cannot be an endpoint anyway, and rewriting
+      // it would only make the error message about a different string.
+      expect(AiEndpointVersionMigration.versioned('not a url'), 'not a url');
+    });
+  });
+
+  group('the step', () {
+    late SettingStore store;
+
+    setUp(() {
+      SqliteDb.openInMemory();
+      store = SettingStore('setting_test');
+    });
+
+    tearDown(SqliteDb.close);
+
+    test('is registered as the step after the current schema', () {
+      final migration = AiEndpointVersionMigration(store: store);
+      expect(migration.from, 22);
+      // Relative on purpose: an absolute number here fails the day the next
+      // step is added, which is not what this test is about.
+      expect(SchemaVersion.current, greaterThan(migration.from));
+      // Missing from the list throws `Missing schema migration from v22` at
+      // launch on a device that has one, and nothing here would say so.
+      expect(
+        kSchemaMigrations.any((m) => m is AiEndpointVersionMigration),
+        isTrue,
+      );
+      expect(
+        kSchemaMigrations.last.from,
+        SchemaVersion.current - 1,
+        reason: 'the chain has to reach the current version',
+      );
+    });
+
+    test('rewrites a stored address that was relying on the guess', () {
+      store.set(
+        AiEndpointVersionMigration.key,
+        const AskAiConfig(
+          baseUrl: 'https://api.openai.com',
+          model: 'gpt-5-nano',
+        ).toJson(),
+        updateLastUpdateTsOnSet: false,
+      );
+
+      AiEndpointVersionMigration(store: store).applySync();
+
+      final raw = store.get<Object>(AiEndpointVersionMigration.key);
+      final config = AskAiConfig.fromJson(Map<String, dynamic>.from(raw! as Map));
+      expect(config.baseUrl, 'https://api.openai.com/v1');
+      // And nothing else about the configuration moved.
+      expect(config.model, 'gpt-5-nano');
+    });
+
+    test('leaves an address that already names a version', () {
+      const url = 'https://open.bigmodel.cn/api/paas/v4';
+      store.set(
+        AiEndpointVersionMigration.key,
+        const AskAiConfig(baseUrl: url).toJson(),
+        updateLastUpdateTsOnSet: false,
+      );
+
+      AiEndpointVersionMigration(store: store).applySync();
+
+      final raw = store.get<Object>(AiEndpointVersionMigration.key);
+      final config = AskAiConfig.fromJson(Map<String, dynamic>.from(raw! as Map));
+      expect(config.baseUrl, url);
+    });
+
+    test('an install that never configured one is not given a row', () {
+      AiEndpointVersionMigration(store: store).applySync();
+
+      expect(store.get<Object>(AiEndpointVersionMigration.key), isNull);
+    });
+
+    test('is not a user edit', () {
+      store.set(
+        AiEndpointVersionMigration.key,
+        const AskAiConfig(baseUrl: 'https://api.openai.com').toJson(),
+        updateLastUpdateTsOnSet: false,
+      );
+      final before = store.lastUpdateTs;
+
+      AiEndpointVersionMigration(store: store).applySync();
+
+      // Stamping it would carry a rewrite nobody made to every other device.
+      expect(store.lastUpdateTs, before);
+    });
+  });
+}


### PR DESCRIPTION
Closes #1465.

## The bug

`composeEndpointUri` inserted `v1` into any address that did not already end in it:

```dart
final append = segments.isNotEmpty && segments.last == 'v1'
    ? target : ['v1', ...target];
```

`v1` is OpenAI's number. Zhipu's is `v4`, so their documented root came out as `/api/paas/v4/v1/chat/completions` and every request 404'd.

It was reported as "the app has no custom base URL". It has had one all along — a full endpoint was always left alone. What it could not do was finish an address whose root ends in anything but `v1`.

## The fix

Recognising `v\d+` too would be the same mistake with a longer list: the next provider to name its root something else is the next report. **The guess is gone.** `composeEndpointUri` appends `chat/completions` or `responses` and nothing else; what the user wrote is the root.

| Typed | Before | Now |
| --- | --- | --- |
| `https://open.bigmodel.cn/api/paas/v4` | `…/v4/v1/chat/completions` | `…/v4/chat/completions` |
| `https://api.openai.com/v1` | `…/v1/chat/completions` | unchanged |
| `https://api.openai.com` | `…/v1/chat/completions` | `…/chat/completions` |
| `https://proxy.example/openai` | `…/openai/v1/chat/completions` | `…/openai/chat/completions` |
| `https://…/v4/chat/completions` | unchanged | unchanged |

Rows three and four are addresses that worked *because* of the guess. Left alone they would now 404 with nothing to say why.

## m022

`AiEndpointVersionMigration` writes the guess into the stored value once, so tomorrow's request is the one that went out yesterday. It leaves alone anything that already names a version (`…/paas/v4`) or is already a complete endpoint (`…/v1/chat/completions`), and it passes `updateLastUpdateTsOnSet: false` — the address means what it always meant, and syncing it as an edit would carry a rewrite nobody made to every other device.

Three edits, as the schema rule requires: the class, `SchemaVersion.current` (22 → 23), and `kSchemaMigrations`.

## Telling the user

The default, the input's placeholder and the hint all name a version now, and the hint names Zhipu's `/api/paas/v4` as well — the reporter had the right value in hand and no reason to believe the field would take it.

## Not covered

Zhipu's `/api/anthropic` endpoint, mentioned in the issue, speaks the Anthropic protocol. This app implements Chat Completions and Responses; pointing an OpenAI-compatible client at it cannot work whatever the path says. Their OpenAI-compatible roots are the ones this fixes.

## Tests

`test/m022_ai_endpoint_version_test.dart` covers the rule (no version gets one, a version of any number is left alone, a complete endpoint is left alone, an unusable value is left as it is) and the step (rewrites, leaves, does nothing to an install that never configured one, and is not a user edit), plus its registration.

The endpoint tests are updated to the new rule, including a full endpoint left exactly as typed — the way out for anything the completion cannot guess.

Two neighbouring tests asserted `SchemaVersion.current` by number. That pins whichever step is newest and fails the day another is added; they are relative now, with the note `m013_virt_key_names_test.dart` already carries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI endpoint configuration now supports explicit API version paths, including OpenAI `/v1` and Zhipu `/v4` formats.
  * Existing saved endpoints are automatically updated when a version path is missing.
  * Endpoint handling preserves custom gateway paths and appends only the selected protocol endpoint.

* **Documentation**
  * Updated endpoint guidance and examples across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->