### PR TITLE
chore(monitor): bump to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3849,7 +3849,7 @@ dependencies = [
 
 [[package]]
 name = "server_box_monitor"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/monitor/Cargo.toml
+++ b/monitor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server_box_monitor"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 
 [lib]


### PR DESCRIPTION
`monitor-release.yml` reads the version out of Cargo metadata and refuses to run when `monitor-v<version>` is already published. The agent has been on 0.1.2 since [#1408](https://github.com/lollipopkit/flutter_server_box/pull/1408) (tag `monitor-v0.1.2`, 2026-09-06), so nothing since then has shipped.

Eleven commits have touched `monitor/`, `crates/sbm_parser` or `packages/webui` since that tag. What makes this worth releasing:

- **`migrations/009_access_log_timestamp.sql`** — a schema change, which has to travel with the binary that expects it.
- **`get_metrics_history` scanned far more rows than the window asked for.** It compared an RFC 3339 column against `datetime('now', ?)`, whose output is `2026-09-08 07:28:22` where the column holds `2026-09-08T08:28:18.493098803+00:00`. Both are text, SQLite compares them as text, and `'T'` sorts above `' '` — so every row sharing the boundary's date compared greater and the window was effectively "since midnight UTC", growing to 24x through the day. 4255 rows scanned for a 60-minute window holding 496. The answer still looked right, because the cap keeps the newest `max_points` buckets either way; only the work was visible. The watch app and both home widgets read this endpoint.
- **#1444 / #1445** — bound the agent's SQLite I/O and the history window, and shorten the WAL after reclaiming.
- **#1409** — cut the binary by a third.
- **The shared command manifest's Windows `SYS` command.** `Get-ComputerInfo` emits progress records while it assembles its object, and through Windows OpenSSH those arrive as CLIXML on stdout, so the status page displayed `<Objs Version="1.1.0.1" ...>` as the operating system. Now `(Get-CimInstance Win32_OperatingSystem).Caption`.

Patch rather than minor: no API change, and `MonitorRemoteAccess` is unchanged, so an app on the current release talks to this agent exactly as it talks to 0.1.2.

## Testing

- `cargo metadata --format-version 1 --no-deps | jq ... .version` answers `0.1.3` — the same read `monitor-release.yml` does to pick the tag.
- The diff is two lines: `monitor/Cargo.toml` and the matching `Cargo.lock` entry.

Merge, then run `monitor-release.yml` by hand — it is `workflow_dispatch` only and is not triggered by the app's tag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the monitor package version from 0.1.2 to 0.1.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->