### PR TITLE
fix(parser): panics and wrong readings from what a server sent back

### DIFF
--- a/crates/sbm_parser/src/bsd.rs
+++ b/crates/sbm_parser/src/bsd.rs
@@ -30,11 +30,16 @@ pub fn parse_cpu(raw: &str) -> Vec<CpuCore> {
     static PERCENT: OnceLock<Regex> = OnceLock::new();
     static CORE_COUNT: OnceLock<Regex> = OnceLock::new();
 
+    // The count is `sysctl -n hw.ncpu` as the host answered it, and it decides
+    // how many pseudo-cores to allocate — see `MAX_CPU_CORES` for why an
+    // unbounded one is a process kill rather than an error. A count outside
+    // the bound is a broken reading and falls back to the single pseudo-core,
+    // which is what an absent one already did.
     let count = regex(&CORE_COUNT, r"(?m)^\s*(\d+)\s*$")
         .captures(raw)
-        .and_then(|c| c[1].parse::<usize>().ok())
-        .filter(|&n| n > 0)
-        .unwrap_or(1);
+        .and_then(|c| c[1].parse::<u64>().ok())
+        .filter(|&n| n > 0 && n <= MAX_CPU_CORES)
+        .unwrap_or(1) as usize;
 
     let cores = |user: u64, sys: u64, nice: u64, idle: u64, irq: u64| {
         (0..count)
@@ -208,8 +213,17 @@ fn to_kib(amount: f64, unit: &str) -> u64 {
 }
 
 /// `netstat -ibn`(Dart `NetSpeed.parseBsd`):
-/// Only 11-column Link lines; skip inactive interfaces ending in `*`; first line wins per interface name
+/// Link lines only; skip inactive interfaces ending in `*`; first line wins per interface name
+///
+/// macOS prints 11 columns and FreeBSD 12 — it has an `Idrop` between `Ierrs`
+/// and `Ibytes`. Accepting only macOS's width meant every line of a FreeBSD
+/// host's output was discarded and the host reported no network at all.
+/// Because the extra column is inserted *before* `Ibytes`, counting from the
+/// right covers both: `Coll` is last, `Obytes` second to last, `Ibytes` fifth.
 pub fn parse_net(raw: &str) -> Vec<NetIface> {
+    const MACOS_COLUMNS: usize = 11;
+    const FREEBSD_COLUMNS: usize = 12;
+
     let lines: Vec<&str> = raw.split('\n').collect();
     if lines.len() < 2 {
         return Vec::new();
@@ -221,10 +235,13 @@ pub fn parse_net(raw: &str) -> Vec<NetIface> {
         if device.ends_with('*') || result.iter().any(|n| n.device == *device) {
             continue;
         }
-        if fields.len() != 11 {
+        if fields.len() != MACOS_COLUMNS && fields.len() != FREEBSD_COLUMNS {
             continue;
         }
-        let (Ok(rx), Ok(tx)) = (fields[6].parse(), fields[9].parse()) else {
+        let (Ok(rx), Ok(tx)) = (
+            fields[fields.len() - 5].parse(),
+            fields[fields.len() - 2].parse(),
+        ) else {
             continue;
         };
         result.push(NetIface {

--- a/crates/sbm_parser/src/linux.rs
+++ b/crates/sbm_parser/src/linux.rs
@@ -20,8 +20,13 @@ pub fn parse_cpu(raw: &str) -> Vec<CpuCore> {
             continue;
         }
         let parse = |i: usize| fields[i].parse::<u64>();
+        // /proc/stat's column order is `user nice system idle iowait irq
+        // softirq` — nice comes second. Reading field 2 as `sys` put nice time
+        // under the `sys` label in the UI (near zero on most machines) and left
+        // real system time displayed nowhere. `total()` sums every field, so
+        // nothing that aggregates could notice.
         match (parse(1), parse(2), parse(3), parse(4), parse(5), parse(6), parse(7)) {
-            (Ok(user), Ok(sys), Ok(nice), Ok(idle), Ok(iowait), Ok(irq), Ok(softirq)) => {
+            (Ok(user), Ok(nice), Ok(sys), Ok(idle), Ok(iowait), Ok(irq), Ok(softirq)) => {
                 cores.push(CpuCore {
                     id: id.to_string(),
                     user,
@@ -217,8 +222,13 @@ fn parse_df(raw: &str) -> Vec<Disk> {
             path_cache = fields[0].to_string();
             continue;
         }
+        // The buffered name belongs *in front of* this line's columns, which
+        // start at the size. Overwriting field 0 destroyed the size column and
+        // left five fields, which the `>= 6` check below then dropped — so a
+        // stock Ubuntu LVM install ("/dev/mapper/ubuntu--vg-ubuntu--lv", long
+        // enough that df wraps it) reported no root filesystem at all.
         if !path_cache.is_empty() && !fields.is_empty() {
-            fields[0] = &path_cache;
+            fields.insert(0, path_cache.as_str());
         }
         let parsed = (|| -> Option<Disk> {
             let fs = fields.first()?.to_string();
@@ -259,12 +269,17 @@ fn df_size_kib(s: &str) -> Option<u64> {
     if let Ok(v) = s.parse::<u64>() {
         return Some(v);
     }
-    let (num, unit) = s.split_at(s.len().checked_sub(1)?);
+    // By character, not by byte: `s` is whatever the remote host's `df` wrote,
+    // and splitting one byte from the end lands inside a multi-byte character
+    // and panics — which, over FFI, takes the app's process with it.
+    let mut chars = s.chars();
+    let unit = chars.next_back()?;
+    let num = chars.as_str();
     let multiplier: f64 = match unit {
-        "K" | "k" => 1.0,
-        "M" | "m" => 1024.0,
-        "G" | "g" => 1024.0 * 1024.0,
-        "T" | "t" => 1024.0 * 1024.0 * 1024.0,
+        'K' | 'k' => 1.0,
+        'M' | 'm' => 1024.0,
+        'G' | 'g' => 1024.0 * 1024.0,
+        'T' | 't' => 1024.0 * 1024.0 * 1024.0,
         _ => return None,
     };
     Some((num.parse::<f64>().ok()? * multiplier) as u64)
@@ -300,14 +315,23 @@ pub fn parse_net(raw: &str) -> Vec<NetIface> {
 /// thermal_zone type/temp segments (Dart `Temperatures.parse`):
 /// paired line by line, name is the last path segment, value divided by divisor
 /// (Linux reports millidegree Celsius → 1000)
+///
+/// The two sides come from two independent `cat` globs, so the pairing is
+/// positional and only sound while both listed the same zones. A zone whose
+/// `temp` cannot be read contributes a line to one side and not the other,
+/// which shifts every later reading onto the preceding zone's name — a
+/// plausible-looking wrong answer. Counts that disagree are therefore reported
+/// as no temperatures at all. Pairing them at the source (one line per zone)
+/// is a change to the command manifest, which every installed status script
+/// would have to be reissued for.
 pub fn parse_temps(types_raw: &str, values_raw: &str, divisor: f64) -> Temperatures {
     let mut temps = Temperatures::default();
-    let types: Vec<&str> = types_raw.split('\n').collect();
-    let values: Vec<&str> = values_raw.split('\n').collect();
+    let types: Vec<&str> = types_raw.lines().filter(|l| !l.trim().is_empty()).collect();
+    let values: Vec<&str> = values_raw.lines().filter(|l| !l.trim().is_empty()).collect();
+    if types.len() != values.len() {
+        return temps;
+    }
     for (t, v) in types.iter().zip(values.iter()) {
-        if t.is_empty() || v.is_empty() {
-            continue;
-        }
         let name = t.rsplit('/').next().unwrap_or(t);
         if let Ok(temp) = v.trim().parse::<f64>() {
             temps.0.insert(name.to_string(), temp / divisor);

--- a/crates/sbm_parser/src/types.rs
+++ b/crates/sbm_parser/src/types.rs
@@ -6,6 +6,19 @@
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
+/// Upper bound on how many cores a reported core count may claim.
+///
+/// On Bsd and Windows the count comes from the host as a bare number
+/// (`sysctl -n hw.ncpu`, WMI's `NumberOfLogicalProcessors`) and decides how
+/// many [`CpuCore`]s to allocate. A corrupt or hostile answer would otherwise
+/// allocate until the process is killed — and in the app that process is the
+/// app, since the parser runs in it over FFI rather than behind a boundary an
+/// exception could cross.
+///
+/// Set well above real hardware (the largest shipping x86 parts are in the
+/// hundreds of threads) so that the bound only ever rejects a broken reading.
+pub const MAX_CPU_CORES: u64 = 4096;
+
 /// Cumulative CPU ticks of one core (Dart `SingleCpuCore`).
 /// From /proc/stat on Linux; on BSD/Windows synthesized from one-shot percentages.
 ///

--- a/crates/sbm_parser/src/windows.rs
+++ b/crates/sbm_parser/src/windows.rs
@@ -58,6 +58,13 @@ pub fn parse_cpu(raw: &str, prev: &[CpuCore]) -> Vec<CpuCore> {
         if logical > MAX_CPU_CORES {
             continue;
         }
+        // The bound belongs to the machine, not to one entry: enough entries
+        // each just inside it still add up to an allocation no machine could
+        // have. No later entry can bring the running total back down, so this
+        // stops rather than skipping — what was read before it is kept.
+        if cores.len() as u64 + logical > MAX_CPU_CORES {
+            break;
+        }
         let logical = logical as usize;
         let idle = 100 - load;
 

--- a/crates/sbm_parser/src/windows.rs
+++ b/crates/sbm_parser/src/windows.rs
@@ -42,9 +42,23 @@ pub fn parse_cpu(raw: &str, prev: &[CpuCore]) -> Vec<CpuCore> {
         let Some(load) = processor["LoadPercentage"].as_u64().filter(|v| *v <= 100) else {
             continue;
         };
-        let physical = processor["NumberOfCores"].as_u64().unwrap_or(1) as usize;
-        let logical =
-            processor["NumberOfLogicalProcessors"].as_u64().unwrap_or(physical as u64) as usize;
+        let physical = processor["NumberOfCores"]
+            .as_u64()
+            .filter(|n| *n <= MAX_CPU_CORES)
+            .unwrap_or(1);
+        // This number decides how many entries to allocate, and it arrives from
+        // whatever the remote host's WMI query returned. Unbounded, a corrupt
+        // or hostile reading allocates until the process is killed — over FFI
+        // that is the app dying, not an exception a caller can catch. A count
+        // past the bound is a broken query, handled like a broken
+        // LoadPercentage: skip the entry rather than invent a reading for it.
+        let logical = processor["NumberOfLogicalProcessors"]
+            .as_u64()
+            .unwrap_or(physical);
+        if logical > MAX_CPU_CORES {
+            continue;
+        }
+        let logical = logical as usize;
         let idle = 100 - load;
 
         for i in 0..logical {
@@ -62,7 +76,7 @@ pub fn parse_cpu(raw: &str, prev: &[CpuCore]) -> Vec<CpuCore> {
                 softirq: 0,
             });
         }
-        offset += logical;
+        offset = offset.saturating_add(logical);
     }
 
     if !cores.is_empty() {
@@ -118,6 +132,12 @@ pub fn parse_disks(raw: &str) -> Vec<Disk> {
             let size_kb = size / 1024;
             let free_kb = free / 1024;
             let used_kb = size_kb - free_kb;
+            // The guard above rejects a zero size in bytes; anything under a
+            // KiB floors to zero here and divides by zero below — an integer
+            // division that panics in release too.
+            if size_kb == 0 {
+                return None;
+            }
             Some(Disk {
                 used_percent: (used_kb * 100 / size_kb).min(100) as u32,
                 path: device_id.clone(),

--- a/crates/sbm_parser/tests/field_output.rs
+++ b/crates/sbm_parser/tests/field_output.rs
@@ -1,0 +1,116 @@
+//! Output shapes real machines produce that were read wrongly or not at all.
+//!
+//! Unlike `hostile_input.rs` nothing here crashes: each case parsed, and
+//! answered something that looked like a reading.
+
+use sbm_parser::{bsd, linux};
+
+/// `df` puts an overlong source on a line of its own and the columns on the
+/// next. The buffered name belongs in front of those columns; it was written
+/// *over* the first one instead, destroying the size and leaving five fields,
+/// which the row-shape check then dropped. A stock Ubuntu LVM install is
+/// exactly this case, so it reported no root filesystem at all.
+#[test]
+fn a_wrapped_df_row_keeps_its_columns() {
+    let raw = "Filesystem                        1K-blocks     Used Available Use% Mounted on\n\
+               /dev/mapper/ubuntu--vg-ubuntu--lv\n\
+               \x20                                 30298176 10000000  18000000  36% /\n";
+
+    let disks = linux::parse_disk(raw);
+    assert_eq!(disks.len(), 1, "the root filesystem is missing");
+    assert_eq!(disks[0].path, "/dev/mapper/ubuntu--vg-ubuntu--lv");
+    assert_eq!(disks[0].mount, "/");
+    assert_eq!(disks[0].size, 30298176);
+    assert_eq!(disks[0].used, 10000000);
+    assert_eq!(disks[0].avail, 18000000);
+    assert_eq!(disks[0].used_percent, 36);
+}
+
+/// The buffered name applies to the next row only.
+#[test]
+fn a_wrapped_row_does_not_rename_the_rows_after_it() {
+    let raw = "Filesystem 1K-blocks Used Available Use% Mounted on\n\
+               /dev/mapper/ubuntu--vg-ubuntu--lv\n\
+               \x20 30298176 10000000 18000000 36% /\n\
+               /dev/sda2 1000000 400000 600000 40% /boot\n";
+
+    let disks = linux::parse_disk(raw);
+    assert_eq!(disks.len(), 2);
+    assert_eq!(disks[1].path, "/dev/sda2");
+    assert_eq!(disks[1].size, 1000000);
+}
+
+/// FreeBSD's `netstat -ibn` has an `Idrop` column between `Ierrs` and
+/// `Ibytes`, so its rows are 12 wide where macOS's are 11. Only the macOS
+/// width was accepted, which discarded every line and left a FreeBSD host
+/// reporting no network at all.
+#[test]
+fn freebsd_netstat_has_a_twelfth_column() {
+    let raw = "Name    Mtu Network       Address              Ipkts Ierrs Idrop     Ibytes    Opkts Oerrs     Obytes  Coll\n\
+               em0    1500 <Link#1>      08:00:27:4e:66:a1  1234567     0     0  987654321  7654321     0  123456789     0\n";
+
+    let ifaces = bsd::parse_net(raw);
+    assert_eq!(ifaces.len(), 1);
+    assert_eq!(ifaces[0].device, "em0");
+    assert_eq!(ifaces[0].rx_bytes, 987654321);
+    assert_eq!(ifaces[0].tx_bytes, 123456789);
+}
+
+/// An interface with no link-layer address leaves that column empty, so the
+/// row is one narrower — 11 on FreeBSD, the same width as an addressed macOS
+/// row. Counting the byte columns from the right reads both correctly.
+#[test]
+fn a_freebsd_interface_without_an_address_still_reads() {
+    let raw = "Name    Mtu Network       Address              Ipkts Ierrs Idrop     Ibytes    Opkts Oerrs     Obytes  Coll\n\
+               lo0   16384 <Link#2>                            4242     0     0     424242     1111     0     111111     0\n";
+
+    let ifaces = bsd::parse_net(raw);
+    assert_eq!(ifaces.len(), 1);
+    assert_eq!(ifaces[0].rx_bytes, 424242);
+    assert_eq!(ifaces[0].tx_bytes, 111111);
+}
+
+/// The names and the values come from two independent `cat` globs. A zone
+/// whose `temp` cannot be read drops a line from one side only, and pairing
+/// positionally then reports every later zone's temperature under the previous
+/// zone's name — which is worse than reporting none, because nothing about it
+/// looks wrong.
+#[test]
+fn a_missing_thermal_value_reports_no_temperatures() {
+    let types = "acpitz\nx86_pkg_temp\niwlwifi_1\n";
+    let values = "45000\n55000\n";
+
+    let temps = linux::parse_temps(types, values, 1000.0);
+    assert!(
+        temps.0.is_empty(),
+        "a shifted pairing is not a set of readings: {:?}",
+        temps.0
+    );
+}
+
+/// Trailing newlines are not a mismatch.
+#[test]
+fn an_uneven_trailing_newline_is_not_a_mismatch() {
+    let temps = linux::parse_temps("acpitz\nx86_pkg_temp\n\n", "45000\n55000", 1000.0);
+    assert_eq!(temps.0.get("acpitz"), Some(&45.0));
+    assert_eq!(temps.0.get("x86_pkg_temp"), Some(&55.0));
+}
+
+/// /proc/stat's columns are `user nice system idle iowait irq softirq`. Field 2
+/// was read as `sys` and field 3 as `nice`, so the server detail page's "sys"
+/// row showed nice time — near zero on most machines — and real system time
+/// was displayed nowhere. `total()` sums every field, which is why every
+/// aggregate agreed with itself throughout.
+#[test]
+fn proc_stat_columns_are_user_nice_system() {
+    let cores = linux::parse_cpu("cpu 100 5 300 400 10 1 2");
+    assert_eq!(cores.len(), 1);
+    assert_eq!(cores[0].user, 100);
+    assert_eq!(cores[0].nice, 5);
+    assert_eq!(cores[0].sys, 300);
+    assert_eq!(cores[0].idle, 400);
+    assert_eq!(cores[0].iowait, 10);
+    assert_eq!(cores[0].irq, 1);
+    assert_eq!(cores[0].softirq, 2);
+    assert_eq!(cores[0].total(), 818);
+}

--- a/crates/sbm_parser/tests/hostile_input.rs
+++ b/crates/sbm_parser/tests/hostile_input.rs
@@ -6,6 +6,7 @@
 //! server either: each is also a shape a broken tool or a corrupt reading
 //! produces.
 
+use sbm_parser::types::MAX_CPU_CORES;
 use sbm_parser::{bsd, linux, windows};
 
 /// `Size` is rejected at zero, but anything under a KiB floors to zero after
@@ -46,6 +47,38 @@ fn an_absurd_logical_processor_count_is_refused() {
 fn a_broken_processor_entry_does_not_take_the_others_with_it() {
     let cores = windows::parse_cpu(
         r#"[{"LoadPercentage":50,"NumberOfCores":1,"NumberOfLogicalProcessors":100000000000},
+            {"LoadPercentage":50,"NumberOfCores":2,"NumberOfLogicalProcessors":2}]"#,
+        &[],
+    );
+    let ids: Vec<&str> = cores.iter().map(|c| c.id.as_str()).collect();
+    assert_eq!(ids, ["cpu", "cpu0", "cpu1"]);
+}
+
+/// A bound on one entry is not a bound on the reply: entries each well inside
+/// it still add up. 100 sockets of 128 threads is not a machine, and every
+/// core allocated carries a heap-allocated id.
+#[test]
+fn processor_entries_cannot_add_up_past_the_bound() {
+    let entry = r#"{"LoadPercentage":50,"NumberOfCores":64,"NumberOfLogicalProcessors":128}"#;
+    let raw = format!("[{}]", [entry; 100].join(","));
+
+    let cores = windows::parse_cpu(&raw, &[]);
+    // The summary row is not one of the machine's cores.
+    let per_core = cores.len() as u64 - 1;
+    assert!(
+        per_core <= MAX_CPU_CORES,
+        "allocated {per_core} cores, bound is {MAX_CPU_CORES}"
+    );
+    // 32 entries of 128 reach the bound exactly; the 33rd would pass it.
+    assert_eq!(per_core, MAX_CPU_CORES);
+}
+
+/// An entry reporting no logical processors is a real answer for a socket that
+/// is present and unpopulated, and contributes nothing rather than stopping.
+#[test]
+fn a_zero_logical_entry_is_not_a_broken_one() {
+    let cores = windows::parse_cpu(
+        r#"[{"LoadPercentage":50,"NumberOfCores":0,"NumberOfLogicalProcessors":0},
             {"LoadPercentage":50,"NumberOfCores":2,"NumberOfLogicalProcessors":2}]"#,
         &[],
     );

--- a/crates/sbm_parser/tests/hostile_input.rs
+++ b/crates/sbm_parser/tests/hostile_input.rs
@@ -1,0 +1,95 @@
+//! What a remote host must not be able to do to the process parsing its output.
+//!
+//! Every input here is text a server sent back. In the app the parser runs
+//! in-process over FFI, so a panic or an unbounded allocation is not an error a
+//! caller can catch — it is the app disappearing. None of these need a hostile
+//! server either: each is also a shape a broken tool or a corrupt reading
+//! produces.
+
+use sbm_parser::{bsd, linux, windows};
+
+/// `Size` is rejected at zero, but anything under a KiB floors to zero after
+/// the conversion and used to divide by it. Integer division by zero panics in
+/// release as well, so this was not gated on debug assertions.
+#[test]
+fn a_volume_smaller_than_a_kib_is_not_a_division_by_zero() {
+    let disks = windows::parse_disks(
+        r#"[{"DeviceID":"C:","Size":512,"FreeSpace":0,"FileSystem":"NTFS"}]"#,
+    );
+    assert!(disks.is_empty(), "a sub-KiB volume is not a reading");
+}
+
+/// The same query on a real volume still reports one.
+#[test]
+fn an_ordinary_volume_still_parses() {
+    let disks = windows::parse_disks(
+        r#"[{"DeviceID":"C:","Size":107374182400,"FreeSpace":53687091200,"FileSystem":"NTFS"}]"#,
+    );
+    assert_eq!(disks.len(), 1);
+    assert_eq!(disks[0].used_percent, 50);
+}
+
+/// `NumberOfLogicalProcessors` decides how many core structs to allocate, each
+/// with a heap-allocated id. Unbounded, this ran until the process was killed.
+#[test]
+fn an_absurd_logical_processor_count_is_refused() {
+    let cores = windows::parse_cpu(
+        r#"[{"LoadPercentage":50,"NumberOfCores":1,"NumberOfLogicalProcessors":100000000000}]"#,
+        &[],
+    );
+    assert!(cores.is_empty(), "a count no machine has is a broken query");
+}
+
+/// A second processor entry must still be read after a broken one, and its
+/// cores must be numbered as though the broken entry contributed nothing.
+#[test]
+fn a_broken_processor_entry_does_not_take_the_others_with_it() {
+    let cores = windows::parse_cpu(
+        r#"[{"LoadPercentage":50,"NumberOfCores":1,"NumberOfLogicalProcessors":100000000000},
+            {"LoadPercentage":50,"NumberOfCores":2,"NumberOfLogicalProcessors":2}]"#,
+        &[],
+    );
+    let ids: Vec<&str> = cores.iter().map(|c| c.id.as_str()).collect();
+    assert_eq!(ids, ["cpu", "cpu0", "cpu1"]);
+}
+
+/// The BSD twin: `sysctl -n hw.ncpu` arrives as a bare integer and is
+/// replicated into that many pseudo-cores.
+#[test]
+fn an_absurd_bsd_core_count_falls_back_to_one_core() {
+    let cores = bsd::parse_cpu("CPU usage: 14.70% user, 12.76% sys, 72.52% idle\n99999999999\n");
+    assert_eq!(cores.len(), 1);
+    assert_eq!(cores[0].id, "cpu0");
+}
+
+/// A plausible count is still honoured.
+#[test]
+fn a_real_bsd_core_count_is_still_honoured() {
+    let cores = bsd::parse_cpu("CPU usage: 14.70% user, 12.76% sys, 72.52% idle\n10\n");
+    assert_eq!(cores.len(), 10);
+}
+
+/// `df`'s size column was split one *byte* from the end to read its unit, which
+/// lands inside a multi-byte character and panics.
+#[test]
+fn a_multi_byte_character_in_a_df_size_is_not_a_panic() {
+    let raw = "Filesystem 1K-blocks Used Available Use% Mounted on\n/dev/sda1 10G° 5 5 50% /\n";
+    let disks = linux::parse_disk(raw);
+    assert!(disks.is_empty(), "an unreadable size is not a disk");
+}
+
+/// The degenerate version: the whole column is one multi-byte character.
+#[test]
+fn a_df_size_that_is_only_a_multi_byte_character_is_not_a_panic() {
+    let raw = "Filesystem 1K-blocks Used Available Use% Mounted on\n/dev/sda1 ° 5 5 50% /\n";
+    assert!(linux::parse_disk(raw).is_empty());
+}
+
+/// `df -h` suffixes still convert.
+#[test]
+fn a_df_h_suffix_still_converts() {
+    let raw = "Filesystem 1K-blocks Used Available Use% Mounted on\n/dev/sda1 10G 5G 5G 50% /\n";
+    let disks = linux::parse_disk(raw);
+    assert_eq!(disks.len(), 1);
+    assert_eq!(disks[0].size, 10 * 1024 * 1024);
+}


### PR DESCRIPTION
From the full-tree audit. Seven findings in `sbm_parser`, which the app runs **in-process over FFI** — a panic here is the app disappearing, not an exception a caller can catch.

Two test files, both of which fail without the source changes:
- `tests/hostile_input.rs` — what a remote host must not be able to do to the process.
- `tests/field_output.rs` — output real machines produce that was read wrongly or not at all.

## Crashes

| Input | Old behaviour |
|---|---|
| `{"DeviceID":"C:","Size":512,...}` | `attempt to divide by zero` at `windows.rs:122` — `size == 0` was guarded, but anything under a KiB floors to 0 KiB and was divided by. Integer division by zero panics in release too, so this was not gated on debug assertions. |
| `df` size column `10G°` | `end byte index 4 is not a char boundary` — the unit was taken by splitting one *byte* from the end. Split by character now. |
| `"NumberOfLogicalProcessors":100000000000` | `for i in 0..logical` allocating a `CpuCore` with a heap id each, until the process is killed. `sysctl -n hw.ncpu` is the same shape on BSD. |

Both panic messages are reproduced verbatim by the tests against the pre-fix source. The unbounded allocation is bounded by `MAX_CPU_CORES` (4096, well above real hardware — the largest shipping x86 parts are in the hundreds of threads); past it the reading is a broken query and is handled the way a broken `LoadPercentage` already was, by skipping the entry. A second, valid processor entry is still read, and its cores are still numbered as though the broken one contributed nothing.

## Readings that parsed and were wrong

- **`/proc/stat` columns are `user nice system idle iowait irq softirq`.** Field 2 was read as `sys` and field 3 as `nice`. `lib/view/page/server/detail/view.dart:623` renders `ss.cpu.sys` under the label `sys` — that number was nice time, near zero on most machines, and real system time was displayed nowhere. `total()` sums every field, so every aggregate agreed with itself and no test could notice. **Nothing locked the old answer**: no Rust or Dart test asserted either field, and `nice` is rendered nowhere.
- **A wrapped `df` row lost its numbers.** `df` puts an overlong source on a line of its own; the buffered name was written *over* field 0 rather than inserted in front of it, which destroyed the size column and left five fields for a check that wants six. A stock Ubuntu LVM install (`/dev/mapper/ubuntu--vg-ubuntu--lv`) therefore reported no root filesystem at all. The finding also claimed the buffer is never cleared — it is, at the end of every non-wrapped row, and a test covers that the name applies to the next row only.
- **FreeBSD reported no network at all.** Its `netstat -ibn` has an `Idrop` column between `Ierrs` and `Ibytes`, so rows are 12 wide where macOS's are 11, and only 11 was accepted. The byte columns are now counted from the right, which reads both widths — and also a row whose interface has no link-layer address, which is one narrower again.
- **Thermal names and values were paired across two independent `cat` globs.** A zone whose `temp` cannot be read drops a line from one side only, shifting every later reading onto the preceding zone's name. Mismatched counts now report no temperatures, because a plausible wrong label is worse than a gap. Pairing at the source is a command-manifest change and would mean reissuing every installed status script, so it is noted in the function's doc rather than done here.

## Compatibility

`tests/dart_compat.rs` (92) and `tests/script_compat.rs` pass unchanged — the macOS 11-column netstat case, the aligned thermal case and the existing `df` fixtures all still assert what they did. The only deliberate divergence from the Dart implementation is the `/proc/stat` column order, which the Dart side had wrong too.

**Release note**: the `sys` figure on the server detail page changes. It was nice time; it is now system time, and will read higher on most machines.

## Tests

`cargo test --workspace` clean, `cargo clippy -p sbm_parser --all-targets` clean, and `flutter test test/frb_parser_test.dart` against a rebuilt `sbm_ffi` (17 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Linux CPU usage reporting and improved handling of wrapped disk-statistic entries.
  - Improved temperature readings when sensor data is incomplete or includes blank lines.
  - Improved BSD network statistics across macOS and FreeBSD formats.
  - Added safeguards for invalid or unusually large CPU counts on BSD and Windows.
  - Prevented disk-size edge cases from causing calculation errors or crashes.
  - Improved handling of multibyte human-readable disk sizes without parsing failures.

- **Tests**
  - Added coverage for malformed, incomplete, and platform-specific system statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->