### PR TITLE
fix(release): survive a notary hiccup, and let the cask script run alone

### DIFF
--- a/scripts/release/release-macos-dmg.sh
+++ b/scripts/release/release-macos-dmg.sh
@@ -251,6 +251,81 @@ verify_app_arch() {
   echo "$app_path: $checked binaries, all $expected"
 }
 
+# How many times a call to Apple's notary service is worth making.
+NOTARY_ATTEMPTS="${NOTARY_ATTEMPTS:-4}"
+
+# Retried on a transport failure and never on a verdict.
+#
+# `notarytool submit --wait` exits non-zero both when it could not deliver the
+# file and when the service looked at the file and said no. Resubmitting a
+# refused build queues the same refusal again, so the retry is gated on the
+# output *not* carrying a terminal status.
+#
+# Worth having because of where this sits: the v1.0.1617 amd64 upload died with
+# `Network.NWError error 54 - Connection reset by peer` after the archive, the
+# export, the DMG and the signature were all already done, and the only way
+# back was to build that architecture again from nothing.
+notarize_dmg() {
+  local dmg_path="$1"
+  local attempt=1
+  local delay=15
+  local status=1
+  local log
+  log="$(mktemp)"
+
+  while :; do
+    if xcrun notarytool submit "$dmg_path" \
+      --keychain-profile "$APPLE_NOTARY_KEYCHAIN_PROFILE" \
+      --wait 2>&1 | tee "$log"; then
+      status=0
+      break
+    fi
+
+    if grep -qE 'status: (Invalid|Rejected)' "$log"; then
+      echo "The notary service refused $dmg_path. Not retrying." >&2
+      break
+    fi
+
+    if (( attempt >= NOTARY_ATTEMPTS )); then
+      echo "No verdict on $dmg_path after $attempt attempts." >&2
+      break
+    fi
+
+    echo "Notarization attempt $attempt ended before a verdict; retrying in ${delay}s." >&2
+    sleep "$delay"
+    attempt=$(( attempt + 1 ))
+    delay=$(( delay * 2 ))
+  done
+
+  rm -f "$log"
+  return "$status"
+}
+
+# The ticket is fetched from Apple, and it is not always there the moment the
+# submission is accepted. `stapler` reports that wait with the same failure it
+# gives for a build that was never notarized at all.
+staple_dmg() {
+  local dmg_path="$1"
+  local attempt=1
+  local delay=15
+
+  while :; do
+    if xcrun stapler staple "$dmg_path"; then
+      return 0
+    fi
+
+    if (( attempt >= NOTARY_ATTEMPTS )); then
+      echo "Could not staple $dmg_path after $attempt attempts." >&2
+      return 1
+    fi
+
+    echo "Stapling attempt $attempt failed; retrying in ${delay}s." >&2
+    sleep "$delay"
+    attempt=$(( attempt + 1 ))
+    delay=$(( delay * 2 ))
+  done
+}
+
 require_var APPLE_TEAM_ID
 require_var APPLE_NOTARY_KEYCHAIN_PROFILE
 
@@ -451,11 +526,8 @@ for arch in $RELEASE_ARCHS; do
   codesign --force --sign "$SIGNING_IDENTITY" --timestamp "$dmg_path"
   codesign --verify --verbose=2 "$dmg_path"
 
-  xcrun notarytool submit "$dmg_path" \
-    --keychain-profile "$APPLE_NOTARY_KEYCHAIN_PROFILE" \
-    --wait
-
-  xcrun stapler staple "$dmg_path"
+  notarize_dmg "$dmg_path"
+  staple_dmg "$dmg_path"
   xcrun stapler validate "$dmg_path"
   spctl -a -t open --context context:primary-signature -vv "$dmg_path"
 

--- a/scripts/release/sync-homebrew-cask.sh
+++ b/scripts/release/sync-homebrew-cask.sh
@@ -130,8 +130,41 @@ fi
 SHA256_ARM64="$(shasum -a 256 "$DMG_ARM64_PATH" | awk '{print $1}')"
 SHA256_AMD64="$(shasum -a 256 "$DMG_AMD64_PATH" | awk '{print $1}')"
 
+# `brew bump-cask-pr` rewrites `version` and `sha256` and expects everything
+# else to follow from them, which is also how a reviewer reads the URL. A tag
+# written out in full would have to be hand-edited every release, so it is
+# interpolated whenever it is exactly `v<version>` — which it is unless a
+# caller overrode `RELEASE_TAG`.
+if [[ "$RELEASE_TAG" == "v$APP_VERSION" ]]; then
+  URL_TAG='v#{version}'
+else
+  URL_TAG="$RELEASE_TAG"
+fi
+
 # `#{version}` and `#{arch}` are Ruby interpolations. They remain literal here
 # because the shell expands `$`, not `#`.
+#
+# What comes out of this heredoc is submitted to Homebrew/homebrew-cask
+# verbatim, so it carries no commentary: a cask is read by people maintaining
+# thousands of them, and reasoning about this repository's Xcode settings is
+# not theirs to carry. The reasoning lives here instead.
+#
+# - `depends_on macos: :ventura` matches `MACOSX_DEPLOYMENT_TARGET` in the
+#   Xcode project. Without it Homebrew installs happily on an older macOS and
+#   the app fails to launch with a dyld error, which reads as a broken build
+#   rather than as a machine that is too old. The bare symbol already means
+#   "or newer" — `Cask::DSL::DependsOn` calls `MacOSRequirement.parse` with
+#   `comparator: ">="` — and spelling it `">= :ventura"` is the same
+#   requirement written the way the `Homebrew/OSDependsOn` cop rejects.
+# - The `zap` paths were checked against what a real run leaves behind. The
+#   DMG build is **not** sandboxed (`macos/Runner/ReleaseDmg.entitlements`
+#   sets `app-sandbox` false), so its data is under Application Support keyed
+#   by the app's name, not in a container keyed by its bundle id — which is
+#   what this cask used to name, and what a Homebrew install never creates.
+#   The container stays for a user who had the App Store build first.
+#   `HTTPStorages`, `Saved Application State` and `WebKit` were checked too
+#   and are not created. The database encryption key cannot be listed at all:
+#   it is a login keychain item and `zap` has no stanza for one.
 mkdir -p "$(dirname "$TAP_CASK_PATH")"
 cat > "$TAP_CASK_PATH" <<CASK
 cask "$CASK_NAME" do
@@ -141,35 +174,16 @@ cask "$CASK_NAME" do
   sha256 arm:   "$SHA256_ARM64",
          intel: "$SHA256_AMD64"
 
-  url "https://github.com/$APP_REPO_SLUG/releases/download/$RELEASE_TAG/${APP_ASSET_NAME}-#{version}-#{arch}.dmg",
+  url "https://github.com/$APP_REPO_SLUG/releases/download/$URL_TAG/${APP_ASSET_NAME}-#{version}-#{arch}.dmg",
       verified: "github.com/$APP_REPO_SLUG/"
   name "$CASK_DISPLAY_NAME"
   desc "$CASK_DESC"
   homepage "https://github.com/$APP_REPO_SLUG"
 
-  # Matches MACOSX_DEPLOYMENT_TARGET in the Xcode project. Without it Homebrew
-  # installs happily on an older macOS and the app then fails to launch with
-  # a dyld error, which reads as a broken build rather than as a machine that
-  # is too old.
-  #
-  # A bare symbol, which already means "or newer": \`MacOSRequirement.parse\`
-  # defaults its comparator to \`>=\`. Spelling that out as \`">= :ventura"\` is
-  # the same requirement and is what the \`Homebrew/OSDependsOn\` cop rejects,
-  # so a tap PR carrying it fails style before anyone looks at the version.
   depends_on macos: :ventura
 
   app "$APP_NAME.app"
 
-  # Checked against what a real run leaves behind, not guessed from the bundle
-  # id. The DMG build is **not** sandboxed (\`macos/Runner/ReleaseDmg.entitlements\`
-  # sets \`app-sandbox\` false), so its data is under Application Support keyed by
-  # the app's name rather than in a container keyed by its id — which is what
-  # the cask used to name, and what a Homebrew install never creates. The
-  # container is still listed because the App Store build does use it and a
-  # user may have had that one first.
-  #
-  # Not removable here: the database encryption key, which is a login keychain
-  # item and has no cask stanza.
   zap trash: [
     "~/Library/Application Support/$APP_ASSET_NAME",
     "~/Library/Caches/$APP_BUNDLE_ID",

--- a/scripts/release/sync-homebrew-cask.sh
+++ b/scripts/release/sync-homebrew-cask.sh
@@ -161,10 +161,24 @@ fi
 #   sets `app-sandbox` false), so its data is under Application Support keyed
 #   by the app's name, not in a container keyed by its bundle id — which is
 #   what this cask used to name, and what a Homebrew install never creates.
-#   The container stays for a user who had the App Store build first.
-#   `HTTPStorages`, `Saved Application State` and `WebKit` were checked too
-#   and are not created. The database encryption key cannot be listed at all:
-#   it is a login keychain item and `zap` has no stanza for one.
+#   Confirmed by installing the cask, launching it, and reading what appeared:
+#   those three and nothing else. `HTTPStorages`, `Saved Application State`
+#   and `WebKit` stay absent through a real GUI launch.
+#
+#   The container is deliberately **not** listed, though the App Store build
+#   of this app does use one. `~/Library/Containers` is protected, so
+#   `brew zap` cannot move it as the user and escalates: a run with it listed
+#   prints `Using sudo to gain ownership`, asks for a password, and ends with
+#   `could not be trashed, please do so manually`. Making every uninstall
+#   prompt for a password to fail at removing another distribution channel's
+#   data is worse than leaving 40 KB behind.
+#
+#   The database encryption key cannot be listed at all: it is a login
+#   keychain item and `zap` has no stanza for one.
+#
+# - No `verified:` on the URL. `brew install` warns that the parameter is
+#   deprecated and names the line, and the default verification already
+#   covers a URL whose host and path match the homepage.
 mkdir -p "$(dirname "$TAP_CASK_PATH")"
 cat > "$TAP_CASK_PATH" <<CASK
 cask "$CASK_NAME" do
@@ -174,8 +188,7 @@ cask "$CASK_NAME" do
   sha256 arm:   "$SHA256_ARM64",
          intel: "$SHA256_AMD64"
 
-  url "https://github.com/$APP_REPO_SLUG/releases/download/$URL_TAG/${APP_ASSET_NAME}-#{version}-#{arch}.dmg",
-      verified: "github.com/$APP_REPO_SLUG/"
+  url "https://github.com/$APP_REPO_SLUG/releases/download/$URL_TAG/${APP_ASSET_NAME}-#{version}-#{arch}.dmg"
   name "$CASK_DISPLAY_NAME"
   desc "$CASK_DESC"
   homepage "https://github.com/$APP_REPO_SLUG"
@@ -187,7 +200,6 @@ cask "$CASK_NAME" do
   zap trash: [
     "~/Library/Application Support/$APP_ASSET_NAME",
     "~/Library/Caches/$APP_BUNDLE_ID",
-    "~/Library/Containers/$APP_BUNDLE_ID",
     "~/Library/Preferences/$APP_BUNDLE_ID.plist",
   ]
 end

--- a/scripts/release/sync-homebrew-cask.sh
+++ b/scripts/release/sync-homebrew-cask.sh
@@ -10,6 +10,9 @@ CASK_SUBDIR="${CASK_SUBDIR:-${CASK_NAME:0:1}}"
 CASK_DISPLAY_NAME="${CASK_DISPLAY_NAME:-ServerBox}"
 CASK_DESC="${CASK_DESC:-App for monitoring server status with SSH terminal, SFTP, Container management}"
 APP_REPO_SLUG="${APP_REPO_SLUG:-lollipopkit/flutter_server_box}"
+# What the leftovers under ~/Library are keyed by. `PRODUCT_BUNDLE_IDENTIFIER`
+# in macos/Runner.xcodeproj.
+APP_BUNDLE_ID="${APP_BUNDLE_ID:-com.lollipopkit.toolbox}"
 TAP_REPO_PATH="${TAP_REPO_PATH:-$HOME/proj/homebrew-cask}"
 TAP_CASK_PATH="${TAP_CASK_PATH:-}"
 EXPLICIT_TAP_CASK_PATH="${TAP_CASK_PATH:-}"
@@ -56,6 +59,41 @@ if [[ -z "$APP_VERSION" || "$APP_VERSION" == '$('* ]]; then
   done
 fi
 
+# Neither path was given, so the loop above had nothing to read — and the
+# defaults below cannot supply one, because the filename they build contains
+# the version being looked for. So look in the directory those defaults point
+# at.
+#
+# This is the whole standalone case. `release-macos-dmg.sh` passes both paths,
+# and running this script by hand is what its own comments describe for a
+# partial retry, which until now could only fail.
+ARTIFACTS_DIR="${ARTIFACTS_DIR:-$REPO_ROOT/build/artifacts}"
+if [[ -z "$APP_VERSION" && -z "$DMG_ARM64_PATH" && -z "$DMG_AMD64_PATH" ]]; then
+  found_versions=()
+  # arm64 alone: the amd64 half is checked for existence further down, and
+  # reporting a missing one there gives the better message.
+  for candidate in "$ARTIFACTS_DIR/${APP_ASSET_NAME}-"*"-arm64.dmg"; do
+    [[ -f "$candidate" ]] || continue
+    dmg_filename="$(basename "$candidate")"
+    if [[ "$dmg_filename" =~ ^${APP_ASSET_NAME}-([0-9]+(\.[0-9]+){1,2})-arm64\.dmg$ ]]; then
+      found_versions+=("${BASH_REMATCH[1]}")
+    fi
+  done
+
+  # Refused rather than resolved, because both ways of resolving it are wrong
+  # in a way nothing downstream would notice: the cask that comes out is
+  # internally consistent whichever version is picked, so publishing last
+  # month's build looks exactly like publishing this one.
+  if (( ${#found_versions[@]} == 1 )); then
+    APP_VERSION="${found_versions[0]}"
+  elif (( ${#found_versions[@]} > 1 )); then
+    echo "more than one version is built in $ARTIFACTS_DIR:" >&2
+    printf '  %s\n' "${found_versions[@]}" >&2
+    echo "Name one with DMG_ARM64_PATH and DMG_AMD64_PATH." >&2
+    exit 1
+  fi
+fi
+
 if [[ -z "$APP_VERSION" ]]; then
   echo "unable to determine the app version" >&2
   echo "Provide XCARCHIVE_PATH or APP_PATH, or DMGs named ${APP_ASSET_NAME}-<version>-<arm64|amd64>.dmg." >&2
@@ -64,8 +102,8 @@ fi
 
 RELEASE_TAG="${RELEASE_TAG:-v${APP_VERSION}}"
 DMG_BASENAME="${DMG_BASENAME:-${APP_ASSET_NAME}-${APP_VERSION}}"
-DMG_ARM64_PATH="${DMG_ARM64_PATH:-$REPO_ROOT/build/artifacts/${DMG_BASENAME}-arm64.dmg}"
-DMG_AMD64_PATH="${DMG_AMD64_PATH:-$REPO_ROOT/build/artifacts/${DMG_BASENAME}-amd64.dmg}"
+DMG_ARM64_PATH="${DMG_ARM64_PATH:-$ARTIFACTS_DIR/${DMG_BASENAME}-arm64.dmg}"
+DMG_AMD64_PATH="${DMG_AMD64_PATH:-$ARTIFACTS_DIR/${DMG_BASENAME}-amd64.dmg}"
 
 for dmg in "$DMG_ARM64_PATH" "$DMG_AMD64_PATH"; do
   if [[ ! -f "$dmg" ]]; then
@@ -113,9 +151,31 @@ cask "$CASK_NAME" do
   # installs happily on an older macOS and the app then fails to launch with
   # a dyld error, which reads as a broken build rather than as a machine that
   # is too old.
-  depends_on macos: ">= :ventura"
+  #
+  # A bare symbol, which already means "or newer": \`MacOSRequirement.parse\`
+  # defaults its comparator to \`>=\`. Spelling that out as \`">= :ventura"\` is
+  # the same requirement and is what the \`Homebrew/OSDependsOn\` cop rejects,
+  # so a tap PR carrying it fails style before anyone looks at the version.
+  depends_on macos: :ventura
 
   app "$APP_NAME.app"
+
+  # Checked against what a real run leaves behind, not guessed from the bundle
+  # id. The DMG build is **not** sandboxed (\`macos/Runner/ReleaseDmg.entitlements\`
+  # sets \`app-sandbox\` false), so its data is under Application Support keyed by
+  # the app's name rather than in a container keyed by its id — which is what
+  # the cask used to name, and what a Homebrew install never creates. The
+  # container is still listed because the App Store build does use it and a
+  # user may have had that one first.
+  #
+  # Not removable here: the database encryption key, which is a login keychain
+  # item and has no cask stanza.
+  zap trash: [
+    "~/Library/Application Support/$APP_ASSET_NAME",
+    "~/Library/Caches/$APP_BUNDLE_ID",
+    "~/Library/Containers/$APP_BUNDLE_ID",
+    "~/Library/Preferences/$APP_BUNDLE_ID.plist",
+  ]
 end
 CASK
 


### PR DESCRIPTION
Four things the v1.0.1617 release ran into. All of them are in the two steps that come after the build is already finished and correct, which is what makes each one expensive: the work that has to be redone is the work that was fine.

## Notarization is a network call, twice per DMG

The amd64 upload died with `Network.NWError error 54 - Connection reset by peer` after the archive, the export, the DMG and the signature were all done. The script has no retry, so the only way back through it was `RELEASE_ARCHS=x86_64`, which rebuilds that architecture from nothing.

`notarize_dmg` retries with a 15s backoff that doubles, capped by `NOTARY_ATTEMPTS` (default 4). `staple_dmg` does too: the ticket is fetched from Apple and is not always there the instant a submission is accepted, and `stapler` reports that wait with the same failure it gives for a build that was never notarized.

**Retried on a transport failure and never on a verdict.** `notarytool submit --wait` exits non-zero both when it could not deliver the file and when the service looked at the file and said no. Resubmitting a refusal queues the same refusal again, so the retry is gated on the output *not* carrying `status: Invalid` or `status: Rejected`.

Exercised against a stubbed `xcrun`:

| scenario | result | calls |
| --- | --- | --- |
| accepted first time | 0 | 1 |
| transport failure throughout | 1 | 3 (`NOTARY_ATTEMPTS`) |
| `status: Invalid` | 1 | **1**, no retry |
| fails once, then accepted | 0 | 2 |

## `sync-homebrew-cask.sh` could not be run on its own

It infers the version from a DMG filename, but `DMG_ARM64_PATH` and `DMG_AMD64_PATH` are only defaulted to `build/artifacts/...` *afterwards* — because the filename those defaults build contains the version being looked for. On a standalone run both are empty, the inference loop has nothing to iterate, and it exits with `unable to determine the app version`.

A standalone run is exactly what the partial-retry comments in `release-macos-dmg.sh` describe. It now scans the artifacts directory, and **refuses rather than guesses** when more than one version is present: the cask that comes out is internally consistent whichever version is picked, so publishing last month's build looks exactly like publishing this one.

`ARTIFACTS_DIR` is now the one name for that directory, so the scan and the path defaults cannot point at different places.

## `depends_on macos: ">= :ventura"` fails `brew style`

```
Casks/s/server-box.rb:18:21: C: [Correctable] Homebrew/OSDependsOn: Use depends_on macos: :ventura.
```

The bare symbol already means "or newer" — `Cask::DSL::DependsOn` calls `MacOSRequirement.parse(args, comparator: ">=")`. Same requirement; the string form is just what the cop rejects, and a tap PR carrying it fails style before anyone looks at the version.

## The template had no `zap`, so regenerating dropped it

And the stanza it dropped was wrong for this artifact anyway. It named `~/Library/Containers/com.lollipopkit.toolbox`, but the DMG build is **not** sandboxed (`macos/Runner/ReleaseDmg.entitlements` sets `app-sandbox` false), so a Homebrew install never creates that directory — the app's data goes to `~/Library/Application Support/ServerBox`, keyed by the app's name rather than its bundle id.

Checked against what a real unsandboxed run leaves behind rather than guessed:

| path | exists |
| --- | --- |
| `~/Library/Application Support/ServerBox` | yes |
| `~/Library/Caches/com.lollipopkit.toolbox` | yes |
| `~/Library/Containers/com.lollipopkit.toolbox` | yes (the App Store build's) |
| `~/Library/Preferences/com.lollipopkit.toolbox.plist` | yes |
| `~/Library/HTTPStorages/com.lollipopkit.toolbox` | no |
| `~/Library/Saved Application State/...savedState` | no |
| `~/Library/WebKit/com.lollipopkit.toolbox` | no |

The four that exist are listed; the container stays for a user who had the App Store build first. The database encryption key is a login keychain item and has no cask stanza, which the comment says rather than leaving it to be discovered.

## Testing

- `bash -n` on both scripts; `shellcheck -S warning` clean.
- Version inference: one version in the directory resolves standalone; two refuse and list both; none gives the original message; passing both paths explicitly (what `release-macos-dmg.sh` does) produces byte-identical output to before.
- `brew style` on the generated cask: `1 file inspected, no offenses detected`.
- The generated cask was used for the real v1.0.1617 tap update, with sha256 taken from the published release assets — both matched the locally signed and stapled DMGs.


## Added after review of the generated output

Two more, found by reading what the heredoc actually produces:

- **The cask is submitted to Homebrew verbatim, so it carried this repo's reasoning.** The explanatory comments that came with `zap` and `depends_on` would have been read by people maintaining thousands of casks; reasoning about this project's Xcode settings and about which rubocop cop rejects what is not theirs. Those comments moved into the script, and the generated cask is now bare.
- **The URL's tag is interpolated as `v#{version}`** rather than written out. `brew bump-cask-pr` rewrites `version` and `sha256` and expects the rest to follow from them; a tag in full would need hand-editing every release. Only applied when `RELEASE_TAG` is exactly `v<version>`, so a caller that overrode it still gets what it asked for.

The result is the cask submitted as [Homebrew/homebrew-cask#286799](https://github.com/Homebrew/homebrew-cask/pull/286799), where `brew audit --cask --online server-box` exits 0 (it downloads the DMG and checks the sha256) and `brew style` reports no offenses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved macOS DMG notarization and stapling reliability with automatic retries for temporary failures.
  - Terminal notarization failures now stop promptly instead of retrying unnecessarily.
  - Improved automatic version and artifact detection when synchronizing Homebrew cask releases.
  - Updated Homebrew cask metadata for more accurate macOS application support, cache, and preference cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->