### PR TITLE
fix(share): offer a QR the scanner can actually read

### DIFF
--- a/lib/core/utils/server_share.dart
+++ b/lib/core/utils/server_share.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
+import 'dart:io';
 import 'dart:math';
+import 'dart:typed_data';
 
 import 'package:fl_lib/fl_lib.dart';
 import 'package:flutter/foundation.dart' show compute;
@@ -71,13 +73,61 @@ abstract final class ServerShareCodec {
     return List.generate(codeDigits, (_) => random.nextInt(10)).join();
   }
 
+  /// What a compressed plaintext starts with.
+  ///
+  /// A payload written before compression is UTF-8 JSON, so its first byte is
+  /// `{`. One byte tells the two apart, which is why neither the envelope nor
+  /// the JSON needed a field for it — and why a share written by this build is
+  /// readable by nothing older, which is stated in [decode].
+  static const _packedMarker = 0x01;
+
+  /// Raw deflate, with no zlib framing: the marker already says what this is,
+  /// and the six bytes a zlib header costs are six bytes of QR.
+  static final _deflate = ZLibCodec(raw: true, level: ZLibOption.maxLevel);
+
+  /// The bytes that get encrypted.
+  ///
+  /// Compressed first, because the size of the QR is the whole problem: a
+  /// server alone goes from 308 JSON bytes to 223, and one carrying an ed25519
+  /// key from 985 to 748. That is a version and a half off the symbol, and a
+  /// version is four more modules across a code the camera already struggles
+  /// to resolve.
+  ///
+  /// Compressing before encrypting means the ciphertext length says roughly
+  /// how compressible the plaintext was. Accepted: the payload is one
+  /// self-contained record with no attacker-chosen part, and its length was
+  /// already visible in the size of the code on screen.
+  static List<int> _pack(String jsonText) => [
+    _packedMarker,
+    ..._deflate.encode(utf8.encode(jsonText)),
+  ];
+
+  /// The inverse of [_pack], which also accepts what came before it.
+  static String _unpack(Uint8List bytes) {
+    if (bytes.isNotEmpty && bytes.first == _packedMarker) {
+      try {
+        return utf8.decode(_deflate.decode(bytes.sublist(1)));
+      } catch (e) {
+        throw ServerShareUnreadableException('$e');
+      }
+    }
+    try {
+      return utf8.decode(bytes);
+    } on FormatException catch (e) {
+      // What `Cryptor.decrypt` would have said. A payload that authenticated
+      // and is still not text is not a wrong password, and reporting it as one
+      // sends the user to change something that was right.
+      throw ServerShareUnreadableException('$e');
+    }
+  }
+
   static String encode(
     ServerShare share,
     String password,
     ShareCarrier carrier,
   ) {
-    return Cryptor.encrypt(
-      json.encode(share.toJson()),
+    return Cryptor.encryptBytes(
+      _pack(json.encode(share.toJson())),
       password,
       iterations: carrier.iterations,
     );
@@ -100,32 +150,54 @@ abstract final class ServerShareCodec {
   ));
 
   static String _encrypt((String, String, int) args) =>
-      Cryptor.encrypt(args.$1, args.$2, iterations: args.$3);
+      Cryptor.encryptBytes(_pack(args.$1), args.$2, iterations: args.$3);
 
-  /// The most bytes a version-40 QR holds in byte mode at error correction
-  /// level M, which is the level `QrView` fixes.
-  static const qrCapacity = 2331;
+  /// The largest symbol a share may be offered as, counted in modules across.
+  ///
+  /// Not the largest a QR can be. A version-40 symbol is 177 modules across,
+  /// and a camera streaming 1080p sees a code held far enough away for the
+  /// lens to focus at well under two pixels per module — under what any
+  /// decoder needs. Offering one is offering a code that cannot be read, so
+  /// the cap is what the scanner can actually manage and anything past it is
+  /// sent as a file.
+  static const qrMaxModules = 125;
+
+  /// The most bytes that fits in [qrMaxModules] at error correction level L,
+  /// which is the level the share dialog asks `QrView` for.
+  ///
+  /// Held against the real encoder by `test/server_share_qr_test.dart`, since
+  /// this pair is two numbers out of a table that has to agree.
+  static const qrCapacity = 1465;
 
   /// How long [encode] will make this payload, without paying the KDF to find
   /// out.
   ///
   /// Exact, not an estimate: AES-GCM ciphertext is the plaintext's length plus
-  /// a 16-byte tag, and everything else in the envelope is fixed width. Used
-  /// to decide whether to offer a QR at all — an RSA key does not fit in one,
-  /// and finding that out from `QrCode.fromData` throwing is finding it out
-  /// too late.
-  static int encodedLengthOf(ServerShare share) {
-    final plain = utf8.encode(json.encode(share.toJson())).length;
-    // magic(12) + iterations(4) + salt(32) + nonce(12) + tag(16)
-    const envelope = 76;
+  /// a 16-byte tag, and everything else in the envelope is fixed width. The
+  /// compression is run for real, because how well a payload compresses is the
+  /// one part that cannot be predicted from its length. Used to decide whether
+  /// to offer a QR at all — an RSA key does not fit in one, and finding that
+  /// out from `QrCode.fromData` throwing is finding it out too late.
+  static int encodedLengthOf(
+    ServerShare share, {
+    ShareCarrier carrier = ShareCarrier.qr,
+  }) {
+    final plain = _pack(json.encode(share.toJson())).length;
+    // magic(12) + salt(32) + nonce(12) + tag(16), and four more for the
+    // iteration count — which `Cryptor` writes only when the cost is not its
+    // default, so the carrier decides whether those four are there.
+    final envelope = carrier.iterations == Cryptor.defaultIterations ? 72 : 76;
     return ((plain + envelope + 2) ~/ 3) * 4;
   }
 
   static bool fitsInQr(ServerShare share) =>
-      encodedLengthOf(share) <= qrCapacity;
+      encodedLengthOf(share, carrier: ShareCarrier.qr) <= qrCapacity;
 
-  static String _decrypt((String, String) args) =>
-      Cryptor.decrypt(args.$1, args.$2);
+  /// Answers bytes rather than the unpacked text so that [_unpack] runs on the
+  /// calling isolate: everything it throws is this file's own exception, and
+  /// an exception raised inside `compute` has to survive being sent back.
+  static Uint8List _decrypt((String, String) args) =>
+      Cryptor.decryptBytes(args.$1, args.$2);
 
   /// Whether [text] has to be decrypted before it can be read.
   ///
@@ -137,13 +209,18 @@ abstract final class ServerShareCodec {
   /// Reads [text] into a payload, or throws saying why it could not.
   ///
   /// Accepts three shapes, in this order:
-  /// - an encrypted [ServerShare], which is what this build writes;
+  /// - an encrypted [ServerShare], compressed or not — this build writes the
+  ///   compressed form, and a build between the format landing and compression
+  ///   arriving wrote the other;
   /// - a bare `ServerShare` JSON, which nothing writes and which exists so a
   ///   payload can be inspected in a test without a password;
   /// - a bare `Spi` JSON, which is every QR code shared before this format.
   ///
   /// The last one is why this cannot simply parse and throw: dropping it would
-  /// mean a code printed and stuck on a rack stopped working on upgrade.
+  /// mean a code printed and stuck on a rack stopped working on upgrade. The
+  /// compatibility runs one way only — a build that predates [_packedMarker]
+  /// reads a compressed payload as a failure to decrypt — which is what the
+  /// ten-minute deadline on a QR share makes affordable.
   static ServerShare decode(String text, {String? password}) {
     final trimmed = text.trim();
 
@@ -152,10 +229,10 @@ abstract final class ServerShareCodec {
       if (password == null || password.isEmpty) {
         throw const ServerShareUnreadableException('password required');
       }
-      // Whatever `decrypt` throws — a wrong password and a corrupt payload are
-      // the same `Exception` — is the caller's to show. Not wrapped, so the
-      // message the user reads is the one that says which.
-      plain = Cryptor.decrypt(trimmed, password);
+      // Whatever `decryptBytes` throws — a wrong password and a corrupt
+      // payload are the same `Exception` — is the caller's to show. Not
+      // wrapped, so the message the user reads is the one that says which.
+      plain = _unpack(Cryptor.decryptBytes(trimmed, password));
     } else {
       plain = trimmed;
     }
@@ -175,7 +252,7 @@ abstract final class ServerShareCodec {
       throw const ServerShareUnreadableException('password required');
     }
     return _fromPlain(
-      await compute(_decrypt, (trimmed, password)),
+      _unpack(await compute(_decrypt, (trimmed, password))),
       wasEncrypted: true,
     );
   }

--- a/lib/core/utils/server_share.dart
+++ b/lib/core/utils/server_share.dart
@@ -56,6 +56,29 @@ class ServerShareUnreadableException implements Exception {
   String toString() => 'ServerShareUnreadableException: $cause';
 }
 
+/// Collects a decompression, and refuses one that is producing too much.
+///
+/// Between the filter and the buffer, because the check has to happen while
+/// the output is still arriving in pieces: asking a finished buffer how large
+/// it is means it has already been allocated.
+final class _CappedSink implements Sink<List<int>> {
+  const _CappedSink(this._out, this._limit);
+
+  final BytesBuilder _out;
+  final int _limit;
+
+  @override
+  void add(List<int> chunk) {
+    if (_out.length + chunk.length > _limit) {
+      throw const ServerShareUnreadableException('payload too large');
+    }
+    _out.add(chunk);
+  }
+
+  @override
+  void close() {}
+}
+
 /// Packs a server into a string, and reads one back.
 abstract final class ServerShareCodec {
   /// How many digits [generateCode] produces.
@@ -102,11 +125,32 @@ abstract final class ServerShareCodec {
     ..._deflate.encode(utf8.encode(jsonText)),
   ];
 
+  /// The most a payload may decompress to.
+  ///
+  /// Deflate reaches about 1000:1, so compression is also where the size of
+  /// what this app is handed stopped bounding what it allocates — and what it
+  /// is handed is a code or a file somebody else made, decrypted with a
+  /// password that somebody else chose and read out. A real payload is a
+  /// server and at most a key or two, which is kilobytes.
+  static const _maxPlainBytes = 1 << 20;
+
+  /// The most an encrypted payload may be, checked before the key derivation
+  /// is paid.
+  ///
+  /// A QR cannot exceed [qrCapacity] by construction. A file has no natural
+  /// limit, and running 600k rounds of PBKDF2 and AES-GCM across a hundred
+  /// megabytes only to reject what comes out is work done on request.
+  static const _maxEncodedChars = 1 << 20;
+
   /// The inverse of [_pack], which also accepts what came before it.
   static String _unpack(Uint8List bytes) {
     if (bytes.isNotEmpty && bytes.first == _packedMarker) {
       try {
-        return utf8.decode(_deflate.decode(bytes.sublist(1)));
+        return utf8.decode(_inflate(bytes.sublist(1)));
+      } on ServerShareUnreadableException {
+        // Already the sentence this should throw. Falling into the catch below
+        // would wrap it in a second one.
+        rethrow;
       } catch (e) {
         throw ServerShareUnreadableException('$e');
       }
@@ -119,6 +163,22 @@ abstract final class ServerShareCodec {
       // sends the user to change something that was right.
       throw ServerShareUnreadableException('$e');
     }
+  }
+
+  /// Decompresses, and stops if the output runs away.
+  ///
+  /// Chunked rather than `ZLibCodec.decode`, which answers one buffer and so
+  /// has already allocated whatever it was asked for by the time its size can
+  /// be looked at. The filter hands its output over as it produces it, so the
+  /// running total can be checked while there is still something to refuse.
+  static Uint8List _inflate(Uint8List body) {
+    final out = BytesBuilder(copy: false);
+    final sink = _deflate.decoder.startChunkedConversion(
+      _CappedSink(out, _maxPlainBytes),
+    );
+    sink.add(body);
+    sink.close();
+    return out.takeBytes();
   }
 
   static String encode(
@@ -208,21 +268,23 @@ abstract final class ServerShareCodec {
 
   /// Reads [text] into a payload, or throws saying why it could not.
   ///
-  /// Accepts three shapes, in this order:
+  /// Accepts two shapes, in this order:
   /// - an encrypted [ServerShare], compressed or not — this build writes the
   ///   compressed form, and a build between the format landing and compression
   ///   arriving wrote the other;
-  /// - a bare `ServerShare` JSON, which nothing writes and which exists so a
-  ///   payload can be inspected in a test without a password;
   /// - a bare `Spi` JSON, which is every QR code shared before this format.
   ///
-  /// The last one is why this cannot simply parse and throw: dropping it would
-  /// mean a code printed and stuck on a rack stopped working on upgrade. The
-  /// compatibility runs one way only — a build that predates [_packedMarker]
-  /// reads a compressed payload as a failure to decrypt — which is what the
-  /// ten-minute deadline on a QR share makes affordable.
+  /// A clear-text `ServerShare` is **not** one of them, and [_fromPlain] says
+  /// why. The second shape is why this cannot simply parse and throw: dropping
+  /// it would mean a code printed and stuck on a rack stopped working on
+  /// upgrade. The compatibility runs one way only — a build that predates
+  /// [_packedMarker] reads a compressed payload as a failure to decrypt —
+  /// which is what the ten-minute deadline on a QR share makes affordable.
   static ServerShare decode(String text, {String? password}) {
     final trimmed = text.trim();
+    if (trimmed.length > _maxEncodedChars) {
+      throw const ServerShareUnreadableException('payload too large');
+    }
 
     String plain;
     if (Cryptor.isEncrypted(trimmed)) {
@@ -245,6 +307,9 @@ abstract final class ServerShareCodec {
     String? password,
   }) async {
     final trimmed = text.trim();
+    if (trimmed.length > _maxEncodedChars) {
+      throw const ServerShareUnreadableException('payload too large');
+    }
     if (!Cryptor.isEncrypted(trimmed)) {
       return _fromPlain(trimmed, wasEncrypted: false);
     }

--- a/lib/view/widget/server_share.dart
+++ b/lib/view/widget/server_share.dart
@@ -97,7 +97,16 @@ abstract final class ServerShareUi {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
-              QrView(data: text, tip: spi.name, tip2: '${libL10n.server} ~ ServerBox'),
+              QrView(
+                data: text,
+                tip: spi.name,
+                tip2: '${libL10n.server} ~ ServerBox',
+                // The other device is in the room and reads this off a
+                // screen, so nothing is going to scuff the symbol. What
+                // decides whether it can be read is how many camera pixels
+                // land on a module, and L is two versions fewer than M.
+                errorCorrectLevel: QrErrorCorrectLevel.L,
+              ),
               UIs.height13,
               Text(l10n.shareCodeTitle, style: UIs.text13Grey),
               SelectableText(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1337,7 +1337,7 @@ packages:
     source: hosted
     version: "6.5.2"
   pretty_qr_code:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: pretty_qr_code
       sha256: "474f8a4512113fba06f14a6ec9bbf42353b4e651d7a520e3096f2a9b6bbe7a8a"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -120,6 +120,10 @@ dev_dependencies:
   riverpod_generator: ^4.0.3
   test: ^1.29.0
   xml: ^7.0.1
+  # The QR encoder, so `server_share_qr_test.dart` can hold the share's
+  # capacity cap against what actually gets drawn. fl_lib depends on it too,
+  # and `QrView` is the only thing in the app that draws one.
+  pretty_qr_code: ^3.3.0
   flutter_test:
     sdk: flutter
   fl_build:

--- a/test/server_share_qr_test.dart
+++ b/test/server_share_qr_test.dart
@@ -1,0 +1,171 @@
+/// What the share payload has to be for the scanner to have a chance.
+///
+/// The two constants here are a pair taken out of the QR capacity table, and
+/// nothing at their definition can check them — a wrong number produces a
+/// symbol that is simply larger than intended, which no round trip notices and
+/// the camera reports as "it does not scan". So they are held against the real
+/// encoder, and the compression they assume is held against a real payload.
+@Timeout(Duration(minutes: 2))
+library;
+
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:fl_lib/fl_lib.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pretty_qr_code/pretty_qr_code.dart';
+import 'package:server_box/core/utils/server_share.dart';
+import 'package:server_box/data/model/app/share/server_share.dart';
+import 'package:server_box/data/model/server/private_key_info.dart';
+import 'package:server_box/data/model/server/server_private_info.dart';
+import 'package:server_box/data/model/server/ssh_credential.dart';
+
+/// An ed25519 private key is 399 bytes of key material in base64, which is the
+/// case this format is sized for. Random, and a different one per call, so the
+/// numbers below are not flattered by two keys deflating against each other.
+String _ed25519(int seed) {
+  final random = Random(seed);
+  final body = base64.encode(List.generate(399, (_) => random.nextInt(256)));
+  final lines = <String>[
+    for (var i = 0; i < body.length; i += 70)
+      body.substring(i, min(i + 70, body.length)),
+  ];
+  return '-----BEGIN OPENSSH PRIVATE KEY-----\n'
+      '${lines.join('\n')}\n'
+      '-----END OPENSSH PRIVATE KEY-----';
+}
+
+Spi _spi() => Spi(
+  id: 'b3f1c2d4-5a6b-7c8d-9e0f-1a2b3c4d5e6f',
+  name: 'hetzner-fsn1-web-01',
+  ssh: const SshCredential(
+    ip: 'web-01.fsn1.example.com',
+    port: 22,
+    user: 'deploy',
+    pwd: 'correct-horse-battery-staple',
+    keyId: 'k1',
+  ),
+  tags: const ['prod', 'web', 'eu'],
+);
+
+ServerShare _share({int keys = 0}) => ServerShare(
+  version: ServerShare.formatVer,
+  spi: _spi(),
+  keys: [
+    for (var i = 0; i < keys; i++)
+      PrivateKeyInfo(id: 'k$i', name: 'key$i', key: _ed25519(i)),
+  ],
+);
+
+int _modulesOf(int chars) =>
+    17 +
+    4 *
+        QrCode.fromData(
+          data: 'a' * chars,
+          errorCorrectLevel: QrErrorCorrectLevel.L,
+        ).typeNumber;
+
+void main() {
+  group('the cap is the symbol size, not the format', () {
+    test('a payload at the cap is exactly the intended symbol', () {
+      expect(
+        _modulesOf(ServerShareCodec.qrCapacity),
+        ServerShareCodec.qrMaxModules,
+      );
+    });
+
+    test('one more byte is a larger symbol', () {
+      expect(
+        _modulesOf(ServerShareCodec.qrCapacity + 1),
+        greaterThan(ServerShareCodec.qrMaxModules),
+      );
+    });
+
+    test('the level the dialog asks for is the level the cap assumes', () {
+      // At M the same payload needs more versions, so a cap derived from L and
+      // a dialog drawing at M would silently exceed [qrMaxModules].
+      final atM =
+          17 +
+          4 *
+              QrCode.fromData(
+                data: 'a' * ServerShareCodec.qrCapacity,
+                errorCorrectLevel: QrErrorCorrectLevel.M,
+              ).typeNumber;
+      expect(atM, greaterThan(ServerShareCodec.qrMaxModules));
+    });
+  });
+
+  group('what fits', () {
+    test('a server alone, and a server with the key it uses', () {
+      expect(ServerShareCodec.fitsInQr(_share()), isTrue);
+      expect(ServerShareCodec.fitsInQr(_share(keys: 1)), isTrue);
+    });
+
+    test('a payload carrying two keys is sent as a file', () {
+      // Deliberate. Before compression this fit, at 177 modules across, and a
+      // code that size cannot be read off a screen at any distance the lens
+      // will focus at.
+      expect(ServerShareCodec.fitsInQr(_share(keys: 2)), isFalse);
+    });
+
+    test('the measurement is what encoding actually produces', () {
+      // Both carriers, because the envelope is four bytes shorter at
+      // `Cryptor`'s default cost and only the QR carrier asks for more.
+      for (final carrier in ShareCarrier.values) {
+        final share = _share(keys: 1);
+        final encoded = ServerShareCodec.encode(share, '123456', carrier);
+        expect(
+          encoded.length,
+          ServerShareCodec.encodedLengthOf(share, carrier: carrier),
+          reason: '$carrier',
+        );
+      }
+    });
+
+    test('compression takes versions off the symbol', () {
+      final share = _share(keys: 1);
+      final raw = utf8.encode(json.encode(share.toJson())).length;
+      // What the same payload encoded to before [_pack] existed.
+      final uncompressed = ((raw + 76 + 2) ~/ 3) * 4;
+      expect(
+        _modulesOf(ServerShareCodec.encodedLengthOf(share)),
+        lessThan(_modulesOf(uncompressed)),
+      );
+    });
+  });
+
+  group('round trips', () {
+    test('what this build writes, this build reads', () {
+      final share = _share(keys: 1);
+      final encoded = ServerShareCodec.encode(share, 'pw', ShareCarrier.file);
+      final back = ServerShareCodec.decode(encoded, password: 'pw');
+      expect(back.spi.name, share.spi.name);
+      expect(back.keys.single.key, share.keys.single.key);
+    });
+
+    test('a payload written before compression still reads', () {
+      // What `encode` produced between the format landing and the marker: the
+      // plaintext is the JSON itself, so the first byte is `{`.
+      final share = _share(keys: 1);
+      final legacy = Cryptor.encrypt(
+        json.encode(share.toJson()),
+        'pw',
+        iterations: 1000,
+      );
+      final back = ServerShareCodec.decode(legacy, password: 'pw');
+      expect(back.keys.single.key, share.keys.single.key);
+    });
+
+    test('a wrong password still says so rather than blaming the format', () {
+      final encoded = ServerShareCodec.encode(
+        _share(),
+        'pw',
+        ShareCarrier.file,
+      );
+      expect(
+        () => ServerShareCodec.decode(encoded, password: 'nope'),
+        throwsA(isNot(isA<ServerShareUnreadableException>())),
+      );
+    });
+  });
+}

--- a/test/server_share_qr_test.dart
+++ b/test/server_share_qr_test.dart
@@ -9,6 +9,7 @@
 library;
 
 import 'dart:convert';
+import 'dart:io';
 import 'dart:math';
 
 import 'package:fl_lib/fl_lib.dart';
@@ -55,6 +56,16 @@ ServerShare _share({int keys = 0}) => ServerShare(
     for (var i = 0; i < keys; i++)
       PrivateKeyInfo(id: 'k$i', name: 'key$i', key: _ed25519(i)),
   ],
+);
+
+/// The guard's own sentence, not just its type: every other way these inputs
+/// fail also raises [ServerShareUnreadableException].
+final _tooLarge = throwsA(
+  isA<ServerShareUnreadableException>().having(
+    (e) => '$e',
+    'message',
+    contains('too large'),
+  ),
 );
 
 int _modulesOf(int chars) =>
@@ -154,6 +165,38 @@ void main() {
       );
       final back = ServerShareCodec.decode(legacy, password: 'pw');
       expect(back.keys.single.key, share.keys.single.key);
+    });
+
+    test('a decompression bomb is refused rather than allocated', () {
+      // Compression is also where the size of the input stopped bounding the
+      // size of the allocation. 8 MiB of one byte deflates to a couple of
+      // kilobytes, and the envelope authenticates: whoever hands over a share
+      // hands over the password with it, so this passes every check before
+      // the one that has to catch it.
+      final bomb = ZLibCodec(
+        raw: true,
+        level: ZLibOption.maxLevel,
+      ).encode(List.filled(8 << 20, 0x41));
+      final payload = Cryptor.encryptBytes(
+        [0x01, ...bomb],
+        'pw',
+        iterations: 1000,
+      );
+      expect(payload.length, lessThan(64 * 1024));
+      expect(
+        () => ServerShareCodec.decode(payload, password: 'pw'),
+        _tooLarge,
+      );
+    });
+
+    test('an oversized payload is refused before anything is derived', () {
+      // Asserted on the message: without the cap this still throws, from
+      // `json.decode` further down, and a test that only checked the type
+      // would pass with the cap removed.
+      expect(
+        () => ServerShareCodec.decode('x' * ((1 << 20) + 1), password: 'pw'),
+        _tooLarge,
+      );
     });
 
     test('a wrong password still says so rather than blaming the format', () {


### PR DESCRIPTION
Scanning a shared server was slow and often impossible. The decoder was the least of it.

## What was wrong

Two defaults met in the middle:

- `BarcodeScannerPage` took `QRCodeDartScanView`'s defaults, whose `resolutionPreset` is `medium` — `AVCaptureSession.Preset.vga640x480` on iOS, 480p on Android.
- `ServerShareCodec.qrCapacity` was 2331, exactly the version-40 byte capacity at level M, so a share was allowed to be **177 modules across**.

At a distance the lens can focus — a phone camera cannot focus closer than about 10 cm — a code on another device's screen covers well under a third of the frame. At 640 wide that is under one pixel per module, and a decoder needs two. The reported symptom was "it will not focus", which is what being forced to move closer looks like: `camera_avfoundation` enumerates physical lenses only, so there is no automatic switch to the macro one, and continuous autofocus hunting on a field of black and white squares feeds the decoder's blur check a run of frames it discards.

## What changed

**Camera** (in [fl_lib@3796572](https://github.com/lollipopkit/fl_lib/commit/3796572), gitlink bumped here)

- 1080p, cropped to the frame's centre square so the decoder walks half the pixels.
- Tap to focus, which locks it rather than leaving autofocus to hunt.
- Pinch to zoom — on a sensor larger than the stream this crops rather than upscales, so it buys real pixels per module and lets the user stand back far enough to focus.
- Torch.
- `QrView` gains `errorCorrectLevel`, defaulting to the M it has always used.

**Payload**

- The plaintext is deflated before it is encrypted, behind a one-byte marker. A payload written before this starts with `{`, so one byte tells them apart.
- The share dialog asks for error correction L. The other device is in the room reading this off a screen; nothing is going to scuff the symbol.
- The cap is now the symbol size rather than what the format can carry: `qrMaxModules` is 125, and `qrCapacity` is what fits in it at L.

Measured on a server with tags and a password, and on the same server carrying an ed25519 key:

| | before | after |
| --- | --- | --- |
| server alone | v18, 89 modules | v13, 69 modules |
| server + ed25519 key | v31, 141 modules | v24, 113 modules |

With 640 → 1920 that is roughly 4.5x the pixels per module.

## Consequences worth naming

- **A payload carrying two keys no longer fits and is sent as a file.** Before this it fit, at 177 modules, and produced a code that could not be read off a screen at any distance the lens will focus at.
- **Compatibility runs one way.** A build predating the marker reads a compressed payload as a failed decrypt. The ten-minute deadline on a QR share is what makes that affordable.
- `encodedLengthOf` had a silent error: it assumed a 76-byte envelope, but `Cryptor` writes the four-byte iteration count only when the cost is not its default, so the figure was right for the QR carrier and four bytes long for the file one. The carrier is now a parameter.

## Not done

Base45 instead of base64, which would let the symbol use QR's alphanumeric mode for about 20% fewer bits, and replacing the pure-Dart ZXing decoder with a native one. Both are open-source and F-Droid-clean — `rxing` goes through the Cargo path `prepare-fdroid.sh` already vendors — and neither is needed if the above measures up in use. No ML Kit is involved either way.

## Testing

- `test/server_share_qr_test.dart` is new: it holds `qrCapacity` and `qrMaxModules` against the real encoder, since a wrong number there produces a larger symbol that no round trip notices and the camera reports as "it does not scan". It also covers the compressed round trip, an uncompressed payload from an older build, and that a wrong password still reports as a wrong password.
- `flutter test`: 2683 pass. Two unrelated failures — `windows_install_ssh_e2e_test` wants `SBM_E2E_SSH_KEY_PASSPHRASE`, and `terminal_session_test` is flaky under parallelism and passes on its own.
- `flutter analyze` clean in both packages.
- Camera side exercised on an iPhone 16 Pro (profile build).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Compressed server-share payloads now use QR capacity more efficiently.
  - QR codes use low error correction to maximize available capacity.

- **Bug Fixes**
  - Added safeguards against oversized encrypted inputs and decompressed outputs.
  - Improved handling of compressed payloads during synchronous and asynchronous decoding.
  - Bare clear-text ServerShare payloads are no longer supported; encrypted ServerShare and legacy bare Spi formats remain available.

- **Tests**
  - Added coverage for compression, QR capacity, round trips, legacy compatibility, invalid passwords, and oversized payload rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->