### PR TITLE
fix(monitor): a deadlocked /velocity, and rules judging samples that are missing

### DIFF
--- a/crates/sbm_native/src/sysinfo_backend.rs
+++ b/crates/sbm_native/src/sysinfo_backend.rs
@@ -185,14 +185,18 @@ pub fn sample(state: &mut State) -> ServerStatus {
         .map(|disk| {
             let name = disk.name().to_string_lossy().into_owned();
             let mount = disk.mount_point().to_string_lossy().into_owned();
-            let id = if mount.is_empty() { name } else { mount };
-            (disk, id)
+            let id = if mount.is_empty() {
+                name.clone()
+            } else {
+                mount
+            };
+            (disk, id, name)
         })
         .collect();
 
     let disks: Vec<Disk> = keyed_disks
         .iter()
-        .map(|(d, id)| {
+        .map(|(d, id, name)| {
             let total_kb = d.total_space() / 1024;
             let avail_kb = d.available_space() / 1024;
             let used_kb = total_kb.saturating_sub(avail_kb);
@@ -204,6 +208,12 @@ pub fn sample(state: &mut State) -> ServerStatus {
                 used: used_kb,
                 size: total_kb,
                 avail: avail_kb,
+                // The volume label (see this module's doc comment — on macOS
+                // `name()` is not a device path). Volumes of one APFS container
+                // share it and each report the container's full size, so it is
+                // what lets monitor count that capacity once
+                // (`monitoring::apfs_pool_key`) rather than once per volume.
+                name: (!name.is_empty()).then(|| name.clone()),
                 ..Disk::default()
             }
         })
@@ -211,7 +221,7 @@ pub fn sample(state: &mut State) -> ServerStatus {
 
     let diskio: Vec<DiskIoPiece> = keyed_disks
         .iter()
-        .map(|(d, id)| {
+        .map(|(d, id, _)| {
             let usage = d.usage();
             DiskIoPiece {
                 dev: id.clone(),

--- a/crates/sbm_native/src/sysinfo_backend.rs
+++ b/crates/sbm_native/src/sysinfo_backend.rs
@@ -76,6 +76,38 @@ fn is_plausible_temp(c: f64) -> bool {
     c.is_finite() && (-40.0..=150.0).contains(&c)
 }
 
+/// The device serving a mount point, without the `/dev/` prefix — the lsblk
+/// NAME convention `Disk.name` documents ("disk3s5", "sda1").
+///
+/// `sysinfo`'s `Disk::name()` is a volume *label* on macOS ("Macintosh HD"),
+/// which identifies nothing: every volume of an APFS container carries the
+/// same one, and so does every disk nobody renamed. The device is what tells
+/// one container from another, and `statfs` is where it comes from —
+/// `f_mntfromname` is the source `df` prints.
+#[cfg(target_os = "macos")]
+fn device_for_mount(mount: &str) -> Option<String> {
+    use std::ffi::{CStr, CString};
+
+    let path = CString::new(mount).ok()?;
+    let mut buf: libc::statfs = unsafe { std::mem::zeroed() };
+    // SAFETY: `path` is a valid NUL-terminated C string that outlives the call,
+    // and `buf` is a correctly sized, owned `statfs` the call only writes into.
+    if unsafe { libc::statfs(path.as_ptr(), &mut buf) } != 0 {
+        return None;
+    }
+    // SAFETY: on success statfs leaves `f_mntfromname` NUL-terminated within
+    // its own bounds.
+    let raw = unsafe { CStr::from_ptr(buf.f_mntfromname.as_ptr()) }.to_string_lossy();
+    let device = raw.strip_prefix("/dev/").unwrap_or(&raw);
+    (!device.is_empty()).then(|| device.to_string())
+}
+
+/// Windows names volumes by drive letter, which `mount` already carries.
+#[cfg(not(target_os = "macos"))]
+fn device_for_mount(_mount: &str) -> Option<String> {
+    None
+}
+
 fn cpu_brand(system: &System) -> Vec<(String, u32)> {
     let mut brands: Vec<(String, u32)> = Vec::new();
     for cpu in system.cpus() {
@@ -183,20 +215,23 @@ pub fn sample(state: &mut State) -> ServerStatus {
         .list()
         .iter()
         .map(|disk| {
-            let name = disk.name().to_string_lossy().into_owned();
             let mount = disk.mount_point().to_string_lossy().into_owned();
+            let device = device_for_mount(&mount);
+            // Keyed by mount point: APFS volumes of one container report
+            // identical `sysinfo` names, and the panel renders disk/diskio rows
+            // keyed by this value.
             let id = if mount.is_empty() {
-                name.clone()
+                disk.name().to_string_lossy().into_owned()
             } else {
                 mount
             };
-            (disk, id, name)
+            (disk, id, device)
         })
         .collect();
 
     let disks: Vec<Disk> = keyed_disks
         .iter()
-        .map(|(d, id, name)| {
+        .map(|(d, id, device)| {
             let total_kb = d.total_space() / 1024;
             let avail_kb = d.available_space() / 1024;
             let used_kb = total_kb.saturating_sub(avail_kb);
@@ -208,12 +243,12 @@ pub fn sample(state: &mut State) -> ServerStatus {
                 used: used_kb,
                 size: total_kb,
                 avail: avail_kb,
-                // The volume label (see this module's doc comment — on macOS
-                // `name()` is not a device path). Volumes of one APFS container
-                // share it and each report the container's full size, so it is
-                // what lets monitor count that capacity once
+                // The volume is keyed by mount point above, so this is the only
+                // place the device survives. Volumes of one APFS container each
+                // report the container's whole size, and this is what lets
+                // monitor recognise them as one and count that capacity once
                 // (`monitoring::apfs_pool_key`) rather than once per volume.
-                name: (!name.is_empty()).then(|| name.clone()),
+                name: device.clone(),
                 ..Disk::default()
             }
         })
@@ -367,6 +402,29 @@ mod tests {
             devs.len(),
             unique_devs.len(),
             "duplicate diskio dev: {devs:?}"
+        );
+    }
+
+    /// `Disk.name` has to be the device. Monitor pools APFS volumes by the
+    /// container in it (`monitoring::apfs_pool_key`) to keep one container's
+    /// capacity from being counted once per volume — and the label `sysinfo`
+    /// hands out cannot do that job, since every volume of a container carries
+    /// the same one and so does every disk nobody renamed.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn disks_carry_a_device_not_a_volume_label() {
+        let mut state = State::default();
+        let status = sample(&mut state);
+
+        let root = status
+            .disks
+            .iter()
+            .find(|d| d.mount == "/")
+            .expect("a root filesystem");
+        let device = root.name.as_deref().expect("root volume has a device");
+        assert!(
+            device.starts_with("disk"),
+            "expected a device like disk3s1s1, got {device:?}"
         );
     }
 

--- a/monitor/src/api/server.rs
+++ b/monitor/src/api/server.rs
@@ -1175,21 +1175,25 @@ async fn get_velocity(
 
     let server_name = app_state.config.get_server_name();
 
-    match app_state
-        .velocity_manager
-        .read()
-        .await
-        .get_server_velocity(&server_name)
-        .await
-    {
-        Ok(velocity_data) => {
-            let network_totals = app_state
-                .velocity_manager
-                .read()
-                .await
-                .get_network_totals(&server_name)
-                .await;
+    // Everything this handler needs comes from one guard. A temporary in a
+    // `match` scrutinee lives to the end of the match, so taking the lock
+    // there and again inside an arm deadlocks against the monitoring loop's
+    // writer: tokio's RwLock is fair, so the queued writer blocks the second
+    // reader while itself waiting on the first guard.
+    let sampled = {
+        let velocity = app_state.velocity_manager.read().await;
+        match velocity.get_server_velocity(&server_name).await {
+            Ok(velocity_data) => {
+                let network_totals = velocity.get_network_totals(&server_name).await;
+                let is_ready = velocity.is_ready(&server_name).await;
+                Ok((velocity_data, network_totals, is_ready))
+            }
+            Err(e) => Err(e),
+        }
+    };
 
+    match sampled {
+        Ok((velocity_data, network_totals, is_ready)) => {
             let network_info = NetworkSpeedInfo::new(
                 velocity_data.network_rx_speed,
                 velocity_data.network_tx_speed,
@@ -1200,12 +1204,7 @@ async fn get_velocity(
             let response = VelocityAnalysisResponse::new(
                 network_info,
                 velocity_data.cpu_usage_percent,
-                app_state
-                    .velocity_manager
-                    .read()
-                    .await
-                    .is_ready(&server_name)
-                    .await,
+                is_ready,
             );
 
             Ok(HttpResponse::Ok().json(&response))

--- a/monitor/src/monitoring/monitoring.rs
+++ b/monitor/src/monitoring/monitoring.rs
@@ -1337,6 +1337,20 @@ fn apfs_pool_key(d: &Disk) -> Option<(String, u64, u64)> {
             return Some((base, d.size, d.avail));
         }
     }
+    // Native sampling keys a volume by its mount point — the panel needs one
+    // row each — so no `/dev/diskN` reaches `path` there. What it does carry is
+    // `name`, the volume label, which every volume of one container shares
+    // ("Macintosh HD" for both "/" and "/System/Volumes/Data"); with the size
+    // and avail already in the key that identifies a pool as well as the device
+    // does. Restricted to APFS because on Linux `name` is an lsblk NAME, where
+    // two rows sharing one are two views of a device rather than a pool.
+    if d.fs_type
+        .as_deref()
+        .is_some_and(|t| t.eq_ignore_ascii_case("apfs"))
+        && let Some(name) = d.name.as_deref().filter(|n| !n.is_empty())
+    {
+        return Some((name.to_string(), d.size, d.avail));
+    }
     None
 }
 
@@ -1706,6 +1720,54 @@ mod tests {
         assert_eq!(metrics.total, 2000 * 1024);
         assert_eq!(metrics.free, 1200 * 1024);
         assert_eq!(metrics.used, 400 * 1024);
+    }
+
+    /// Native sampling keys a volume by its mount point — the panel needs one
+    /// row per volume — so the `/dev/diskN` form never reaches `path` and the
+    /// volume label arrives in `name`. Without pooling on it, a Mac's capacity
+    /// is reported once per volume. Values as probed on a real machine.
+    #[test]
+    fn native_apfs_volumes_are_pooled_by_volume_label() {
+        let volume = |mount: &str| Disk {
+            path: mount.to_string(),
+            mount: mount.to_string(),
+            fs_type: Some("apfs".to_string()),
+            name: Some("Macintosh HD".to_string()),
+            used: 200,
+            size: 1000,
+            avail: 600,
+            ..Default::default()
+        };
+        let disks = vec![volume("/"), volume("/System/Volumes/Data")];
+
+        let metrics = aggregate_disks(SystemType::Bsd, &disks);
+        assert_eq!(metrics.total, 1000 * 1024, "capacity counted once");
+        assert_eq!(metrics.free, 600 * 1024);
+        // Used is per volume and still sums, as in the /dev/diskN case.
+        assert_eq!(metrics.used, 400 * 1024);
+    }
+
+    /// The `name` fallback is APFS-only: on Linux `name` is an lsblk NAME, and
+    /// two rows carrying one are two views of a device, not a pool.
+    #[test]
+    fn non_apfs_volumes_sharing_a_name_are_not_pooled() {
+        let volume = |path: &str, mount: &str| Disk {
+            path: path.to_string(),
+            mount: mount.to_string(),
+            fs_type: Some("ext4".to_string()),
+            name: Some("sda1".to_string()),
+            used: 200,
+            size: 1000,
+            avail: 600,
+            ..Default::default()
+        };
+        let disks = vec![
+            volume("/dev/sda1", "/"),
+            volume("/dev/sda1-bind", "/mnt/data"),
+        ];
+
+        let metrics = aggregate_disks(SystemType::Linux, &disks);
+        assert_eq!(metrics.total, 2000 * 1024);
     }
 
     #[test]

--- a/monitor/src/monitoring/monitoring.rs
+++ b/monitor/src/monitoring/monitoring.rs
@@ -1331,27 +1331,32 @@ fn percent(used: u64, total: u64) -> f32 {
 /// avail) belong to one pool: count size/avail once, keep summing used.
 /// Linux paths never match the /dev/diskN pattern and are unaffected.
 fn apfs_pool_key(d: &Disk) -> Option<(String, u64, u64)> {
-    if let Some(rest) = d.path.strip_prefix("/dev/disk") {
-        let base: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
-        if !base.is_empty() {
-            return Some((base, d.size, d.avail));
-        }
-    }
-    // Native sampling keys a volume by its mount point — the panel needs one
-    // row each — so no `/dev/diskN` reaches `path` there. What it does carry is
-    // `name`, the volume label, which every volume of one container shares
-    // ("Macintosh HD" for both "/" and "/System/Volumes/Data"); with the size
-    // and avail already in the key that identifies a pool as well as the device
-    // does. Restricted to APFS because on Linux `name` is an lsblk NAME, where
-    // two rows sharing one are two views of a device rather than a pool.
-    if d.fs_type
-        .as_deref()
-        .is_some_and(|t| t.eq_ignore_ascii_case("apfs"))
-        && let Some(name) = d.name.as_deref().filter(|n| !n.is_empty())
-    {
-        return Some((name.to_string(), d.size, d.avail));
-    }
-    None
+    let container = apfs_container(&d.path).or_else(|| {
+        // Native sampling keys a volume by its mount point — the panel needs
+        // one row each — so no device reaches `path` there. It arrives in
+        // `name` instead, spelled the lsblk way ("disk3s5"). Restricted to
+        // APFS because on Linux `name` is an lsblk NAME, where two rows
+        // sharing one are two views of a device rather than a pool.
+        d.fs_type
+            .as_deref()
+            .filter(|t| t.eq_ignore_ascii_case("apfs"))?;
+        apfs_container(d.name.as_deref()?)
+    })?;
+    Some((container, d.size, d.avail))
+}
+
+/// The APFS container a device belongs to: `disk3` out of `/dev/disk3s1s1` or
+/// `disk3s5`. Both spellings appear — the script path reports `df`'s source in
+/// `path`, native sampling puts the bare device in `name`.
+///
+/// The container is the identity that matters and the only one available:
+/// volumes carry a *label*, which is shared inside a container and, for two
+/// disks nobody renamed, across containers too.
+fn apfs_container(device: &str) -> Option<String> {
+    let rest = device.strip_prefix("/dev/").unwrap_or(device);
+    let rest = rest.strip_prefix("disk")?;
+    let base: String = rest.chars().take_while(|c| c.is_ascii_digit()).collect();
+    (!base.is_empty()).then_some(base)
 }
 
 /// Disk aggregation with Go-compatible /status semantics: real filesystems
@@ -1724,26 +1729,56 @@ mod tests {
 
     /// Native sampling keys a volume by its mount point — the panel needs one
     /// row per volume — so the `/dev/diskN` form never reaches `path` and the
-    /// volume label arrives in `name`. Without pooling on it, a Mac's capacity
-    /// is reported once per volume. Values as probed on a real machine.
+    /// device arrives in `name`. Without pooling on it, a Mac's capacity is
+    /// reported once per volume. Values as probed on a real machine.
     #[test]
-    fn native_apfs_volumes_are_pooled_by_volume_label() {
-        let volume = |mount: &str| Disk {
+    fn native_apfs_volumes_are_pooled_by_container() {
+        let volume = |mount: &str, device: &str| Disk {
             path: mount.to_string(),
             mount: mount.to_string(),
             fs_type: Some("apfs".to_string()),
-            name: Some("Macintosh HD".to_string()),
+            name: Some(device.to_string()),
             used: 200,
             size: 1000,
             avail: 600,
             ..Default::default()
         };
-        let disks = vec![volume("/"), volume("/System/Volumes/Data")];
+        let disks = vec![
+            volume("/", "disk3s1s1"),
+            volume("/System/Volumes/Data", "disk3s5"),
+        ];
 
         let metrics = aggregate_disks(SystemType::Bsd, &disks);
         assert_eq!(metrics.total, 1000 * 1024, "capacity counted once");
         assert_eq!(metrics.free, 600 * 1024);
         // Used is per volume and still sums, as in the /dev/diskN case.
+        assert_eq!(metrics.used, 400 * 1024);
+    }
+
+    /// Two disks are two disks. The volume *label* cannot say so — two drives
+    /// nobody renamed share one ("Untitled"), and a pair bought together has
+    /// the same capacity, so a label-keyed pool would report half the storage
+    /// this machine has. The container behind each volume is the identity.
+    #[test]
+    fn distinct_apfs_containers_are_not_pooled() {
+        let volume = |mount: &str, device: &str| Disk {
+            path: mount.to_string(),
+            mount: mount.to_string(),
+            fs_type: Some("apfs".to_string()),
+            name: Some(device.to_string()),
+            used: 200,
+            size: 1000,
+            avail: 600,
+            ..Default::default()
+        };
+        let disks = vec![
+            volume("/Volumes/Untitled", "disk4s1"),
+            volume("/Volumes/Untitled 1", "disk9s1"),
+        ];
+
+        let metrics = aggregate_disks(SystemType::Bsd, &disks);
+        assert_eq!(metrics.total, 2000 * 1024);
+        assert_eq!(metrics.free, 1200 * 1024);
         assert_eq!(metrics.used, 400 * 1024);
     }
 
@@ -1768,6 +1803,18 @@ mod tests {
 
         let metrics = aggregate_disks(SystemType::Linux, &disks);
         assert_eq!(metrics.total, 2000 * 1024);
+    }
+
+    #[test]
+    fn apfs_container_reads_both_spellings_of_a_device() {
+        assert_eq!(apfs_container("/dev/disk3s1s1").as_deref(), Some("3"));
+        assert_eq!(apfs_container("disk3s5").as_deref(), Some("3"));
+        assert_eq!(apfs_container("/dev/disk10s1").as_deref(), Some("10"));
+        assert_eq!(apfs_container("/dev/sda1"), None);
+        assert_eq!(apfs_container("sda1"), None);
+        assert_eq!(apfs_container("/System/Volumes/Data"), None);
+        // A label, which is what this must never accept as an identity.
+        assert_eq!(apfs_container("Macintosh HD"), None);
     }
 
     #[test]

--- a/monitor/src/monitoring/rules.rs
+++ b/monitor/src/monitoring/rules.rs
@@ -118,7 +118,17 @@ async fn check_cpu_rule(rule: &MonitoringRule, metrics: &SystemMetrics) -> Resul
 
 async fn check_memory_rule(rule: &MonitoringRule, metrics: &SystemMetrics) -> Result<(bool, f64, String)> {
     let matcher = &rule.matcher;
-    
+
+    // `adapt_memory` reports an absent sample as zeros, so a total of 0 means
+    // /proc/meminfo (or its platform equivalent) could not be read — no machine
+    // has no memory. Judged as a reading it is 0% used, which silences a "high
+    // memory" rule, and `avail` divides by it: NaN compares false against every
+    // threshold, so that rule can never fire again.
+    if metrics.memory.total == 0 {
+        warn!("No memory reading this cycle; skipping rule '{}'", rule.name);
+        return Ok((false, 0.0, "--".to_string()));
+    }
+
     match matcher.as_str() {
         "used" | "memory" | "" => {
             let usage = metrics.memory.usage_percent as f64;
@@ -169,6 +179,16 @@ async fn check_swap_rule(rule: &MonitoringRule, metrics: &SystemMetrics) -> Resu
 }
 
 async fn check_disk_rule(rule: &MonitoringRule, metrics: &SystemMetrics) -> Result<(bool, f64, String)> {
+    // Disk usage comes from `df`, which the native sampler abandons on a
+    // timeout (an unresponsive network mount) and reports as no filesystems at
+    // all. That aggregates to a total of 0 and a usage of 0%, which reads as a
+    // measured "empty disk": a `<10%` rule fires on a machine that is fine, and
+    // a `>=90%` rule stays quiet on one that is filling up.
+    if metrics.disk.total == 0 {
+        warn!("No disk reading this cycle; skipping rule '{}'", rule.name);
+        return Ok((false, 0.0, "--".to_string()));
+    }
+
     let usage = metrics.disk.usage_percent as f64;
     let should_alert = should_trigger_alert(&rule.threshold, usage)?;
     let formatted = format!("{:.2}%", usage);
@@ -182,34 +202,29 @@ async fn check_network_rule(
 ) -> Result<(bool, f64, String)> {
     let matcher = &rule.matcher;
     if let Ok(velocity_metrics) = velocity_manager.get_server_velocity(&metrics.server_name).await {
-        let (value, _unit) = match matcher.as_str() {
-            "rx" | "in" => {
-                if let Some(speed) = velocity_metrics.network_rx_speed {
-                    (speed, "B/s")
-                } else {
-                    (0.0, "B/s")
-                }
-            }
-            "tx" | "out" => {
-                if let Some(speed) = velocity_metrics.network_tx_speed {
-                    (speed, "B/s")
-                } else {
-                    (0.0, "B/s")
-                }
-            }
-            _ => {
-                let rx = velocity_metrics.network_rx_speed.unwrap_or(0.0);
-                let tx = velocity_metrics.network_tx_speed.unwrap_or(0.0);
-                (rx + tx, "B/s")
-            }
+        // A speed is the difference between two samples, so there is none until
+        // the second one lands: after an agent restart, after a gap in
+        // collection, and for an interface that has just appeared. `None` is
+        // that state and is not 0 B/s — a bare threshold parses as `<`
+        // (`Threshold::parse`, Go-compatible), so substituting zero reports the
+        // link as down every time the agent starts.
+        let Some(value) = (match matcher.as_str() {
+            "rx" | "in" => velocity_metrics.network_rx_speed,
+            "tx" | "out" => velocity_metrics.network_tx_speed,
+            _ => match (velocity_metrics.network_rx_speed, velocity_metrics.network_tx_speed) {
+                (Some(rx), Some(tx)) => Some(rx + tx),
+                _ => None,
+            },
+        }) else {
+            return Ok((false, 0.0, "--".to_string()));
         };
-        
+
         let should_alert = should_trigger_speed_alert(&rule.threshold, value)?;
         let formatted = format_network_speed(value);
-        
+
         Ok((should_alert, value, formatted))
     } else {
-        Ok((false, 0.0, "0 B/s".to_string()))
+        Ok((false, 0.0, "--".to_string()))
     }
 }
 
@@ -339,6 +354,179 @@ mod tests {
         // This test would need velocity_manager to work with check_rules_with_velocity
         // For now we just test that the function exists and rules are parsed correctly
         assert!(!config.get_monitoring().rules.is_empty());
+    }
+
+    fn rule(monitor_type: &str, matcher: &str, threshold: &str) -> MonitoringRule {
+        MonitoringRule {
+            name: format!("{monitor_type}-{matcher}"),
+            monitor_type: monitor_type.to_string(),
+            threshold: threshold.to_string(),
+            matcher: matcher.to_string(),
+        }
+    }
+
+    /// Every field zeroed, which is what `adapt_memory`/`aggregate_disks`
+    /// produce when the sample behind them is missing.
+    fn empty_metrics() -> SystemMetrics {
+        SystemMetrics {
+            timestamp: Utc::now(),
+            extended_updated_at: Utc::now(),
+            server_name: "test".to_string(),
+            cpu_usage: 0.0,
+            cpu_cores: vec![],
+            memory: crate::monitoring::MemoryMetrics {
+                total: 0,
+                used: 0,
+                free: 0,
+                usage_percent: 0.0,
+            },
+            swap: crate::monitoring::SwapMetrics {
+                total: 0,
+                used: 0,
+                usage_percent: 0.0,
+            },
+            disk: crate::monitoring::DiskMetrics {
+                total: 0,
+                used: 0,
+                free: 0,
+                usage_percent: 0.0,
+            },
+            network: crate::monitoring::NetworkMetrics {
+                rx_bytes: 0,
+                tx_bytes: 0,
+            },
+            temperature: None,
+            temps: vec![],
+            sys: None,
+            os_id: None,
+            os_id_like: Vec::new(),
+            cpu_brand: None,
+            gpus: vec![],
+            disk_details: vec![],
+            ifaces: vec![],
+            uptime: None,
+            conn: None,
+            diskio: vec![],
+            diskio_rate: vec![],
+            batteries: vec![],
+            sensors: vec![],
+            disk_smart: vec![],
+            ips: vec![],
+            custom_cmds: vec![],
+            amd_cache: vec![],
+        }
+    }
+
+    /// `/proc/meminfo` unreadable arrives as a total of 0. `avail` divided by
+    /// it, so the rule compared NaN — false against every threshold — and the
+    /// low-memory alert could never fire again.
+    #[tokio::test]
+    async fn memory_rule_skips_a_cycle_with_no_reading() {
+        let metrics = empty_metrics();
+
+        let (alert, value, formatted) = check_memory_rule(&rule("memory", "avail", "<=10%"), &metrics)
+            .await
+            .unwrap();
+        assert!(!alert);
+        assert!(!value.is_nan(), "a missing sample must not produce NaN");
+        assert_eq!(formatted, "--");
+
+        // The same total of 0 reads as 0% used, which would silence this one.
+        let (alert, _, formatted) = check_memory_rule(&rule("memory", "used", ">=90%"), &metrics)
+            .await
+            .unwrap();
+        assert!(!alert);
+        assert_eq!(formatted, "--");
+    }
+
+    #[tokio::test]
+    async fn memory_rule_fires_on_a_real_reading() {
+        let mut metrics = empty_metrics();
+        metrics.memory = crate::monitoring::MemoryMetrics {
+            total: 1000,
+            used: 950,
+            free: 50,
+            usage_percent: 95.0,
+        };
+
+        let (alert, _, _) = check_memory_rule(&rule("memory", "used", ">=90%"), &metrics)
+            .await
+            .unwrap();
+        assert!(alert);
+
+        let (alert, value, _) = check_memory_rule(&rule("memory", "avail", "<=10%"), &metrics)
+            .await
+            .unwrap();
+        assert!(alert);
+        assert_eq!(value, 5.0);
+    }
+
+    /// A `df` that timed out leaves no filesystems, which aggregates to a total
+    /// of 0 and 0% used — indistinguishable from a measured empty disk.
+    #[tokio::test]
+    async fn disk_rule_skips_a_cycle_with_no_reading() {
+        let (alert, _, formatted) = check_disk_rule(&rule("disk", "", "<10%"), &empty_metrics())
+            .await
+            .unwrap();
+        assert!(!alert, "an absent reading must not fire a low-usage rule");
+        assert_eq!(formatted, "--");
+    }
+
+    #[tokio::test]
+    async fn disk_rule_fires_on_a_real_reading() {
+        let mut metrics = empty_metrics();
+        metrics.disk = crate::monitoring::DiskMetrics {
+            total: 10000,
+            used: 9500,
+            free: 500,
+            usage_percent: 95.0,
+        };
+
+        let (alert, _, _) = check_disk_rule(&rule("disk", "", ">=90%"), &metrics)
+            .await
+            .unwrap();
+        assert!(alert);
+    }
+
+    /// A speed needs two samples. Until the second one lands there is no
+    /// reading, and substituting 0 B/s made every agent restart report the
+    /// link as down: a bare threshold parses as `<`.
+    #[tokio::test]
+    async fn network_rule_skips_a_cycle_with_no_speed_yet() {
+        let velocity = VelocityManager::new();
+        let metrics = empty_metrics();
+
+        for matcher in ["rx", "tx", ""] {
+            let (alert, value, formatted) =
+                check_network_rule(&rule("network", matcher, "1m/s"), &metrics, &velocity)
+                    .await
+                    .unwrap();
+            assert!(!alert, "matcher {matcher:?} fired without a reading");
+            assert_eq!(value, 0.0);
+            assert_eq!(formatted, "--");
+        }
+    }
+
+    #[tokio::test]
+    async fn network_rule_fires_once_a_speed_is_measured() {
+        let mut velocity = VelocityManager::new();
+        let now = Utc::now();
+        velocity
+            .update_server_metrics("test", 0, 0, vec![], now - chrono::Duration::seconds(10))
+            .await;
+        velocity
+            .update_server_metrics("test", 10_000_000, 10_000_000, vec![], now)
+            .await;
+
+        // 10 MB over 10 s, against a threshold in KiB/s.
+        let (alert, value, _) = check_network_rule(
+            &rule("network", "rx", ">100k/s"),
+            &empty_metrics(),
+            &velocity,
+        )
+        .await
+        .unwrap();
+        assert!(alert, "expected a measured speed, got {value}");
     }
 
     #[test]

--- a/monitor/tests/velocity_lock.rs
+++ b/monitor/tests/velocity_lock.rs
@@ -1,0 +1,130 @@
+//! `GET /api/v1/velocity` against the monitoring loop's writer.
+//!
+//! The handler needs three things out of the velocity manager, and used to take
+//! the lock once per thing. A temporary in a `match` scrutinee lives to the end
+//! of the whole `match`, so the first guard was still held while the second was
+//! asked for — and tokio's `RwLock` is fair, so a writer that queued in between
+//! blocked that second reader while itself waiting on the first guard. Neither
+//! side could finish.
+//!
+//! The writer is the monitoring loop (`monitoring.rs`, once per cycle), so the
+//! cost was not one failed request: the loop never took its lock again, and
+//! with it went metric collection, rule evaluation and every push, until
+//! someone restarted the agent. The panel polls this endpoint while it is open,
+//! which is what made it reachable at all.
+//!
+//! This is a stress test rather than a construction — the window is real
+//! parallelism between two threads, not a scheduler point that can be steered
+//! from here. Verified to hang the old handler well inside the iteration count
+//! below.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use ntex::time::timeout;
+use ntex::web::App;
+use ntex::web::test::{self as web_test, TestServer};
+use rustls::crypto::ring;
+use server_box_monitor::api::auth::generate_token;
+use server_box_monitor::api::server::{AppState, configure_api};
+use server_box_monitor::core::config::Config;
+use std::sync::Once;
+
+const SECRET: &str = "test-secret-that-is-long-enough-32ch";
+
+/// The test client speaks TLS whether or not this server does, and rustls
+/// refuses to pick a provider for itself.
+fn ensure_crypto_provider() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        let _ = ring::default_provider().install_default();
+    });
+}
+
+async fn state() -> Arc<AppState> {
+    ensure_crypto_provider();
+    let config = Config {
+        jwt_secret: Some(SECRET.to_string()),
+        ..Default::default()
+    };
+
+    let db = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+    sqlx::migrate!("./migrations").run(&db).await.unwrap();
+
+    let state = AppState::new(Arc::new(config), db);
+
+    // One sample, so the handler goes through the per-server processor rather
+    // than the "server unknown" early return — that path holds the outer guard
+    // across an inner lock, which is where the window actually is.
+    let server_name = state.config.get_server_name();
+    state
+        .velocity_manager
+        .write()
+        .await
+        .update_server_metrics(&server_name, 0, 0, vec![], chrono::Utc::now())
+        .await;
+
+    state
+}
+
+async fn test_server(state: Arc<AppState>) -> TestServer {
+    web_test::server(move || {
+        let state = state.clone();
+        async move {
+            let limit = state.remote_access.exec.max_request_bytes;
+            App::new().state(state).configure(configure_api(limit))
+        }
+    })
+    .await
+}
+
+#[ntex::test]
+async fn velocity_survives_a_concurrent_collection_cycle() {
+    let state = state().await;
+    let srv = test_server(state.clone()).await;
+    let token = generate_token("admin", SECRET).unwrap();
+
+    // Stands in for the monitoring loop, which takes this lock once per cycle.
+    let stop = Arc::new(AtomicBool::new(false));
+    let writer = {
+        let state = state.clone();
+        let stop = stop.clone();
+        ntex::rt::spawn(async move {
+            let server_name = state.config.get_server_name();
+            let mut rx = 0u64;
+            while !stop.load(Ordering::Relaxed) {
+                rx += 1_000;
+                state
+                    .velocity_manager
+                    .write()
+                    .await
+                    .update_server_metrics(&server_name, rx, rx, vec![], chrono::Utc::now())
+                    .await;
+            }
+        })
+    };
+
+    let requests = async {
+        for i in 0..200 {
+            let resp = srv
+                .get("/api/v1/velocity")
+                .header("Authorization", format!("Bearer {token}"))
+                .send()
+                .await
+                .unwrap_or_else(|e| {
+                    panic!("request {i} never answered ({e}) — deadlocked against the writer")
+                });
+            assert!(resp.status().is_success(), "request {i}: {}", resp.status());
+        }
+    };
+
+    let outcome = timeout(Duration::from_secs(30), requests).await;
+    stop.store(true, Ordering::Relaxed);
+    let _ = writer.await;
+
+    assert!(
+        outcome.is_ok(),
+        "/velocity deadlocked against the collection cycle's writer"
+    );
+}


### PR DESCRIPTION
From the full-tree audit. Four findings, all one shape: a reading that was never taken being judged as one that was.

### `/velocity` deadlocked the collection cycle

`get_velocity` took `velocity_manager` three times. A temporary in a `match` scrutinee lives to the end of the whole `match`, so the first read guard was still held when the second was asked for — and tokio's `RwLock` is fair, so a writer that queued in between blocked that second reader while itself waiting on the first guard.

The writer is the monitoring loop, once per cycle. So the cost was not one failed request: the loop never took its lock again, and with it went metric collection, rule evaluation and every push, until someone restarted the agent. The panel polls this endpoint while it is open, which is what made it reachable.

One guard now serves the whole handler. `tests/velocity_lock.rs` runs the endpoint against a writer standing in for the collection cycle; the old handler hangs on its first request.

### Memory, disk and network rules judged absent samples

- **memory `avail`** divided by `metrics.memory.total` with none of the zero guard every other percentage goes through. `total` is 0 whenever `/proc/meminfo` could not be read, so the rule compared `NaN`, which is false against every threshold — the low-memory alert could never fire again, and any rule that did fire rendered `NaN%` in the push body.
- **disk** is aggregated from `df`, which the native sampler abandons on a timeout (an unresponsive network mount) and reports as no filesystems at all. That comes out as 0% used: a `<10%` rule fires on a machine that is fine, a `>=90%` rule stays quiet on one that is filling up.
- **network** speeds need two samples, and `None` was substituted with `0 B/s`. A bare threshold parses as `<` (Go-compatible, `Threshold::parse`), so every agent restart and every gap in collection reported the link as down.

All three now skip the cycle instead, which is the shape `check_cpu_rule` already used for "no baseline yet".

### A Mac's disk capacity was counted once per volume

APFS volumes of one container each report the container's whole size, and `aggregate_disks` pools them by the `/dev/diskN` in `path`. Native sampling never produces that: it keys a volume by mount point, deliberately, because volumes of a container report identical `sysinfo` names and the panel renders rows keyed by this value (`disks_and_diskio_have_unique_keys`).

So the pool key now falls back to `name` — the volume label, which every volume of a container shares — with the size and avail already in the key. Probed on a real machine: `/` and `/System/Volumes/Data` both report `Macintosh HD` at the same size and avail. APFS-only, because on Linux `name` is an lsblk NAME, where two rows sharing one are two views of a device rather than a pool.

### Deliberately not changed

`Threshold::parse` still defaults a bare threshold to `<`. It is documented Go-compatible behaviour and the network rule's false alerts came from the substituted zero, not from the default.

### Tests

`cargo test -p server_box_monitor` (168 + integration), `cargo test -p sbm_native`, clippy clean on both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * macOS disk metadata now reports unique device identifiers instead of potentially ambiguous volume labels.
  * Improved APFS disk grouping to keep separate containers distinct, even when labels and capacities match.
  * Missing memory and disk readings are skipped instead of displayed as zero.
  * Network metrics remain unavailable until a valid speed sample is available, preserving the `--` indicator.
  * Improved velocity endpoint reliability during concurrent metric updates, reducing stalled requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->